### PR TITLE
Gate 2 Phase 0 sign-off + Phase 1 readiness audit

### DIFF
--- a/.github/workflows/pypi-validate.yml
+++ b/.github/workflows/pypi-validate.yml
@@ -28,6 +28,24 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Verify PyPI namespace ownership
+        run: |
+          set -e
+          name=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["name"])')
+          if [ "$name" != "ecli-editor" ]; then
+            echo "::error::pyproject.toml [project].name is '$name', expected 'ecli-editor'."
+            echo "::error::Reserved PyPI namespace is 'ecli-editor'. Either update pyproject.toml or reserve the new name first."
+            exit 1
+          fi
+          lookup=$(python3 -m pip index versions ecli-editor 2>&1 || true)
+          if ! echo "$lookup" | grep -q "Available versions"; then
+            echo "::error::PyPI project 'ecli-editor' lookup failed. Network issue or namespace deletion?"
+            echo "$lookup"
+            exit 1
+          fi
+          echo "::notice::PyPI namespace ecli-editor confirmed. Current versions:"
+          echo "$lookup"
+
       - name: Install uv
         run: pipx install uv
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,9 +213,6 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [build-python]
-    environment:
-      name: pypi
-      url: https://pypi.org/p/ecli-editor
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,11 +215,35 @@ jobs:
     needs: [build-python]
     environment:
       name: pypi
-      url: https://pypi.org/p/ecli
+      url: https://pypi.org/p/ecli-editor
     permissions:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Verify PyPI namespace ownership
+        run: |
+          set -e
+          name=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["name"])')
+          if [ "$name" != "ecli-editor" ]; then
+            echo "::error::pyproject.toml [project].name is '$name', expected 'ecli-editor'."
+            echo "::error::Reserved PyPI namespace is 'ecli-editor'. Either update pyproject.toml or reserve the new name first."
+            exit 1
+          fi
+          lookup=$(python3 -m pip index versions ecli-editor 2>&1 || true)
+          if ! echo "$lookup" | grep -q "Available versions"; then
+            echo "::error::PyPI project 'ecli-editor' lookup failed. Network issue or namespace deletion?"
+            echo "$lookup"
+            exit 1
+          fi
+          echo "::notice::PyPI namespace ecli-editor confirmed. Current versions:"
+          echo "$lookup"
+
       - name: Download Python distributions
         uses: actions/download-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -36,20 +36,7 @@ WIN_ARCH ?= x86_64
 -include $(RELEASE_DIR)/.win.env
 
 define verify_sha256
-	@artifact="$(1)"; \
-	sidecar="$$artifact.sha256"; \
-	test -f "$$artifact" || (echo "Missing $$artifact"; exit 2); \
-	test -f "$$sidecar" || (echo "Missing $$sidecar"; exit 3); \
-	dir="$$(dirname "$$artifact")"; \
-	base="$$(basename "$$artifact")"; \
-	if command -v sha256sum >/dev/null 2>&1; then \
-		(cd "$$dir" && sha256sum -c "$$base.sha256") || (echo "checksum mismatch: $$artifact"; exit 4); \
-	elif command -v shasum >/dev/null 2>&1; then \
-		(cd "$$dir" && shasum -a 256 -c "$$base.sha256") || (echo "checksum mismatch: $$artifact"; exit 4); \
-	else \
-		echo "Missing SHA256 tool: sha256sum or shasum"; \
-		exit 5; \
-	fi
+	@scripts/verify-artifact.sh "$(1)"
 endef
 
 define validate_if_present

--- a/docs/planning/gate2-phase0-report.md
+++ b/docs/planning/gate2-phase0-report.md
@@ -252,13 +252,15 @@ New files of note:
 ## PyPI Reservation Status
 
 ```text
-$ python -m pip index versions ecli-editor
-ERROR: No matching distribution found for ecli-editor
-pip_index_exit=1
+$ python3 -m pip index versions ecli-editor
+ecli-editor (0.0.1)
+Available versions: 0.0.1
+  INSTALLED: 0.1.0
+  LATEST:    0.0.1
 ```
 
-Maintainer reserves placeholder; PR #4 publish flow remains gated behind tag
-push. No PyPI publication was performed by the agent.
+PyPI namespace `ecli-editor` was reserved by the maintainer on 2026-05-09 with
+placeholder version 0.0.1. No PyPI publication was performed by the agent.
 
 ## CI Status
 
@@ -269,11 +271,338 @@ push. No PyPI publication was performed by the agent.
 | #11 | Head `fd45f30`: CI `test` success, SonarCloud success, project automation success on https://github.com/SSobol77/ecli/pull/11 |
 | #12 | Head `88126c4`: CI success, PyPI/macOS/Windows validation success, SonarCloud success on https://github.com/SSobol77/ecli/pull/12 |
 
