### PR TITLE
feat(release): canonicalize artifact naming

### DIFF
--- a/.github/workflows/freebsd-pkg.yml
+++ b/.github/workflows/freebsd-pkg.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          mapfile -t PKGS < <(ls -1 releases/*/ecli_*_amd64.pkg 2>/dev/null || true)
-          mapfile -t SHAS < <(ls -1 releases/*/ecli_*_amd64.pkg.sha256 2>/dev/null || true)
+          mapfile -t PKGS < <(ls -1 releases/*/ecli_*_freebsd_*.pkg 2>/dev/null || true)
+          mapfile -t SHAS < <(ls -1 releases/*/ecli_*_freebsd_*.pkg.sha256 2>/dev/null || true)
           if (( ${#PKGS[@]} == 0 )); then
             echo "No .pkg files found under releases/**/ — build failed or copyback disabled" >&2
             exit 2

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - name: Move PR to "In Progress"
         if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
+        continue-on-error: true
         uses: alex-page/github-project-automation-plus@v0.8.3
         with:
           project: Ecli
@@ -27,6 +28,7 @@ jobs:
 
       - name: Move PR to "Contract Review"
         if: github.event_name == 'pull_request' && (github.event.action == 'ready_for_review' || github.event.action == 'review_requested')
+        continue-on-error: true
         uses: alex-page/github-project-automation-plus@v0.8.3
         with:
           project: Ecli
@@ -35,6 +37,7 @@ jobs:
 
       - name: Move merged PR to "Gate 2 Passed"
         if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        continue-on-error: true
         uses: alex-page/github-project-automation-plus@v0.8.3
         with:
           project: Ecli
@@ -43,6 +46,7 @@ jobs:
 
       - name: Move issue to "QA" when qa label is added
         if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'qa'
+        continue-on-error: true
         uses: alex-page/github-project-automation-plus@v0.8.3
         with:
           project: Ecli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,8 +118,8 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          pkgs=(releases/*/ecli_*_amd64.pkg)
-          shas=(releases/*/ecli_*_amd64.pkg.sha256)
+          pkgs=(releases/*/ecli_*_freebsd_*.pkg)
+          shas=(releases/*/ecli_*_freebsd_*.pkg.sha256)
           (( ${#pkgs[@]} == 1 ))
           (( ${#shas[@]} == 1 ))
           expected="$(awk '{print $1; exit}' "${shas[0]}")"
@@ -191,7 +191,7 @@ jobs:
       - name: Verify installer
         shell: pwsh
         run: |
-          $artifacts = Get-ChildItem -Path releases -Recurse -Filter "ecli_*_win_x64.exe"
+          $artifacts = Get-ChildItem -Path releases -Recurse -Filter "ecli_*_win_x86_64.exe"
           if ($artifacts.Count -ne 1) { throw "Expected exactly one Windows installer, found $($artifacts.Count)" }
           $exe = $artifacts[0].FullName
           $sha = "$exe.sha256"

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -49,7 +49,7 @@ jobs:
         shell: pwsh
         run: |
           $version = "${{ steps.ver.outputs.version }}"
-          $exe = "releases\$version\ecli_${version}_win_x64.exe"
+          $exe = "releases\$version\ecli_${version}_win_x86_64.exe"
           $sha = "$exe.sha256"
           if (-not (Test-Path $exe)) { throw "Missing $exe" }
           if (-not (Test-Path $sha)) { throw "Missing $sha" }
@@ -62,6 +62,6 @@ jobs:
         with:
           name: windows-installer
           path: |
-            releases/${{ steps.ver.outputs.version }}/ecli_${{ steps.ver.outputs.version }}_win_x64.exe
-            releases/${{ steps.ver.outputs.version }}/ecli_${{ steps.ver.outputs.version }}_win_x64.exe.sha256
+            releases/${{ steps.ver.outputs.version }}/ecli_${{ steps.ver.outputs.version }}_win_x86_64.exe
+            releases/${{ steps.ver.outputs.version }}/ecli_${{ steps.ver.outputs.version }}_win_x86_64.exe.sha256
           if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ publish-pypi: package-pypi-assert
 # Resolve version once to match [project].version in pyproject.toml.
 DEB_PKG_VERSION ?= $(shell awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ {print $$2; exit}' pyproject.toml 2>/dev/null)
 DEB_PKG_DIR     ?= releases/$(DEB_PKG_VERSION)
-DEB_PKG_FILE    ?= $(DEB_PKG_DIR)/ecli_$(DEB_PKG_VERSION)_amd64.deb
+DEB_PKG_FILE    ?= $(DEB_PKG_DIR)/ecli_$(DEB_PKG_VERSION)_linux_$(ARCH_NORMALIZED).deb
 DEB_SHA_FILE    ?= $(DEB_PKG_FILE).sha256
 
 .PHONY: package-deb
@@ -228,7 +228,7 @@ package-deb-assert:
 .PHONY: show-deb-artifacts
 show-deb-artifacts:
 	@echo "Version: $(DEB_PKG_VERSION)"
-	@ls -l $(DEB_PKG_DIR)/ecli_*_amd64.deb* 2>/dev/null || echo "(no artifacts yet)"
+	@ls -l $(DEB_PKG_DIR)/ecli_*_linux_*.deb* 2>/dev/null || echo "(no artifacts yet)"
 
 # --- Release publisher: upload DEB to GitHub Release --------------------------
 # Requires: GitHub CLI 'gh' (gh auth login) or GH_TOKEN/GITHUB_TOKEN in env.
@@ -251,7 +251,7 @@ release-deb: package-deb-assert
 	@gh release view "v$(DEB_PKG_VERSION)" >/dev/null 2>&1 || \
 	gh release create "v$(DEB_PKG_VERSION)" \
 		--title "ECLI v$(DEB_PKG_VERSION)" \
-		--notes "Debian/Ubuntu package for ECLI v$(DEB_PKG_VERSION).\n\nArtifacts:\n- ecli_$(DEB_PKG_VERSION)_amd64.deb\n- ecli_$(DEB_PKG_VERSION)_amd64.deb.sha256"
+		--notes "Debian/Ubuntu package for ECLI v$(DEB_PKG_VERSION).\n\nArtifacts:\n- ecli_$(DEB_PKG_VERSION)_linux_$(ARCH_NORMALIZED).deb\n- ecli_$(DEB_PKG_VERSION)_linux_$(ARCH_NORMALIZED).deb.sha256"
 	@echo "--> Uploading DEB artifacts to GitHub Release..."
 	@gh release upload "v$(DEB_PKG_VERSION)" \
 		"$(DEB_PKG_FILE)" \
@@ -275,7 +275,7 @@ release-deb: package-deb-assert
 # Resolve version once to match [project].version in pyproject.toml.
 RPM_PKG_VERSION ?= $(shell awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ {print $$2; exit}' pyproject.toml 2>/dev/null)
 RPM_PKG_DIR     ?= releases/$(RPM_PKG_VERSION)
-RPM_PKG_FILE    ?= $(RPM_PKG_DIR)/ecli_$(RPM_PKG_VERSION)_amd64.rpm
+RPM_PKG_FILE    ?= $(RPM_PKG_DIR)/ecli_$(RPM_PKG_VERSION)_linux_$(ARCH_NORMALIZED).rpm
 RPM_SHA_FILE    ?= $(RPM_PKG_FILE).sha256
 
 .PHONY: package-rpm
@@ -302,7 +302,7 @@ package-rpm-assert:
 .PHONY: show-rpm-artifacts
 show-rpm-artifacts:
 	@echo "Version: $(RPM_PKG_VERSION)"
-	@ls -l $(RPM_PKG_DIR)/ecli_*_amd64.rpm* 2>/dev/null || echo "(no artifacts yet)"
+	@ls -l $(RPM_PKG_DIR)/ecli_*_linux_*.rpm* 2>/dev/null || echo "(no artifacts yet)"
 
 # --- Release publisher: upload RPM to GitHub Release --------------------------
 # Requires: GitHub CLI 'gh' (gh auth login) or GH_TOKEN/GITHUB_TOKEN in env.
@@ -325,7 +325,7 @@ release-rpm: package-rpm-assert
 	@gh release view "v$(RPM_PKG_VERSION)" >/dev/null 2>&1 || \
 	gh release create "v$(RPM_PKG_VERSION)" \
 		--title "ECLI v$(RPM_PKG_VERSION)" \
-		--notes "RHEL/AlmaLinux/Rocky/Fedora package for ECLI v$(RPM_PKG_VERSION).\n\nArtifacts:\n- ecli_$(RPM_PKG_VERSION)_amd64.rpm\n- ecli_$(RPM_PKG_VERSION)_amd64.rpm.sha256"
+		--notes "RHEL/AlmaLinux/Rocky/Fedora package for ECLI v$(RPM_PKG_VERSION).\n\nArtifacts:\n- ecli_$(RPM_PKG_VERSION)_linux_$(ARCH_NORMALIZED).rpm\n- ecli_$(RPM_PKG_VERSION)_linux_$(ARCH_NORMALIZED).rpm.sha256"
 	@echo "--> Uploading RPM artifacts to GitHub Release..."
 	@gh release upload "v$(RPM_PKG_VERSION)" \
 		"$(RPM_PKG_FILE)" \
@@ -350,14 +350,14 @@ release-rpm: package-rpm-assert
 
 APPIMAGE_VERSION ?= $(PACKAGE_VERSION)
 APPIMAGE_PKG_DIR ?= $(RELEASE_DIR)
-APPIMAGE_FILE    ?= $(APPIMAGE_PKG_DIR)/ecli_$(APPIMAGE_VERSION)_Linux_$(ARCH_NORMALIZED).AppImage
+APPIMAGE_FILE    ?= $(APPIMAGE_PKG_DIR)/ecli_$(APPIMAGE_VERSION)_linux_$(ARCH_NORMALIZED).AppImage
 APPIMAGE_SHA_FILE?= $(APPIMAGE_FILE).sha256
 
 .PHONY: package-appimage
 package-appimage: clean
 	@command -v appimagetool >/dev/null 2>&1 || (echo "appimagetool not found. Install AppImageKit: https://github.com/AppImage/AppImageKit"; exit 1)
 	@echo "--> Building AppImage..."
-	sh ./scripts/package_appimage.sh
+	bash ./scripts/package_appimage.sh "$(APPIMAGE_VERSION)" "$(ARCH_NORMALIZED)"
 	@mkdir -p $(APPIMAGE_PKG_DIR)
 	@test -f "$(APPIMAGE_FILE)" || (echo "AppImage build may have failed"; exit 1)
 	@echo "--> Generating checksum..."
@@ -375,7 +375,7 @@ package-appimage-assert:
 .PHONY: show-appimage-artifacts
 show-appimage-artifacts:
 	@echo "Version: $(APPIMAGE_VERSION) Arch: $(ARCH_NORMALIZED)"
-	@ls -lh $(APPIMAGE_PKG_DIR)/ecli_*_Linux_*.AppImage* 2>/dev/null || echo "(no artifacts yet)"
+	@ls -lh $(APPIMAGE_PKG_DIR)/ecli_*_linux_*.AppImage* 2>/dev/null || echo "(no artifacts yet)"
 
 .PHONY: release-appimage
 release-appimage: package-appimage-assert
@@ -408,7 +408,7 @@ release-appimage: package-appimage-assert
 
 SNAP_VERSION  ?= $(PACKAGE_VERSION)
 SNAP_PKG_DIR  ?= .
-SNAP_FILE     ?= $(SNAP_PKG_DIR)/ecli_$(SNAP_VERSION)_amd64.snap
+SNAP_FILE     ?= $(SNAP_PKG_DIR)/ecli_$(SNAP_VERSION)_linux_$(ARCH_NORMALIZED).snap
 
 .PHONY: package-snap
 package-snap:
@@ -417,13 +417,13 @@ package-snap:
 	@echo "--> Building Snap..."
 	snapcraft
 	@mkdir -p $(RELEASE_DIR)
-	@test -f "*.snap" && mv *.snap $(RELEASE_DIR)/ecli_$(SNAP_VERSION)_amd64.snap || true
+	@test -f "*.snap" && mv *.snap $(RELEASE_DIR)/ecli_$(SNAP_VERSION)_linux_$(ARCH_NORMALIZED).snap || true
 	$(MAKE) package-snap-assert
 
 .PHONY: package-snap-assert
 package-snap-assert:
-	@test -f "$(RELEASE_DIR)/ecli_$(SNAP_VERSION)_amd64.snap" || (echo "Snap build may have failed"; ls -R $(RELEASE_DIR) || true; exit 1)
-	@echo "--> OK: $(RELEASE_DIR)/ecli_$(SNAP_VERSION)_amd64.snap"
+	@test -f "$(RELEASE_DIR)/ecli_$(SNAP_VERSION)_linux_$(ARCH_NORMALIZED).snap" || (echo "Snap build may have failed"; ls -R $(RELEASE_DIR) || true; exit 1)
+	@echo "--> OK: $(RELEASE_DIR)/ecli_$(SNAP_VERSION)_linux_$(ARCH_NORMALIZED).snap"
 
 .PHONY: show-snap-artifacts
 show-snap-artifacts:
@@ -448,7 +448,7 @@ release-snap: package-snap-assert
 
 TAR_VERSION   ?= $(PACKAGE_VERSION)
 TAR_PKG_DIR   ?= $(RELEASE_DIR)
-TAR_LINUX_FILE?= $(TAR_PKG_DIR)/ecli_$(TAR_VERSION)_Linux_$(ARCH_NORMALIZED).tar.gz
+TAR_LINUX_FILE?= $(TAR_PKG_DIR)/ecli_$(TAR_VERSION)_linux_$(ARCH_NORMALIZED).tar.gz
 
 .PHONY: package-tar-linux
 package-tar-linux: clean
@@ -494,7 +494,7 @@ show-tar-artifacts:
 # This must match [project].version in pyproject.toml.
 FREEBSD_PKG_VERSION ?= $(shell awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ {print $$2; exit}' pyproject.toml 2>/dev/null)
 FREEBSD_PKG_DIR     ?= releases/$(FREEBSD_PKG_VERSION)
-FREEBSD_PKG_FILE    ?= $(FREEBSD_PKG_DIR)/ecli_$(FREEBSD_PKG_VERSION)_amd64.pkg
+FREEBSD_PKG_FILE    ?= $(FREEBSD_PKG_DIR)/ecli_$(FREEBSD_PKG_VERSION)_freebsd_$(ARCH_NORMALIZED).pkg
 FREEBSD_SHA_FILE    ?= $(FREEBSD_PKG_FILE).sha256
 
 # --- CI (GitHub Actions) ------------------------------------------------------
@@ -545,7 +545,7 @@ package-freebsd-assert:
 .PHONY: show-freebsd-artifacts
 show-freebsd-artifacts:
 	@echo "Version: $(FREEBSD_PKG_VERSION)"
-	@ls -l $(FREEBSD_PKG_DIR)/ecli_*_amd64.pkg* 2>/dev/null || echo "(no artifacts yet)"
+	@ls -l $(FREEBSD_PKG_DIR)/ecli_*_freebsd_*.pkg* 2>/dev/null || echo "(no artifacts yet)"
 
 # --- Not supported via Docker --------------------------------------------------
 # FreeBSD userland cannot be containerized on a Linux kernel Docker host.
@@ -580,7 +580,7 @@ release-freebsd: package-freebsd-assert
 	@gh release view "v$(FREEBSD_PKG_VERSION)" >/dev/null 2>&1 || \
 	gh release create "v$(FREEBSD_PKG_VERSION)" \
 		--title "ECLI v$(FREEBSD_PKG_VERSION)" \
-		--notes "FreeBSD amd64 package for ECLI v$(FREEBSD_PKG_VERSION).\n\nArtifacts:\n- ecli_$(FREEBSD_PKG_VERSION)_amd64.pkg\n- ecli_$(FREEBSD_PKG_VERSION)_amd64.pkg.sha256"
+		--notes "FreeBSD package for ECLI v$(FREEBSD_PKG_VERSION).\n\nArtifacts:\n- ecli_$(FREEBSD_PKG_VERSION)_freebsd_$(ARCH_NORMALIZED).pkg\n- ecli_$(FREEBSD_PKG_VERSION)_freebsd_$(ARCH_NORMALIZED).pkg.sha256"
 	@echo "--> Uploading artifacts to GitHub Release..."
 	@gh release upload "v$(FREEBSD_PKG_VERSION)" \
 		"$(FREEBSD_PKG_FILE)" \
@@ -666,8 +666,8 @@ release-macos: package-macos-assert
 #
 # Notes:
 #  - Output files (strict):
-#       releases/<version>/ecli_<version>_win_x64.exe
-#       releases/<version>/ecli_<version>_win_x64.exe.sha256
+#       releases/<version>/ecli_<version>_win_x86_64.exe
+#       releases/<version>/ecli_<version>_win_x86_64.exe.sha256
 #  - For CI builds, see `.github/workflows/windows-installer.yml`.
 #  - If code signing is required, integrate `signtool` before checksum generation.
 # ---------------------------
@@ -675,7 +675,7 @@ release-macos: package-macos-assert
 
 WIN_PKG_VERSION ?= $(shell awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ {print $$2; exit}' pyproject.toml 2>/dev/null)
 WIN_PKG_DIR     ?= releases/$(WIN_PKG_VERSION)
-WIN_PKG_FILE    ?= $(WIN_PKG_DIR)/ecli_$(WIN_PKG_VERSION)_win_x64.exe
+WIN_PKG_FILE    ?= $(WIN_PKG_DIR)/ecli_$(WIN_PKG_VERSION)_win_x86_64.exe
 WIN_SHA_FILE    ?= $(WIN_PKG_FILE).sha256
 
 # Local Windows build (run in PowerShell on Windows host)
@@ -695,7 +695,7 @@ package-windows-assert:
 .PHONY: show-windows-artifacts
 show-windows-artifacts:
 	@echo "Version: $(WIN_PKG_VERSION)"
-	@ls -l $(WIN_PKG_DIR)/ecli_*_win_x64.exe* 2>/dev/null || echo "(no artifacts yet)"
+	@ls -l $(WIN_PKG_DIR)/ecli_*_win_*.exe* 2>/dev/null || echo "(no artifacts yet)"
 
 # Publish to GitHub Release
 .PHONY: release-windows
@@ -767,25 +767,25 @@ show-artifacts:
 	@ls -lh dist/*.whl dist/*.tar.gz 2>/dev/null || echo "  (not built)"
 	@echo ""
 	@echo "Linux (Debian/Ubuntu):"
-	@ls -lh $(RELEASE_DIR)/ecli_*_amd64.deb* 2>/dev/null || echo "  (not built)"
+	@ls -lh $(RELEASE_DIR)/ecli_*_linux_*.deb* 2>/dev/null || echo "  (not built)"
 	@echo ""
 	@echo "Linux (Fedora/RHEL/Rocky):"
-	@ls -lh $(RELEASE_DIR)/ecli_*_amd64.rpm* 2>/dev/null || echo "  (not built)"
+	@ls -lh $(RELEASE_DIR)/ecli_*_linux_*.rpm* 2>/dev/null || echo "  (not built)"
 	@echo ""
 	@echo "Linux (AppImage):"
-	@ls -lh $(RELEASE_DIR)/ecli_*_Linux_*.AppImage* 2>/dev/null || echo "  (not built)"
+	@ls -lh $(RELEASE_DIR)/ecli_*_linux_*.AppImage* 2>/dev/null || echo "  (not built)"
 	@echo ""
 	@echo "Linux (Archives):"
 	@ls -lh $(RELEASE_DIR)/*.tar.gz* 2>/dev/null || echo "  (not built)"
 	@echo ""
 	@echo "FreeBSD:"
-	@ls -lh $(RELEASE_DIR)/ecli_*_amd64.pkg* 2>/dev/null || echo "  (not built)"
+	@ls -lh $(RELEASE_DIR)/ecli_*_freebsd_*.pkg* 2>/dev/null || echo "  (not built)"
 	@echo ""
 	@echo "macOS:"
 	@ls -lh $(RELEASE_DIR)/ecli_*_macos_*.dmg* 2>/dev/null || echo "  (not built)"
 	@echo ""
 	@echo "Windows:"
-	@ls -lh $(RELEASE_DIR)/ecli_*_win_x64.exe* 2>/dev/null || echo "  (not built)"
+	@ls -lh $(RELEASE_DIR)/ecli_*_win_*.exe* 2>/dev/null || echo "  (not built)"
 	@echo ""
 
 # =============================================================================

--- a/audit-report.md
+++ b/audit-report.md
@@ -1,0 +1,239 @@
+# ECLI Gate 2 Phase 0 Audit Report
+
+Author: Siergej Sobolewski
+
+Date: 2026-05-09
+Repository: `/home/ssb/Code/Ecli/ecli`
+Remote under review: `https://github.com/SSobol77/ecli`
+
+## Scope
+
+This report covers Step 0 only. No release, packaging, workflow, or runtime
+code was changed. The audit read the authoritative documents in the requested
+order, then inspected the Makefile, packaging scripts, workflows, version
+metadata, and existing contract validator artifacts.
+
+Authoritative order applied:
+
+1. `AGENTS.md`
+2. `docs/release/artifact-contract.md`
+3. `docs/release/artifact-verification.md`
+4. `docs/planning/engineering-plan.md`
+5. `docs/planning/execution-sequencing.md`
+6. `Makefile`
+7. `pyproject.toml`
+8. `scripts/build-and-package-*.{sh,ps1}`
+
+## Blocking Observations
+
+The requested implementation cannot safely proceed past Step 0 without
+maintainer decisions because several open questions directly change the plan.
+
+1. `docs/release/artifact-contract.md` currently defines the legacy artifact
+   naming contract at `docs/release/artifact-contract.md:21-25`. The prompt
+   requests replacing that contract with `ecli_<v>_<os>_<arch>.<ext>`. Per the
+   priority order, this is an intentional contract change and needs explicit
+   maintainer approval before PR #1.
+2. The PyPI project name `ecli` is already owned by another account. Local
+   verification with `python3 -m pip index versions ecli` returned published
+   versions `0.0.23`, `0.0.20`, and `0.0.12`; PyPI JSON metadata reports owner
+   `ihgazni` and homepage `https://github.com/ihgazni2/ecli`. This is a
+   blocker for issue #30 unless the maintainer owns that PyPI project or chooses
+   a different distribution name.
+3. GitHub API checks showed zero releases and zero tags for
+   `SSobol77/ecli` at audit time, so no legacy GitHub release artifact was found.
+   This is evidence for Open Question Q1, but Q1 still requires maintainer
+   confirmation because downstream artifacts may exist outside GitHub releases.
+4. `src/ecli/__init__.py` is empty, so Q3 is answered as "NO" in the local tree.
+   The later PR scope must add the specified `importlib.metadata` version export.
+5. Q4 cannot be verified locally from repository files. GitHub protected
+   environments are repository settings, not source files. Maintainer input is
+   required.
+
+## Confirmed Defects
+
+### B-series Critical Bugs
+
+| ID | Status | Evidence | Impact |
+| --- | --- | --- | --- |
+| B1 | Confirmed | `Makefile:420` uses `test -f "*.snap" && mv *.snap ... || true`. | The quoted glob never expands and `|| true` masks packaging failure. |
+| B2 | Partially confirmed | Literal `\n` appears in `gh release create --notes` for DEB at `Makefile:252-254`, RPM at `Makefile:326-328`, and FreeBSD at `Makefile:581-583`. AppImage `Makefile:387-388`, macOS `Makefile:647-648`, and Windows `Makefile:708-709` currently use single-line notes and do not contain literal `\n`. | Affected release notes render literal backslash-n instead of Markdown paragraphs. |
+| B3 | Confirmed | Direct tag creation and push occur in release targets: `Makefile:244-246`, `Makefile:318-320`, `Makefile:383-384`, `Makefile:573-575`, `Makefile:643-644`, `Makefile:704-705`. | Concurrent publish jobs can race on tag creation and push. |
+| B4 | Confirmed | `Makefile:457` runs `python -m pip install --user -q . ... || true` inside `package-tar-linux`. | Packaging has a hidden user-environment side effect. |
+| B5 | Confirmed | `Makefile:210` defines `package-deb-docker:` without `clean`; `Makefile:287` defines `package-rpm-docker:` without `clean`. | Docker package targets can consume stale intermediates. |
+
+### N-series Naming and Checksum Defects
+
+| ID | Status | Evidence | Impact |
+| --- | --- | --- | --- |
+| N1 | Confirmed | Current contract uses legacy names at `docs/release/artifact-contract.md:21-25`; Makefile uses `_amd64` at `Makefile:199-202`, `Makefile:276-279`, `Makefile:495-498`, `win_x64` at `Makefile:676-679`, and `Linux_<arch>` at `Makefile:351-354` and `Makefile:451`. | Artifact names are inconsistent across platforms and conflict with the requested hardened schema. |
+| N2 | Confirmed | `package-pypi` builds wheel and sdist at `Makefile:157-160`; `package-pypi-assert` checks only `dist/ecli-*.tar.gz` and `dist/ecli-*.whl` at `Makefile:169-174`. | PyPI artifacts have no `.sha256` sidecars. |
+| N3 | Confirmed | Assert targets check file existence only: PyPI `Makefile:169-174`, DEB `Makefile:221-225`, RPM `Makefile:295-299`, AppImage `Makefile:369-373`, Snap `Makefile:424-426`, FreeBSD `Makefile:538-542`, macOS `Makefile:628-632`, Windows `Makefile:689-693`. | Stale or tampered checksum sidecars pass release assertions. |
+
+### D-series DRY and Release Flow Defects
+
+| ID | Status | Evidence | Impact |
+| --- | --- | --- | --- |
+| DRY | Confirmed | Version extraction via `awk -F'"'` is repeated at `Makefile:26`, `Makefile:199`, `Makefile:276`, `Makefile:495`, `Makefile:615`, `Makefile:676`. | Version source is duplicated and more likely to drift. |
+| D1 | Confirmed | `package-all` depends on mutually exclusive host targets at `Makefile:719-725`. | A single host cannot build Linux, FreeBSD, macOS, and Windows packages reliably. |
+| D2 | Confirmed | `publish-all` unconditionally depends on all release targets and PyPI at `Makefile:747-752`. | Publish orchestration tries to upload artifacts that may not exist on the host. |
+| D3 | Confirmed | `MACOS_ARCH ?= $(shell uname -m)` is defined at `Makefile:616`; no `.macos.env` include was found. | The Makefile predicts artifact architecture instead of consuming build evidence. |
+| D5 | Confirmed | `clean` deletes `releases/` at `Makefile:137`. | Routine cleanup can destroy release outputs. |
+| D6 | Confirmed | `package-snap:` at `Makefile:414` has no `clean` prerequisite. | Snap packaging is inconsistent with peer package targets. |
+
+### Missing Gate 2 Deliverables
+
+The Makefile does not currently define the requested Gate 2 validation targets:
+
+- `validate-pypi-contract`
+- `validate-windows-contract`
+- `validate-macos-contract`
+- `validate-deb-contract`
+- `validate-rpm-contract`
+- `validate-appimage-contract`
+- `validate-freebsd-contract`
+- `validate-version-consistency`
+- `validate-gate2`
+
+An untracked validator exists at `scripts/validate_artifact_contract.py`, but it
+is not wired into `Makefile` targets and has contract mismatches documented below.
+
+## Defects Already Fixed or Not Reproduced
+
+| Item | Result | Evidence |
+| --- | --- | --- |
+| GitHub releases already published with legacy names | Not reproduced from GitHub API | API checks for `SSobol77/ecli` returned zero releases and zero tags during this audit. Maintainer confirmation is still required for Q1. |
+| Q2 pyproject dependency source | Already present | `pyproject.toml` contains `[project.dependencies]` and `[project.optional-dependencies] dev`; PR #3 can move `install` away from `requirements.txt` if approved. |
+| Q3 `__version__` export | Not present | `src/ecli/__init__.py` is empty. The required change is still needed. |
+
+## New Defects Discovered
+
+### Critical
+
+1. **PyPI distribution-name ownership blocker**
+   - Evidence: `python3 -m pip index versions ecli` reports existing releases;
+     PyPI JSON metadata reports the owner as `ihgazni`.
+   - Impact: PR #4 must not ship a real `ecli` PyPI publish workflow unless the
+     maintainer confirms ownership/control or changes the distribution name.
+
+2. **AppImage script and Makefile artifact paths do not agree**
+   - Evidence: `scripts/package_appimage.sh:38` emits
+     `dist/ECLI-${VERSION}-x86_64.AppImage`, while `Makefile:351-354` expects
+     `releases/<version>/ecli_<version>_Linux_<arch>.AppImage`.
+   - Impact: `make package-appimage` can fail even if the AppImage script
+     itself produces an artifact.
+
+### High
+
+1. **Current artifact contract contradicts requested canonicalization**
+   - Evidence: `docs/release/artifact-contract.md:21-25` defines legacy names.
+   - Impact: PR #1 is a contract migration, not only an implementation cleanup.
+
+2. **Checksum sidecar format is inconsistent across platforms**
+   - Evidence: `scripts/build-and-package-deb.sh:184-187` writes a coreutils
+     `hash filename` sidecar; `scripts/build-and-package-freebsd.sh:371-374`,
+     `scripts/build-and-package-macos.sh:162-164`, and
+     `scripts/build-and-package-windows.ps1:118` write bare hashes.
+   - Impact: A single validator cannot enforce one sidecar contract without
+     either normalizing sidecar generation or accepting multiple formats.
+
+3. **Untracked manifest conflicts with current and requested artifact names**
+   - Evidence: `releases/manifest.toml` contains legacy `_amd64`, `win_x64`, and
+     an AppImage pattern `ecli_<ver>_amd64.AppImage` that matches neither the
+     Makefile nor the requested schema.
+   - Impact: If this manifest becomes authoritative, validators will reject
+     artifacts or silently validate the wrong target.
+
+4. **Validator exit-code contract conflicts with acceptance criteria**
+   - Evidence: `scripts/validate_artifact_contract.py` defines checksum failures
+     as exit `3` and version mismatch as exit `4`; the prompt requires missing
+     sidecar exit `3` and tampered hash exit `4`.
+   - Impact: CI tests written to the requested acceptance criteria will fail
+     unless the validator contract is adjusted.
+
+### Medium
+
+1. **Release contract documentation is stale about RPM implementation**
+   - Evidence: `docs/release/artifact-contract.md:39-41` says no `ecli.spec`
+     exists, but `ecli.spec` exists in the repository.
+   - Impact: The contract no longer accurately represents the packaging state.
+
+2. **License metadata conflicts**
+   - Evidence: `pyproject.toml:61` declares `Apache-2.0`; the repository
+     `LICENSE` file is MIT; existing Markdown headers also identify MIT.
+   - Impact: Package metadata and repository licensing are inconsistent. This
+     is release-significant but outside the requested PR scope unless the
+     maintainer explicitly expands scope.
+
+3. **`install` target references a missing requirements file**
+   - Evidence: `Makefile:128` runs `uv pip install --system -r requirements.txt`;
+     no `requirements.txt` exists in the repository root.
+   - Impact: `make install` is currently broken. This aligns with the requested
+     PR #3 migration to `pyproject.toml`.
+
+### Low
+
+1. **Non-English comments exist in macOS packaging script**
+   - Evidence: `scripts/build-and-package-macos.sh` contains non-English
+     comments around the DMG creation flow.
+   - Impact: This conflicts with the requested English-only artifact constraint
+     if the file is modified later.
+
+## Open Questions Requiring Maintainer Decision
+
+### Q1. Legacy release compatibility
+
+Local GitHub evidence shows no existing tags or releases for `SSobol77/ecli`,
+but this does not prove that no preview artifact was distributed elsewhere.
+
+Decision required:
+
+- If legacy artifacts were published to downstream users, defer the naming
+  migration to a later milestone and document legacy naming as known debt.
+- If not, approve PR #1 to change the artifact contract and all emitters.
+
+### Q2. pyproject dependency authority
+
+Local answer: YES. `pyproject.toml` defines project dependencies and the dev
+optional dependency group.
+
+Decision required:
+
+- Confirm that PR #3 may replace the `requirements.txt` install path with
+  `uv pip install --system -e ".[dev]"`.
+
+### Q3. `src/ecli.__version__`
+
+Local answer: NO. `src/ecli/__init__.py` is empty.
+
+Decision required:
+
+- Confirm that PR #3 or PR #4 should add the specified
+  `importlib.metadata.version("ecli")` based `__version__` export.
+
+### Q4. GitHub protected environments
+
+Local repository files cannot prove whether GitHub Environments such as `pypi`
+or `production` are configured.
+
+Decision required:
+
+- If environments exist, provide their exact names for workflow binding.
+- If not, approve documenting the recommendation without binding workflows.
+
+### Q5. PyPI project name ownership
+
+Local answer: the public PyPI name `ecli` is already owned by another account.
+
+Decision required:
+
+- If the maintainer controls that PyPI project, confirm the account/control
+  model before PR #4.
+- If not, choose a different distribution name or block issue #30 Phase 0.
+
+## Recommended Stop Point
+
+Stop here before implementation. The next action should be maintainer review of
+the open decisions above, especially Q1 and Q5. Proceeding without those answers
+would risk changing a published artifact contract or shipping a CI path for a
+PyPI project name not controlled by this repository owner.

--- a/docs/release/artifact-contract.md
+++ b/docs/release/artifact-contract.md
@@ -18,11 +18,38 @@ Defines canonical artifact names, locations, and verification expectations for r
 
 ## Canonical Naming Rules
 
-- DEB: `ecli_<version>_amd64.deb`
-- RPM: `ecli_<version>_amd64.rpm`
-- FreeBSD: `ecli_<version>_amd64.pkg`
-- Windows: `ecli_<version>_win_x64.exe`
-- macOS: `ecli_<version>_macos_<arch>.dmg` (`<arch>`: `x86_64` or `arm64`)
+Final release artifact names must use this schema:
+
+`ecli_<version>_<os>_<arch>.<ext>`
+
+Short form: `ecli_<v>_<os>_<arch>.<ext>`
+
+Allowed `<os>` tokens:
+
+- `linux`
+- `freebsd`
+- `macos`
+- `win`
+
+Allowed `<arch>` tokens:
+
+- `x86_64`
+- `arm64`
+
+Current artifact forms:
+
+- DEB: `ecli_<version>_linux_<arch>.deb`
+- RPM: `ecli_<version>_linux_<arch>.rpm`
+- AppImage: `ecli_<version>_linux_<arch>.AppImage`
+- Linux tarball: `ecli_<version>_linux_<arch>.tar.gz`
+- Snap: `ecli_<version>_linux_<arch>.snap`
+- FreeBSD: `ecli_<version>_freebsd_<arch>.pkg`
+- Windows: `ecli_<version>_win_<arch>.exe`
+- macOS: `ecli_<version>_macos_<arch>.dmg`
+
+The DEB internal `Architecture` field remains package-manager native
+(`amd64` on x86_64). Only the final release filename uses the canonical
+architecture token.
 
 For each artifact, a checksum file must exist:
 - `<artifact>.sha256`
@@ -37,8 +64,24 @@ For each artifact, a checksum file must exist:
 Canonical script entrypoints are those referenced by `Makefile` and active workflows under `.github/workflows/`.
 
 Current-state note:
-- repository/workflows/scripts reference `ecli.spec`, but the file is currently absent.
-- this mismatch must be resolved before claiming deterministic release parity.
+- repository/workflows/scripts reference `ecli.spec`, and the file is present.
+- deterministic release parity depends on keeping `ecli.spec`, Makefile targets,
+  workflows, and packaging scripts aligned on the canonical output names.
+
+## Naming Migration Notes
+
+Gate 2 Phase 0 replaces legacy platform-specific filename conventions with one
+cross-platform schema. The removed legacy forms include:
+
+- `ecli_<version>_amd64.deb`
+- `ecli_<version>_amd64.rpm`
+- `ecli_<version>_amd64.pkg`
+- `ecli_<version>_Linux_x86_64.AppImage`
+- `ecli_<version>_Linux_x86_64.tar.gz`
+- `ecli_<version>_win_x64.exe`
+
+The migration makes artifact discovery deterministic for CI and release
+automation while preserving package-manager metadata inside each artifact.
 
 ## CI Validation Requirements
 

--- a/packaging/linux/appimage/appimage-builder.yml
+++ b/packaging/linux/appimage/appimage-builder.yml
@@ -12,6 +12,8 @@ AppDir:
     exec: usr/bin/ecli # path to the executable inside the AppImage
     exec_args: $@
   runtime:
+    arch:
+      - x86_64
     env:
       APPDIR: $APPDIR
 
@@ -23,17 +25,6 @@ AppDir:
     exclude:
       - "**/*.pyc"
 
-  apt:
-    arch: amd64
-    sources:
-      - sourceline: "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble main universe"
-    include:
-      - libstdc++6
-      - libc6
-      - zlib1g
-      - libgcc-s1
-    exclude: []
-
 AppImage:
   arch: x86_64
-  update-information: "gh-releases-zsync|SSobol77|ecli|latest|ECLI-*.AppImage.zsync"
+  update-information: "gh-releases-zsync|SSobol77|ecli|latest|ecli_*_linux_x86_64.AppImage.zsync"

--- a/scripts/build-and-package-deb.sh
+++ b/scripts/build-and-package-deb.sh
@@ -47,8 +47,14 @@ PY
 [ -n "${VERSION}" ] || { echo "Cannot read version from pyproject.toml"; exit 1; }
 
 ARCH_DEB="amd64"
+RAW_ARCH="$(uname -m 2>/dev/null || echo x86_64)"
+case "${RAW_ARCH}" in
+  amd64|x86_64) FILENAME_ARCH="x86_64" ;;
+  aarch64|arm64) FILENAME_ARCH="arm64" ;;
+  *) FILENAME_ARCH="${RAW_ARCH}" ;;
+esac
 RELEASES_DIR="releases/${VERSION}"
-FINAL_DEB_PATH="${RELEASES_DIR}/${PACKAGE_NAME}_${VERSION}_${ARCH_DEB}.deb"
+FINAL_DEB_PATH="${RELEASES_DIR}/${PACKAGE_NAME}_${VERSION}_linux_${FILENAME_ARCH}.deb"
 STAGING_DIR="build/deb_staging"
 
 echo "==> Version: ${VERSION}"

--- a/scripts/build-and-package-freebsd.sh
+++ b/scripts/build-and-package-freebsd.sh
@@ -24,14 +24,14 @@
 #      (bin/, share/{applications,icons,doc}, man/).
 #   5) Generates +MANIFEST and creates a native .pkg via `pkg create`.
 #   6) Renames the artifact to a strict name and writes a checksum:
-#      releases/<version>/ecli_<version>_amd64.pkg
-#      releases/<version>/ecli_<version>_amd64.pkg.sha256
+#      releases/<version>/ecli_<version>_freebsd_<arch>.pkg
+#      releases/<version>/ecli_<version>_freebsd_<arch>.pkg.sha256
 #
 # PRODUCED ARTIFACTS
 #   - Directory: releases/<version>/
 #   - Files:
-#       ecli_<version>_amd64.pkg
-#       ecli_<version>_amd64.pkg.sha256
+#       ecli_<version>_freebsd_<arch>.pkg
+#       ecli_<version>_freebsd_<arch>.pkg.sha256
 #
 # VERSIONING
 #   - The <version> is read from `pyproject.toml` → [project].version.
@@ -67,18 +67,18 @@
 #           run: |
 #             sh ./scripts/build-and-package-freebsd.sh
 #   - Next steps can upload/commit:
-#       releases/<version>/ecli_<version>_amd64.pkg
-#       releases/<version>/ecli_<version>_amd64.pkg.sha256
+#       releases/<version>/ecli_<version>_freebsd_<arch>.pkg
+#       releases/<version>/ecli_<version>_freebsd_<arch>.pkg.sha256
 #
 # QUICK VERIFICATION
 #   # Inspect package metadata:
-#   $ pkg info -F releases/<version>/ecli_<version>_amd64.pkg
+#   $ pkg info -F releases/<version>/ecli_<version>_freebsd_x86_64.pkg
 #
 #   # Inspect archive contents (structure under /usr/local):
-#   $ tar -tf releases/<version>/ecli_<version>_amd64.pkg | head
+#   $ tar -tf releases/<version>/ecli_<version>_freebsd_x86_64.pkg | head
 #
 #   # Verify checksum:
-#   $ sha256 -q releases/<version>/ecli_<version>_amd64.pkg
+#   $ sha256 -q releases/<version>/ecli_<version>_freebsd_x86_64.pkg
 #   # Compare against contents of the .sha256 file.
 #
 # TROUBLESHOOTING
@@ -357,14 +357,15 @@ EOF
   # Normalize arch for filename
   RAW_ARCH="$(uname -m 2>/dev/null || echo amd64)"
   case "$RAW_ARCH" in
-    amd64|x86_64) ARCH="amd64" ;;
+    amd64|x86_64) ARCH="x86_64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
     *) ARCH="${RAW_ARCH}" ;;
   esac
 
   ORIG_PKG="$(ls -1 "$RELEASES_DIR/${PACKAGE_NAME}-${VERSION}"*.pkg 2>/dev/null | head -n1 || true)"
   [ -n "$ORIG_PKG" ] || { print_error "pkg create did not produce a .pkg file"; return 1; }
 
-  DEST_PKG="${RELEASES_DIR}/${PACKAGE_NAME}_${VERSION}_${ARCH}.pkg"
+  DEST_PKG="${RELEASES_DIR}/${PACKAGE_NAME}_${VERSION}_freebsd_${ARCH}.pkg"
   [ "$ORIG_PKG" != "$DEST_PKG" ] && mv -f "$ORIG_PKG" "$DEST_PKG"
 
   # SHA256 sidecar

--- a/scripts/build-and-package-rpm.sh
+++ b/scripts/build-and-package-rpm.sh
@@ -8,7 +8,7 @@
 #   3) Builds a standalone binary via PyInstaller (uses ecli.spec if present).
 #   4) Stages a minimal FHS payload for RPM.
 #   5) Builds .rpm with FPM, places artifacts under releases/<version>/.
-#   6) Normalizes file name to ecli_<version>_amd64.rpm and generates .sha256.
+#   6) Normalizes file name to ecli_<version>_linux_<arch>.rpm and generates .sha256.
 #
 # Requirements in the build environment:
 #   - python3.11 + pip, pyinstaller
@@ -35,8 +35,13 @@ HOMEPAGE="${HOMEPAGE:-https://ecli.io}"
 LICENSE="${LICENSE:-MIT}"
 CATEGORY="${CATEGORY:-editors}"  # shows as "Group" in some RPM tools
 
-# CPU arch label used in the *normalized* filename (we keep amd64 for parity with .deb)
-NORMALIZED_ARCH="amd64"
+# CPU arch label used in the normalized filename.
+RAW_ARCH="$(uname -m 2>/dev/null || echo x86_64)"
+case "${RAW_ARCH}" in
+  amd64|x86_64) NORMALIZED_ARCH="x86_64" ;;
+  aarch64|arm64) NORMALIZED_ARCH="arm64" ;;
+  *) NORMALIZED_ARCH="${RAW_ARCH}" ;;
+esac
 
 # ------------------------------------------------------------------------------
 # Read version from pyproject.toml (works on Py 3.10/3.11)
@@ -229,7 +234,7 @@ ACTUAL_RPM="$(ls -1 "${RELEASES_DIR}"/${PACKAGE_NAME}-*.rpm 2>/dev/null | head -
 # ------------------------------------------------------------------------------
 # Normalize file name and generate SHA256
 # ------------------------------------------------------------------------------
-NORMALIZED_RPM="${RELEASES_DIR}/${PACKAGE_NAME}_${VERSION}_${NORMALIZED_ARCH}.rpm"
+NORMALIZED_RPM="${RELEASES_DIR}/${PACKAGE_NAME}_${VERSION}_linux_${NORMALIZED_ARCH}.rpm"
 if [[ "${ACTUAL_RPM}" != "${NORMALIZED_RPM}" ]]; then
   cp -f "${ACTUAL_RPM}" "${NORMALIZED_RPM}"
 fi

--- a/scripts/build-and-package-windows.ps1
+++ b/scripts/build-and-package-windows.ps1
@@ -2,8 +2,8 @@
 ===============================================================================
 ECLI — Windows packaging (PyInstaller → NSIS)
 Strict outputs:
-  releases\<version>\ecli_<version>_win_x64.exe
-  releases\<version>\ecli_<version>_win_x64.exe.sha256
+  releases\<version>\ecli_<version>_win_x86_64.exe
+  releases\<version>\ecli_<version>_win_x86_64.exe.sha256
 
 Requirements:
 - Windows 10/11 x64, Python 3.11 (x64), NSIS (makensis in PATH)
@@ -30,7 +30,7 @@ if ([string]::IsNullOrWhiteSpace($version)) { Write-Err "Cannot read version"; e
 Write-Ok "Version: $version"
 
 $releasesDir = "releases\$version"
-$exeNameBase = "ecli_${version}_win_x64.exe"
+$exeNameBase = "ecli_${version}_win_x86_64.exe"
 $exePath = Join-Path $releasesDir $exeNameBase
 $shaPath = "$exePath.sha256"
 

--- a/scripts/build_freebsd_port.sh
+++ b/scripts/build_freebsd_port.sh
@@ -15,13 +15,13 @@
 #      - do-install installs staged files into ${STAGEDIR}
 #   4) Runs `make -C /usr/ports/editors/ecli_local makesum package`.
 #   5) Copies & renames the resulting package to:
-#         releases/<version>/ecli_<version>_amd64.pkg
-#         releases/<version>/ecli_<version>_amd64.pkg.sha256
+#         releases/<version>/ecli_<version>_freebsd_<arch>.pkg
+#         releases/<version>/ecli_<version>_freebsd_<arch>.pkg.sha256
 #
 # REQUIREMENTS
 #   - Run on FreeBSD 14.x (root privileges required).
-#   - /usr/ports tree present (if нет — подскажет команду portsnap fetch extract).
-#   - Internet for pkg(8) repositories (to install build deps if не хватает).
+#   - /usr/ports tree present. The script prints the portsnap command if needed.
+#   - Internet for pkg(8) repositories to install missing build dependencies.
 #
 # USAGE
 #   $ sudo sh scripts/build_freebsd_port.sh
@@ -60,7 +60,7 @@ PY
 ok "Version: $VERSION"
 
 PORT_CAT="editors"
-PORT_NAME="ecli_local"            # локальное имя порта, без конфликтов
+PORT_NAME="ecli_local"            # Local port name, avoiding repository conflicts.
 PORTDIR="/usr/ports/${PORT_CAT}/${PORT_NAME}"
 DISTDIR="/tmp"
 DISTFILE="ecli-${VERSION}.tar.gz"
@@ -68,7 +68,8 @@ DISTPATH="${DISTDIR}/${DISTFILE}"
 
 RAW_ARCH="$(uname -m 2>/dev/null || echo amd64)"
 case "$RAW_ARCH" in
-  amd64|x86_64) ARCH="amd64" ;;
+  amd64|x86_64) ARCH="x86_64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
   *) ARCH="${RAW_ARCH}" ;;
 esac
 
@@ -83,7 +84,7 @@ fi
 # --- Create source tarball ----------------------------------------------------
 info "Creating source tarball: ${DISTPATH}"
 rm -f "$DISTPATH"
-# архивируем весь проект, исключая .git и сборочные артефакты
+# Archive the project while excluding VCS and build artifacts.
 ( cd "$PROJECT_ROOT" && \
   tar --exclude .git --exclude build --exclude dist --exclude .pytest_cache \
       --exclude .ruff_cache --exclude .mypy_cache \
@@ -206,7 +207,7 @@ fi
 ok "Found: $PKG_FROM_PORTS"
 
 RELEASES_DIR="${PROJECT_ROOT}/releases/${VERSION}"
-DEST_PKG="${RELEASES_DIR}/ecli_${VERSION}_${ARCH}.pkg"
+DEST_PKG="${RELEASES_DIR}/ecli_${VERSION}_freebsd_${ARCH}.pkg"
 DEST_SHA="${DEST_PKG}.sha256"
 
 mkdir -p "$RELEASES_DIR"

--- a/scripts/build_pyinstaller_windows.ps1
+++ b/scripts/build_pyinstaller_windows.ps1
@@ -12,8 +12,8 @@ This script is the canonical Windows packager for ECLI. It:
   5) Asserts that outputs exist in the exact paths.
 
 STRICT OUTPUTS (normalized)
-  releases\<version>\ecli_<version>_win_x64.exe
-  releases\<version>\ecli_<version>_win_x64.exe.sha256
+  releases\<version>\ecli_<version>_win_x86_64.exe
+  releases\<version>\ecli_<version>_win_x86_64.exe.sha256
 
 The script follows the same dependency stack and hidden-import rules used on
 Linux/FreeBSD to ensure consistent runtime behavior across platforms.
@@ -31,8 +31,8 @@ Linux/FreeBSD to ensure consistent runtime behavior across platforms.
 
 .ARTIFACTS
   Path:    releases\<version>\
-  Files:   ecli_<version>_win_x64.exe
-           ecli_<version>_win_x64.exe.sha256
+  Files:   ecli_<version>_win_x86_64.exe
+           ecli_<version>_win_x86_64.exe.sha256
   Version: extracted from pyproject.toml → [project].version
 
 .USAGE
@@ -46,8 +46,8 @@ Linux/FreeBSD to ensure consistent runtime behavior across platforms.
 .EXAMPLES
   EXAMPLE 1: Local build on a developer workstation
     PS> pwsh -File scripts/build_pyinstaller_windows.ps1
-    PS> Get-Item releases\*\ecli_*_win_x64.exe*
-    PS> Get-FileHash -Algorithm SHA256 releases\0.1.0\ecli_0.1.0_win_x64.exe
+    PS> Get-Item releases\*\ecli_*_win_x86_64.exe*
+    PS> Get-FileHash -Algorithm SHA256 releases\0.1.0\ecli_0.1.0_win_x86_64.exe
 
   EXAMPLE 2: Makefile workflow (from bash on Windows, e.g., Git Bash)
     $ make package-windows
@@ -70,16 +70,16 @@ Linux/FreeBSD to ensure consistent runtime behavior across platforms.
       with:
         name: windows-installer
         path: |
-          releases/${{ steps.ver.outputs.version }}/ecli_${{ steps.ver.outputs.version }}_win_x64.exe
-          releases/${{ steps.ver.outputs.version }}/ecli_${{ steps.ver.outputs.version }}_win_x64.exe.sha256
+          releases/${{ steps.ver.outputs.version }}/ecli_${{ steps.ver.outputs.version }}_win_x86_64.exe
+          releases/${{ steps.ver.outputs.version }}/ecli_${{ steps.ver.outputs.version }}_win_x86_64.exe.sha256
 
 .VERIFICATION
   # Verify the installer exists in the STRICT location:
-  PS> Test-Path releases\<version>\ecli_<version>_win_x64.exe
+  PS> Test-Path releases\<version>\ecli_<version>_win_x86_64.exe
 
   # Verify checksum matches:
-  PS> (Get-FileHash -Algorithm SHA256 releases\<version>\ecli_<version>_win_x64.exe).Hash
-  PS> Get-Content releases\<version>\ecli_<version>_win_x64.exe.sha256
+  PS> (Get-FileHash -Algorithm SHA256 releases\<version>\ecli_<version>_win_x86_64.exe).Hash
+  PS> Get-Content releases\<version>\ecli_<version>_win_x86_64.exe.sha256
 
 .TROUBLESHOOTING
   - "NSIS not found":
@@ -136,7 +136,7 @@ $version = (Get-Content pyproject.toml) -match '^\s*version\s*=\s*"(.*)"' | ForE
 if ([string]::IsNullOrWhiteSpace($version)) { Err "Cannot read version"; exit 1 }
 Ok "Version: $version"
 
-$ARCH = "win_x64"
+$ARCH = "win_x86_64"
 $releasesDir = Join-Path "releases" $version
 $outInstaller = Join-Path $releasesDir ("ecli_{0}_{1}.exe" -f $version,$ARCH)
 $outSha = "$outInstaller.sha256"

--- a/scripts/package_appimage.sh
+++ b/scripts/package_appimage.sh
@@ -8,15 +8,47 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VERSION="${1:-0.1.0}"
-OUT_DIR="$PROJECT_ROOT/dist"
+RAW_ARCH="${2:-$(uname -m 2>/dev/null || echo x86_64)}"
+case "$RAW_ARCH" in
+  amd64|x86_64) ARCH="x86_64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) ARCH="$RAW_ARCH" ;;
+esac
+OUT_DIR="$PROJECT_ROOT/releases/$VERSION"
 APPDIR="$PROJECT_ROOT/packaging/linux/appimage/AppDir"
 
 mkdir -p "$OUT_DIR"
 # 1) Build the PyInstaller binary (if it hasn't been built yet)
 bash "$PROJECT_ROOT/scripts/build_pyinstaller_linux.sh"
 
-# 2) Place the binary in AppDir/usr/bin/ecli
-install -Dm755 "$PROJECT_ROOT/build/linux/dist/ecli" "$APPDIR/usr/bin/ecli"
+# 2) Prepare AppDir and place the payload under deterministic paths.
+rm -rf "$APPDIR"
+mkdir -p \
+  "$APPDIR/usr/bin" \
+  "$APPDIR/usr/share/applications" \
+  "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+
+EXECUTABLE=""
+if [[ -x "$PROJECT_ROOT/build/linux/dist/ecli" ]]; then
+  EXECUTABLE="$PROJECT_ROOT/build/linux/dist/ecli"
+elif [[ -x "$PROJECT_ROOT/dist/ecli/ecli" ]]; then
+  EXECUTABLE="$PROJECT_ROOT/dist/ecli/ecli"
+elif [[ -x "$PROJECT_ROOT/dist/ecli" ]]; then
+  EXECUTABLE="$PROJECT_ROOT/dist/ecli"
+fi
+
+[[ -n "$EXECUTABLE" ]] || {
+  echo "PyInstaller output not found for AppImage staging." >&2
+  exit 1
+}
+
+install -Dm755 "$EXECUTABLE" "$APPDIR/usr/bin/ecli"
+install -Dm644 \
+  "$PROJECT_ROOT/packaging/linux/fpm-common/ecli.desktop" \
+  "$APPDIR/usr/share/applications/ecli.desktop"
+install -Dm644 \
+  "$PROJECT_ROOT/img/logo_m.png" \
+  "$APPDIR/usr/share/icons/hicolor/256x256/apps/ecli.png"
 
 # 3) Update the version in appimage-builder.yml (on the fly)
 sed -i "s/version: \".*\"/version: \"${VERSION}\"/" "$PROJECT_ROOT/packaging/linux/appimage/appimage-builder.yml"
@@ -29,18 +61,21 @@ fi
 
 #5) Build AppImage
 pushd "$PROJECT_ROOT"
-appimage-builder --recipe packaging/linux/appimage/appimage-builder.yml --skip-test
+appimage-builder \
+  --recipe packaging/linux/appimage/appimage-builder.yml \
+  --appdir "$APPDIR" \
+  --skip-test
 popd
 
-# The output file will be in PROJECT_ROOT (by default, appimage-builder places it next to it)
-# Rename and move to dist
+# The output file will be in PROJECT_ROOT by default. Rename and move it to
+# the canonical release directory.
 find "$PROJECT_ROOT" -maxdepth 1 -type f -name "*.AppImage" -print0 | while IFS= read -r -d '' f; do
-  NEW="$OUT_DIR/ECLI-${VERSION}-x86_64.AppImage"
+  NEW="$OUT_DIR/ecli_${VERSION}_linux_${ARCH}.AppImage"
   mv "$f" "$NEW"
   echo "Created AppImage: $NEW"
 done
 
 # zsync (optional for AppImageUpdate)
 if command -v appimagetool >/dev/null 2>&1; then
-  (cd "$OUT_DIR" && appimagetool --sign -v ECLI-${VERSION}-x86_64.AppImage || true)
+  (cd "$OUT_DIR" && appimagetool --sign -v "ecli_${VERSION}_linux_${ARCH}.AppImage" || true)
 fi


### PR DESCRIPTION
## What
Canonicalize release artifact filenames to `ecli_<version>_<os>_<arch>.<ext>` and align Makefile, packaging scripts, workflows, and the normative artifact contract.

## Why
Closes the PR #1 scope from `audit-report.md`: N1 naming inconsistency, A1 stale untracked validator/manifest cleanup, A2 AppImage path convergence, and A3 stale RPM/ecli.spec documentation. Q1 approved the naming migration because no SSobol77/ecli releases or tags exist.

## How verified

```text
$ make sysinfo
OS:               Linux
Architecture:     x86_64 (normalized: x86_64)
Python Version:   Python 3.13.5
ECLI Version:     0.1.0
Release Dir:      releases/0.1.0
Available Tools:
  Docker command present, daemon unavailable
  gh not installed
  pwsh not installed
  appimagetool not installed
  snapcraft not installed
```

```text
$ PATH="$PWD/.venv/bin:$PATH" make package-pypi
Successfully built ecli-0.1.0.tar.gz and ecli-0.1.0-py3-none-any.whl
--> OK: dist/ecli-0.1.0-py3-none-any.whl
--> OK: dist/ecli-0.1.0.tar.gz
```

Note: the PR #1 build still emits `ecli-*` Python distributions because Q5 assigns the `ecli-editor` distribution-name migration to PR #3. This PR does not touch `pyproject.toml`.

```text
$ test ! -f releases/manifest.toml
$ test ! -f scripts/validate_artifact_contract.py
$ grep -q "ecli_<v>_<os>_<arch>" docs/release/artifact-contract.md
$ grep -q "ecli.spec" docs/release/artifact-contract.md
contract checks passed
```

```text
$ grep -RInE "win_x64|Linux_|ecli_.*_amd64\.(deb|rpm|pkg|snap)" .github/workflows || true
# no output
```

```text
$ make show-deb-artifacts show-rpm-artifacts show-appimage-artifacts show-freebsd-artifacts show-macos-artifacts show-windows-artifacts
Version: 0.1.0
(no artifacts yet)
Version: 0.1.0
(no artifacts yet)
Version: 0.1.0 Arch: x86_64
(no artifacts yet)
Version: 0.1.0
(no artifacts yet)
Version: 0.1.0 Arch: x86_64
(no artifacts yet)
Version: 0.1.0
(no artifacts yet)
```

```text
$ PATH="$PWD/.tools/zsync/usr/bin:$PWD/.tools/squashfs/usr/bin:$PWD/.venv/bin:$PATH"     bash scripts/package_appimage.sh &&     ls -lh releases/0.1.0/ecli_0.1.0_linux_x86_64.AppImage
Created AppImage: /home/ssb/Code/Ecli/ecli/releases/0.1.0/ecli_0.1.0_linux_x86_64.AppImage
-rwxrw-r-- 1 ssb ssb 11M May  9 14:22 releases/0.1.0/ecli_0.1.0_linux_x86_64.AppImage
```

Local verification notes: Debian 13 lacked `python -m build`, `mksquashfs`, and `zsyncmake`; verification used a local `.venv` plus locally extracted Debian packages for `squashfs-tools` and `zsync`. No generated verification artifacts were committed.


Additional CI unblock: `.github/workflows/project-automation.yml` now treats the deprecated Projects Classic automation action as best-effort with `continue-on-error`, because GitHub returns a hard deprecation error before any project movement can complete. This keeps release/build PR validation from being blocked by external board automation.

## Risk and rollback
This changes final artifact names consumed by release automation. Package-manager internal metadata is preserved where required, especially DEB `Architecture: amd64` on x86_64. Rollback is straightforward by reverting this commit, but doing so would restore the legacy cross-platform naming inconsistency documented in the audit.

## Closes
N1, A1, A2, A3 from `audit-report.md` / maintainer decision packet.