+## Post-Merge Verification
+
+Timestamp: 2026-05-09T23:15:08+02:00
+
+### A.2.1 Smoke Tests
+
+Initial amended command:
+
+```sh
+cd $(git rev-parse --show-toplevel)
+python3 -m pip install --user -e ".[dev]" --quiet
+python3 -m pytest tests/test_smoke.py -v
+```
+
+Output:
+
+```text
+error: externally-managed-environment
+
+× This environment is externally managed
+╰─> To install Python packages system-wide, try apt install
+    python3-xyz, where xyz is the package you are trying to
+    install.
+
+    If you wish to install a non-Debian-packaged Python package,
+    create a virtual environment using python3 -m venv path/to/venv.
+    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
+    sure you have python3-full installed.
+
+    If you wish to install a non-Debian packaged Python application,
+    it may be easiest to use pipx install xyz, which will manage a
+    virtual environment for you. Make sure you have pipx installed.
+
+    See /usr/share/doc/python3.13/README.venv for more information.
+
+note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
+hint: See PEP 668 for the detailed specification.
+```
+
+Debian 13 PEP 668 handling was triggered. Per maintainer amendment, the
+developer-workstation verification reran with `--break-system-packages`. CI must
+use a virtualenv instead of this override.
+
+Rerun command:
+
+```sh
+cd $(git rev-parse --show-toplevel)
+python3 -m pip install --user --break-system-packages -e ".[dev]" --quiet
+python3 -m pytest tests/test_smoke.py -v
+```
+
+Output:
+
+```text
+  WARNING: The script dotenv is installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  WARNING: The script pygmentize is installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  WARNING: The scripts docutils, rst2html, rst2html4, rst2html5, rst2latex, rst2man, rst2odt, rst2pseudoxml, rst2s5, rst2xetex and rst2xml are installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  WARNING: The scripts coverage, coverage-3.13 and coverage3 are installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  WARNING: The scripts py.test and pytest are installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  WARNING: The scripts pyi-archive_viewer, pyi-bindepend, pyi-grab_version, pyi-makespec, pyi-set_version and pyinstaller are installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  WARNING: The scripts dmypy, mypy, mypyc, stubgen and stubtest are installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  WARNING: The script pyproject-build is installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  WARNING: The script tato is installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  WARNING: The script keyring is installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  WARNING: The script ecli is installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  WARNING: The script twine is installed in '/home/ssb/.local/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
+jupyterlab 4.0.11 requires jupyter-lsp>=2.0.0, which is not installed.
+============================= test session starts ==============================
+platform linux -- Python 3.13.5, pytest-9.0.3, pluggy-1.5.0 -- /usr/bin/python3
+cachedir: .pytest_cache
+rootdir: /home/ssb/Code/Ecli/ecli
+configfile: pyproject.toml
+plugins: mock-3.15.1, asyncio-1.3.0, aiohttp-1.1.0, cov-7.1.0, anyio-4.8.0, typeguard-4.4.2
+asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 2 items
+
+tests/test_smoke.py::test_package_imports PASSED                         [ 50%]
+tests/test_smoke.py::test_version_format PASSED                          [100%]
+
+============================== 2 passed in 0.01s ===============================
+```
+
+### A.2.2 Entry Point Smoke
+
+Command:
+
+```sh
+python3 -c "from ecli.__main__ import main; print('OK', type(main).__name__)"
+```
+
+Output:
+
+```text
+Could not parse user config '/home/ssb/.config/ecli/config.toml': Unbalanced quotes (line 18 column 34 char 258). Using defaults.
+OK function
+```
+
+### A.2.3-Revised Editable Install Entry Point Linkage Check
+
+Command:
+
+```sh
+ls -la ~/.local/bin/ecli
+```
+
+Output:
+
+```text
+-rwxrwxr-x 1 ssb ssb 212 May  9 23:03 /home/ssb/.local/bin/ecli
+```
+
+Command:
+
+```sh
+file ~/.local/bin/ecli
+```
+
+Output:
+
+```text
+/home/ssb/.local/bin/ecli: Python script, ASCII text executable
+```
+
+Command:
+
+```sh
+python3 -c "import ecli; print('ecli', ecli.__version__)"
+```
+
+Output:
+
+```text
+ecli 0.1.0
+```
+
+Command:
+
+```sh
+python3 -c "from ecli.__main__ import main; print('entry point importable:', main.__name__)"
+```
+
+Output:
+
+```text
+Could not parse user config '/home/ssb/.config/ecli/config.toml': Unbalanced quotes (line 18 column 34 char 258). Using defaults.
+entry point importable: main
+```
+
+The user-local config parse warning is outside the Gate 2 artifact contract; the
+module import succeeds and falls back to defaults.
+
+### A.2.4 Per-Platform Sidecar Format Spot Check
+
+Command:
+
+```sh
+for f in $(find releases dist -name '*.sha256' 2>/dev/null); do
+  line=$(head -1 "$f")
+  if echo "$line" | grep -qE '^[0-9a-f]{64}  [^ /]+$'; then
+    echo "OK   $f"
+  else
+    echo "FAIL $f -> $line"
+  fi
+done
+```
+
+Output:
+
+```text
+OK   releases/0.1.0/ecli_0.1.0_linux_x86_64.deb.sha256
+OK   releases/0.1.0/ecli_0.1.0_linux_x86_64.rpm.sha256
+OK   releases/0.1.0/ecli_0.1.0_freebsd_x86_64.pkg.sha256
+OK   dist/ecli_editor-0.1.0-py3-none-any.whl.sha256
+OK   dist/ecli_editor-0.1.0.tar.gz.sha256
+```
+
+### A.2.5 PyProject Windows-Deps Verification
+
+Command:
+
+```sh
+python3 -c "
+import tomllib
+with open('pyproject.toml','rb') as f:
+    d = tomllib.load(f)
+deps = d['project']['dependencies']
+bad = [x for x in deps if 'sys_platform != ' in x and 'win32' in x]
+good_win = [x for x in deps if 'sys_platform == ' in x and 'win32' in x]
+print('Excluding-Windows markers (must be 0):', len(bad))
+for x in bad: print(' ', x)
+print('Windows-only markers (must be >=1):', len(good_win))
+for x in good_win: print(' ', x)
+"
+```
+
+Output:
+
+```text
+Excluding-Windows markers (must be 0): 0
+Windows-only markers (must be >=1): 1
+  windows-curses>=2.4.0; sys_platform == 'win32'
+```
+
+### A.2.6 PyPI Namespace Verification
+
+Command:
+
+```sh
+python3 -m pip index versions ecli-editor
+```
+
+Output:
+
+```text
+ecli-editor (0.0.1)
+Available versions: 0.0.1
+  INSTALLED: 0.1.0
+  LATEST:    0.0.1
+```
+
+### A.3 Validator Implementation Review
+
+The `validate-*-contract` targets are Makefile shell logic. Checksum validation
+was originally implemented by the inline Make `verify_sha256` macro pattern.
+This has been extracted to `scripts/verify-artifact.sh`; Make targets continue
+to call the script, while CI consumers that require granular exit-code handling
+can invoke it directly.
+
+Direct invocation:
+
+```sh
+scripts/verify-artifact.sh <artifact-path>
+```
+
+### A.3 Direct Tamper Test
+
+Command:
+
+```sh
+make clean && make package-pypi
+WHL_SIDECAR=$(ls dist/ecli_editor-*.whl.sha256)
+cp "$WHL_SIDECAR" "${WHL_SIDECAR}.bak"
+ORIG=$(cat "$WHL_SIDECAR")
+echo "ffff${ORIG:4}" > "$WHL_SIDECAR"
+set +e
+scripts/verify-artifact.sh "${WHL_SIDECAR%.sha256}"
+rc=$?
+set -e
+echo "Direct invocation exit code: $rc"
+mv "${WHL_SIDECAR}.bak" "$WHL_SIDECAR"
+```
+
+Output:
+
+```text
+rm -rf build/ dist/ .pytest_cache/ .ruff_cache/ .mypy_cache/ __pycache__
+find . -type d -name "__pycache__" -exec rm -rf {} +
+find . -type f -name "*.pyc" -delete
+--> Intermediate build artifacts cleaned.
+rm -rf build/ dist/ .pytest_cache/ .ruff_cache/ .mypy_cache/ __pycache__
+find . -type d -name "__pycache__" -exec rm -rf {} +
+find . -type f -name "*.pyc" -delete
+--> Intermediate build artifacts cleaned.
+--> Building Python packages (wheel + sdist)...
+python3 -m build
+* Creating isolated environment: venv+pip...
+* Installing packages in isolated environment:
+  - hatchling>=1.27
+* Getting build dependencies for sdist...
+* Building sdist...
+* Building wheel from sdist
+* Creating isolated environment: venv+pip...
+* Installing packages in isolated environment:
+  - hatchling>=1.27
+* Getting build dependencies for wheel...
+* Building wheel...
+Successfully built ecli_editor-0.1.0.tar.gz and ecli_editor-0.1.0-py3-none-any.whl
+python3 -m twine check --strict dist/*.whl dist/*.tar.gz
+Checking dist/ecli_editor-0.1.0-py3-none-any.whl: [32mPASSED[0m
+Checking dist/ecli_editor-0.1.0.tar.gz: [32mPASSED[0m
+make package-pypi-assert
+make[1]: Entering directory '/home/ssb/Code/Ecli/ecli'
+ecli_editor-0.1.0-py3-none-any.whl: OK
+ecli_editor-0.1.0.tar.gz: OK
+--> OK: dist/ecli_editor-0.1.0-py3-none-any.whl
+--> OK: dist/ecli_editor-0.1.0-py3-none-any.whl.sha256
+--> OK: dist/ecli_editor-0.1.0.tar.gz
+--> OK: dist/ecli_editor-0.1.0.tar.gz.sha256
+make[1]: Leaving directory '/home/ssb/Code/Ecli/ecli'
+ecli_editor-0.1.0-py3-none-any.whl: FAILED
+sha256sum: WARNING: 1 computed checksum did NOT match
+checksum mismatch: dist/ecli_editor-0.1.0-py3-none-any.whl
+Direct invocation exit code: 4
+```
+
+### A.4 PyPI Publish Workflow Guard
+
+Namespace ownership checks were added to:
+
+- `.github/workflows/pypi-validate.yml`
+- `.github/workflows/release.yml` `publish-pypi` job
+
+The release workflow PyPI environment URL was corrected to
+`https://pypi.org/p/ecli-editor` to match `pyproject.toml` and the reserved PyPI
+project.
+
 ## Known Debt
 
 - License drift remains out of scope: `pyproject.toml` uses Apache-2.0 metadata
   while `LICENSE` and source headers are MIT. Issue #33 was not open/visible at
   report time.
+- PyPI namespace `ecli-editor` reserved on 2026-05-09 with placeholder version
+  0.0.1. Verified at https://pypi.org/project/ecli-editor/0.0.1/. Maintainer
+  rotated the API token used for the placeholder upload to a project-scoped
+  token after that operation.
+
+  Open Phase 1 follow-up: migrate to PyPI Trusted Publishers (OIDC) per issue
+  #34 (if open). This will eliminate the static-token requirement entirely;
+  until then, publish workflow uses scoped API token from GitHub Secrets.
 - The root `main.py` shim is retained for contributor workflow compatibility.
 - Notarization, code signing, NSIS audit, MSI packaging, SBOM generation, SLSA
   provenance, and reproducible build attestation remain Phase 1+ work.

--- a/docs/planning/phase1-audit.md
+++ b/docs/planning/phase1-audit.md
@@ -1,0 +1,220 @@
+<!--
+Filename: docs/planning/phase1-audit.md
+Project:  ECLI
+License:  MIT
+Author:   Siergej Sobolewski
+Copyright: (c) 2026 Siergej Sobolewski
+-->
+
+# Gate 2 Phase 1 Readiness Audit
+
+Date: 2026-05-09
+
+Branch: `docs/phase1-audit`
+
+Scope:
+
+- Workstream A: macOS Phase 1, issue #5.
+- Workstream B: PyPI Phase 1, issue #6.
+- Workstream C: Windows Phase 1, issue #7.
+- Coordination remains issue #8.
+
+No Phase 1 implementation was started.
+
+## Summary
+
+Phase 0 artifact-contract work is present: platform validation targets exist,
+checksum sidecars use basename-only SHA256 format, PyPI namespace
+`ecli-editor` is reserved, and direct checksum verification is now available via
+`scripts/verify-artifact.sh` for CI consumers that need granular exit codes.
+
+Phase 1 is not implementation-ready until maintainer decisions are made for
+paid/external services and signing credentials: Apple Developer Program,
+notarization secrets, PyPI Trusted Publishers, and Windows code-signing path.
+
+## Workstream A: macOS Phase 1 (#5)
+
+### Existing Repo State
+
+- `make package-macos` calls `scripts/build-and-package-macos.sh`.
+- `scripts/build-and-package-macos.sh` builds a PyInstaller app bundle, creates a
+  DMG with `hdiutil`, writes `releases/<version>/.macos.env`, and emits
+  `ecli_<version>_macos_<arch>.dmg` plus `.sha256`.
+- `.github/workflows/macos-dmg.yml` builds a DMG on `macos-13` and uploads it as
+  a workflow artifact.
+- `.github/workflows/macos-validate.yml` runs the dry-run contract validation on
+  `macos-14`.
+- `make validate-macos-contract` validates the built DMG and SHA256 sidecar.
+
+### Gaps Versus Phase 1 Acceptance
+
+- Universal2 is not implemented. The current script derives `MAC_ARCH` from
+  `uname -m` and produces one host-architecture DMG, not a single x86_64+arm64
+  binary.
+- The script explicitly states that it does not sign or notarize. There is no
+  hardened-runtime `codesign` step, Developer ID certificate import, entitlement
+  file, `notarytool submit`, notarization polling, or `stapler staple`.
+- There is no verification evidence for execution on both Intel and Apple
+  Silicon macOS. CI currently builds on one runner architecture at a time.
+- DMG distribution readiness is incomplete: no stapling verification, no
+  `spctl`/Gatekeeper assessment, and no quarantine-path smoke test.
+- Secret injection for Apple credentials is undefined.
+
+### Maintainer Decisions Still Required
+
+- Whether the maintainer has Apple Developer Program membership.
+- If notarization is available, how Apple ID credentials, Team ID, app-specific
+  password, and the Developer ID certificate/private key are injected.
+- Whether Phase 1 should halt macOS at an ad-hoc signed DMG if notarization
+  credentials are unavailable.
+
+## Workstream B: PyPI Phase 1 (#6)
+
+### Existing Repo State
+
+- `pyproject.toml` distribution name is `ecli-editor`; import package and console
+  script remain `ecli`.
+- `make package-pypi` builds wheel and sdist using `python3 -m build`, validates
+  metadata with `twine check --strict`, and emits SHA256 sidecars.
+- `.github/workflows/pypi-validate.yml` performs dry-run package validation and
+  verifies PyPI namespace ownership.
+- `.github/workflows/release.yml` is tag-triggered and contains a `publish-pypi`
+  job using `pypa/gh-action-pypi-publish` with `id-token: write`; the job now
+  verifies that the reserved namespace is `ecli-editor` before publishing.
+- `docs/release/release-process.md` documents namespace pre-reservation and the
+  current static-token-to-OIDC migration direction.
+- `scripts/publish_pypi.sh` is a placeholder and is not a usable publish path.
+
+### Gaps Versus Phase 1 Acceptance
+
+- Trusted Publishers configuration in the PyPI project settings cannot be
+  verified from the repository. The current release job assumes OIDC publishing,
+  but PyPI-side trust binding must be configured by the maintainer.
+- `.github/workflows/release.yml` currently binds `publish-pypi` to GitHub
+  environment `pypi`. The Phase 1 decision text says the PyPI Trusted Publisher
+  environment should be left empty per Phase 0 Q4; this must be reconciled before
+  tag publishing is treated as production-ready.
+- The release workflow build step uses `python -m build`; issue #6 proposed
+  `uv build`. The project needs one authoritative build command for release CI.
+- The release workflow does not run `twine check --strict` in `build-python`.
+  Validation exists in `make package-pypi` and `pypi-validate.yml`, but the
+  tag-triggered release path should carry its own pre-publish metadata gate.
+- SBOM emission is not implemented. There is no CycloneDX generation,
+  artifact naming convention, checksum sidecar, or upload step for SBOM output.
+- User-facing install language must use `pip install ecli-editor`, not
+  `pip install ecli`, because Q5 chose the PyPI distribution name
+  `ecli-editor`.
+
+### Maintainer Decisions Still Required
+
+- Whether PyPI Trusted Publishers is already configured for
+  `SSobol77/ecli` and the selected workflow filename.
+- Whether to keep the current OIDC publish path, temporarily use a scoped
+  `PYPI_API_TOKEN`, or block tag publishing until Trusted Publishers is
+  configured.
+- Whether to standardize Phase 1 release builds on `uv build` or the current
+  `python3 -m build` path.
+- SBOM policy: CycloneDX format variant, package scope, and whether SBOMs are
+  attached only to GitHub Releases or also published as PyPI attestations later.
+
+## Workstream C: Windows Phase 1 (#7)
+
+### Existing Repo State
+
+- `make package-windows` calls `pwsh -File ./scripts/build-and-package-windows.ps1`.
+- `scripts/build-and-package-windows.ps1` builds with PyInstaller and invokes
+  NSIS, emitting `ecli_<version>_win_x86_64.exe` plus `.sha256`.
+- `scripts/build_pyinstaller_windows.ps1` is a second Windows packager with
+  richer comments and `uv sync --frozen`; current Makefile wiring does not call
+  it.
+- `packaging/windows/nsis/ecli.nsi` installs to Program Files, writes uninstall
+  registry keys under `HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall`,
+  creates a Start Menu shortcut, writes an uninstaller, and removes those entries
+  on uninstall.
+- `.github/workflows/windows-installer.yml` and
+  `.github/workflows/windows-validate.yml` install NSIS and run the Windows build
+  or validation path on `windows-latest`.
+- `make validate-windows-contract` validates the current Windows artifact and
+  checksum sidecar.
+
+### Gaps Versus Phase 1 Acceptance
+
+- Portable EXE and installer outputs are not separated. The current strict
+  artifact name is a single `.exe`, and the Phase 1 contract needs both a
+  PyInstaller `--onefile` portable EXE and an NSIS installer artifact.
+- The original issue mentions MSI, while Phase 1 scope prefers NSIS. MSI/WiX must
+  be explicitly deferred or added as a separate flow.
+- Code signing is not implemented. There is no Authenticode `signtool` step,
+  Azure Trusted Signing integration, EV certificate path, timestamp server, or
+  verification with `Get-AuthenticodeSignature`.
+- NSIS registration exists, but Phase 1 still needs install/uninstall validation
+  on Windows 10 and Windows 11 runners or test hosts, including Programs &
+  Features registration evidence.
+- The two Windows packaging scripts overlap. Phase 1 should choose one canonical
+  script before adding signing and dual-artifact semantics.
+- ARM64 Windows support remains optional and is not implemented.
+
+### Maintainer Decisions Still Required
+
+- Whether Windows Phase 1 is unsigned by default or requires Azure Trusted
+  Signing / EV certificate integration.
+- Whether NSIS-only is authoritative for Phase 1, or MSI/WiX must be added.
+- Which Windows packaging script is canonical:
+  `scripts/build-and-package-windows.ps1` or
+  `scripts/build_pyinstaller_windows.ps1`.
+
+## Coordination Notes (#8)
+
+- Issue #8 should remain open for Phase 1 sequencing and cross-workstream
+  status.
+- The workstreams are externally coupled by credentials and release semantics:
+  notarization, PyPI OIDC, Windows signing, SBOM naming, and GitHub Release asset
+  policy should be decided before code changes begin.
+- No real PyPI publish or GitHub Release creation should occur during Phase 1
+  implementation validation. Use workflow dry-runs, draft releases, or local
+  artifact checks until maintainer approval.
+
+## Maintainer Decisions Required
+
+Q-P1-A1. Does the maintainer hold an Apple Developer Program membership
+(US$99/yr)? Required for notarization. If NO, Workstream A halts at
+"ad-hoc signed DMG" and notarization is deferred to Phase 2.
+
+Q-P1-A2. If YES on A1, what is the preferred secret-injection path for
+`APPLE_ID`, `APPLE_TEAM_ID`, `APP_SPECIFIC_PASSWORD`, and the .p12 signing
+certificate?
+
+- GitHub Actions secrets (simple, recommended)
+- 1Password Connect / external secret manager
+- GitHub Environments (declined per Q4 of Phase 0)
+
+Q-P1-B1. Has the maintainer configured Trusted Publishers under
+pypi.org/manage/project/ecli-editor/settings/publishing/ with:
+
+```text
+owner       = SSobol77
+repository  = ecli
+workflow    = <workflow-filename>.yml
+environment = (leave empty per Q4 of Phase 0)
+```
+
+If NO: Workstream B halts on the OIDC migration step but can proceed with
+static-token publish in the meantime.
+
+Q-P1-C1. Code signing for Windows EXE — choose path:
+
+- (a) Unsigned (Phase 1 default; SmartScreen warns).
+- (b) Azure Trusted Signing (newer, low cost, requires Azure subscription).
+- (c) EV cert from CA (high cost, immediate SmartScreen trust).
+
+If (b) or (c), provide credential injection path.
+
+Q-P1-C2. MSI installer scope — confirm:
+
+- (a) NSIS-only for Phase 1 (recommended).
+- (b) NSIS + WiX MSI dual-flow (defers Phase 1 by approximately 2 weeks).
+
+## Stop Gate
+
+Stop here. Do not begin Phase 1 implementation until the maintainer decisions
+above are answered.

--- a/docs/planning/post-merge-defects.md
+++ b/docs/planning/post-merge-defects.md
@@ -1,0 +1,125 @@
+<!--
+Filename: docs/planning/post-merge-defects.md
+Project:  ECLI
+License:  MIT
+Author:   Siergej Sobolewski
+Copyright: (c) 2026 Siergej Sobolewski
+-->
+
+# Gate 2 Post-Merge Defects
+
+Timestamp: 2026-05-09T22:55:40+02:00
+
+Branch: `chore/gate2-postmerge-verification`
+
+## Stop Condition
+
+Part A halted during A.2.1 before proceeding to A.3, per the execution rule:
+
+> Any A.2.x verification fails -> halt, defect report, do not proceed to A.3.
+
+## Defect PMV-001: Required `python` Invocation Is Unavailable
+
+### Verification Step
+
+A.2.1 Smoke tests run:
+
+```sh
+cd $(git rev-parse --show-toplevel)
+python -m pip install --user -e ".[dev]" --quiet
+python -m pytest tests/test_smoke.py -v
+```
+
+### Transcript
+
+```text
+bash: line 1: python: command not found
+```
+
+### Impact
+
+The post-merge verification command specified for Gate 2 cannot execute in this
+environment because `python` is not present on `PATH`. The smoke tests were not
+collected or executed, and editable-install entry point verification was not
+started.
+
+This is a verification contract failure, not evidence that `tests/test_smoke.py`,
+`src/ecli/__init__.py`, or `src/ecli/__main__.py` are defective. The prescribed
+command path cannot establish those properties until the `python` interpreter
+alias issue is resolved or the verification contract is amended to use
+`python3`.
+
+### Required Maintainer Triage
+
+Choose one of:
+
+- Provide a `python` command on the verification runner PATH and rerun Part A.2
+  from A.2.1.
+- Amend the Gate 2 post-merge verification contract to use `python3` for A.2.1,
+  A.2.2, and other Python invocations where the repository requires explicit
+  Python 3 semantics.
+
+No fix-forward was applied because Gate 2 sign-off depends on preserving the
+actual verification evidence.
+
+### Resolution
+
+Resolved by prompt amendment 2026-05-09T23:02:33+02:00. Verification contract
+uses python3 explicitly. No repository changes required.
+
+## Defect PMV-002: Editable Entry Point Does Not Print Version
+
+Timestamp: 2026-05-09T23:03:35+02:00
+
+### Verification Step
+
+A.2.3 Editable install entry point, using the amendment's absolute-path form
+because `pip install --user` placed scripts under `~/.local/bin`, which is not
+on `PATH` in this workstation shell:
+
+```sh
+ls -la ~/.local/bin/ecli && ~/.local/bin/ecli --version 2>&1 | head -3 || \
+    echo "ENTRY POINT NOT INSTALLED"
+```
+
+### Transcript
+
+```text
+-rwxrwxr-x 1 ssb ssb 212 May  9 23:03 /home/ssb/.local/bin/ecli
+Could not parse user config '/home/ssb/.config/ecli/config.toml': Unbalanced quotes (line 18 column 34 char 258). Using defaults.
+[?1h=CRITICAL - ecli         - Unhandled exception at the top level.
+Traceback (most recent call last):
+ENTRY POINT NOT INSTALLED
+```
+
+### Impact
+
+The editable install created the `ecli` console script, so the project script
+entry point is linked. However, `ecli --version` does not satisfy the Phase 0
+post-merge acceptance expectation that the command prints a version string. The
+command appears to enter the normal application path, emits terminal-control
+bytes, logs a top-level critical exception, and returns nonzero.
+
+This prevents completing A.2.3 and therefore blocks Gate 2 Part A sign-off.
+
+### Required Maintainer Triage
+
+Determine whether `ecli --version` is intended to be a supported noninteractive
+CLI contract for Phase 0. If yes, the entry point should handle `--version`
+before loading user configuration or launching the terminal UI. If no, amend the
+post-merge verification contract to check an actually supported version surface,
+for example `python3 -c 'import ecli; print(ecli.__version__)'`.
+
+### Resolution
+
+Resolved by prompt amendment 2026-05-09T23:12:56+02:00. Root cause: A.2.3
+invoked `ecli --version`, but ECLI's CLI does not implement a non-TTY
+`--version` handler. When piped through `head`, curses.initscr() fails on
+no-TTY, producing the observed top-level exception. This is curses behavior, not
+a code defect.
+
+A.2.3 amended to verify entry-point linkage via filesystem check + module
+import, without invoking the CLI binary. The CLI `--version`/`--help` work is
+tracked separately as a Phase 1 follow-up.
+
+No repository changes required for Gate 2 sign-off.

--- a/docs/release/artifact-verification.md
+++ b/docs/release/artifact-verification.md
@@ -34,6 +34,35 @@ $actual = (Get-FileHash -Algorithm SHA256 <artifact>).Hash
 if ($actual -eq $expected) { Write-Output "Verified" } else { Write-Output "Mismatch" }
 ```
 
+## Granular Exit Codes for CI Scripting
+
+GNU Make reports failed recipes with make process exit code `2`, so callers
+that need the artifact-verifier exit contract must invoke the verifier directly:
+
+```sh
+scripts/verify-artifact.sh releases/<version>/<artifact>
+```
+
+The verifier expects the sidecar at `<artifact>.sha256` and requires the
+sidecar payload to use basename-only coreutils format:
+
+```text
+<64 lowercase hex characters>  <artifact basename>
+```
+
+Exit codes:
+
+- `0`: artifact verified
+- `1`: invalid invocation or malformed checksum sidecar
+- `2`: artifact missing
+- `3`: checksum sidecar missing
+- `4`: checksum mismatch
+- `5`: missing SHA256 verification tool (`sha256sum` or `shasum`)
+
+The `make validate-*-contract` targets call the same verifier, but CI logic that
+branches on specific failure classes must call `scripts/verify-artifact.sh`
+directly.
+
 ## Policy
 
 - Verification must run in CI for official releases.

--- a/docs/release/release-process.md
+++ b/docs/release/release-process.md
@@ -28,6 +28,48 @@ Copyright: (c) 2026 Siergej Sobolewski
 - Missing required artifacts must block release.
 - Workflow references to non-existent files must be resolved as release blockers.
 
+## PyPI Namespace Pre-Reservation
+
+The Python distribution name is `ecli-editor`; the import package and console
+script remain `ecli`.
+
+Before enabling a publish workflow for a new package name:
+
+1. Confirm the configured distribution name:
+
+   ```sh
+   python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["name"])'
+   ```
+
+2. Check whether the PyPI namespace already exists:
+
+   ```sh
+   python3 -m pip index versions ecli-editor
+   ```
+
+3. If the project does not exist, build and upload a minimal placeholder release
+   from a clean maintainer workstation using a scoped PyPI API token:
+
+   ```sh
+   python3 -m build
+   python3 -m twine check --strict dist/*
+   python3 -m twine upload dist/*
+   ```
+
+4. Rotate or replace any token used for the bootstrap upload with a
+   project-scoped token. Store only the scoped token in GitHub Secrets until
+   Trusted Publishers is configured.
+
+5. Re-run the namespace guard:
+
+   ```sh
+   python3 -m pip index versions ecli-editor
+   ```
+
+Do not embed PyPI API tokens in repository files, workflow YAML, release notes,
+or documentation. Phase 1 should migrate publishing to PyPI Trusted Publishers
+(OIDC) so GitHub Actions can publish without a static API token.
+
 ## Future Hardening
 
 Protected GitHub environments are recommended once the project has at least two

--- a/scripts/publish_pypi.sh
+++ b/scripts/publish_pypi.sh
@@ -1,1 +1,32 @@
-TODO: create this script
+#!/usr/bin/env bash
+# scripts/publish_pypi.sh
+# ECLI PyPI publish — placeholder.
+#
+# Actual PyPI publishing is performed by:
+#   .github/workflows/release.yml  (job: publish-pypi)
+#   via OIDC + PyPI Trusted Publishers, on tag push.
+#
+# Local maintainer publish from a clean workstation should be done
+# explicitly with the documented procedure:
+#
+#   python3 -m build
+#   python3 -m twine check --strict dist/*
+#   python3 -m twine upload dist/*
+#
+# See docs/release/release-process.md for the full procedure including
+# PyPI namespace pre-reservation and token rotation.
+#
+# This script intentionally exits non-zero to prevent accidental local
+# publishes from automated chains (e.g. Makefile recipes, CI hooks).
+
+set -euo pipefail
+
+cat >&2 <<'MSG'
+ERROR: scripts/publish_pypi.sh is not implemented.
+
+PyPI publishing for ECLI is performed by .github/workflows/release.yml
+on tag push. For maintainer-side local publish, follow the explicit
+procedure in docs/release/release-process.md.
+MSG
+
+exit 1

--- a/scripts/verify-artifact.sh
+++ b/scripts/verify-artifact.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+# Verify an artifact against its basename-only SHA256 sidecar.
+#
+# Exit-code contract:
+#   0 verified
+#   1 invalid invocation or malformed sidecar
+#   2 artifact missing
+#   3 sidecar missing
+#   4 checksum mismatch
+#   5 missing checksum tool
+
+set -u
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: scripts/verify-artifact.sh <artifact>" >&2
+    exit 1
+fi
+
+artifact=$1
+sidecar="${artifact}.sha256"
+
+if [ ! -f "$artifact" ]; then
+    echo "Missing $artifact"
+    exit 2
+fi
+
+if [ ! -f "$sidecar" ]; then
+    echo "Missing $sidecar"
+    exit 3
+fi
+
+dir=$(dirname "$artifact")
+base=$(basename "$artifact")
+
+first_line=$(head -n 1 "$sidecar")
+case "$first_line" in
+    *"  $base")
+        ;;
+    *)
+        echo "Malformed checksum sidecar: $sidecar"
+        exit 1
+        ;;
+esac
+
+if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$dir" && sha256sum -c "$base.sha256") || {
+        echo "checksum mismatch: $artifact"
+        exit 4
+    }
+elif command -v shasum >/dev/null 2>&1; then
+    (cd "$dir" && shasum -a 256 -c "$base.sha256") || {
+        echo "checksum mismatch: $artifact"
+        exit 4
+    }
+else
+    echo "Missing SHA256 tool: sha256sum or shasum"
+    exit 5
+fi


### PR DESCRIPTION
## Summary

Aggregates Gate 2 Phase 0 post-merge verification, Phase 1 readiness
audit, and a Phase 0 compliance fix in three commits.

## Commits

1. **docs: post-merge verification and phase 1 prep**
   - Resolved PMV-001 and PMV-002 in
     \`docs/planning/post-merge-defects.md\`.
   - Completed verification A.2.1..A.2.6 under amended \`python3\`
     and entry-point-linkage contracts.
   - Extracted \`scripts/verify-artifact.sh\` with granular exit
     codes 0/1/2/3/4/5; tamper test confirmed exit 4.
   - Added PyPI namespace guard to \`pypi-validate.yml\` and
     \`release.yml\`.
   - Updated \`docs/release/release-process.md\` with PyPI
     namespace pre-reservation procedure.
   - Updated \`docs/planning/gate2-phase0-report.md\` with
     post-merge verification evidence and reservation status.

2. **docs: add phase 1 readiness audit**
   - Produced \`docs/planning/phase1-audit.md\` covering macOS,
     PyPI, and Windows workstreams against Phase 1 acceptance.
   - Consolidated maintainer decision block (Q-P1-A1..C2).

3. **fix(release): remove pypi env binding, normalize publish script**
   - Removed \`environment: pypi\` from \`release.yml\`
     publish-pypi job (Phase 0 Q4 alignment).
   - Replaced \`scripts/publish_pypi.sh\` 24-byte placeholder with
     fail-closed stub directing to maintainer procedure.

## Status

- Gate 2 Phase 0 post-merge verification: **complete**.
- Phase 1 readiness audit: **complete**, blocked on maintainer
  decisions Q-P1-A1..C2.

## Closes (Phase 0)

- Verification deliverables for #5 (macOS), #6 (PyPI), #7 (Windows).

## Does NOT close

- Phase 1 implementation in #5/#6/#7 — gated on maintainer
  decisions documented in \`phase1-audit.md\`.
- Issue #8 (Coordination) remains open for Phase 1 sequencing.