### PR TITLE
docs(release): add Phase 1 implementation report

### DIFF
--- a/docs/planning/phase1-implementation-report.md
+++ b/docs/planning/phase1-implementation-report.md
@@ -1,0 +1,268 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+
+Project: Ecli
+File: docs/planning/phase1-implementation-report.md
+Website: https://www.ecli.io
+Repository: https://github.com/SSobol77/ecli
+PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+
+Copyright (c) 2026 Siergej Sobolewski
+
+Licensed under the Apache License, Version 2.0.
+See the LICENSE file in the project root for full license text.
+-->
+# Gate 2 Phase 1 Implementation Report
+
+Date: 2026-05-10
+
+Base state: `main` at `cc30717`.
+
+Phase 1 is complete for workstreams A, B, and C. Workstream D was deferred by
+maintainer decision; the Phase 0 FreeBSD package flow remains functional but is
+not Gate 2 polished. PR #17 was accepted as an out-of-band hygiene addition to
+close long-standing Apache-2.0 metadata drift before v0.1.0 release operations.
+
+No real PyPI publish, production tag push, or production GitHub Release was
+performed during Phase 1 implementation.
+
+## Workstream Summary
+
+| Workstream | PR | Merge commit | Files | Line delta | CI status | Result |
+|---|---:|---|---:|---:|---|---|
+| A - macOS Universal2 ad-hoc signed DMG | [#14](https://github.com/SSobol77/ecli/pull/14) | `46868b0` | 20 | +903 / -1340 | Passed: PyPI Contract Validate, Windows Contract Validate, macOS Contract Validate, SonarCloud | Complete |
+| B - PyPI token publish + CycloneDX SBOM | [#15](https://github.com/SSobol77/ecli/pull/15) | `73b4914` | 6 | +567 / -6 | Passed: CI, PyPI Contract Validate, Windows Contract Validate, macOS Contract Validate, SonarCloud | Complete |
+| C - Windows portable EXE + NSIS installer | [#16](https://github.com/SSobol77/ecli/pull/16) | `68ec4b6` | 15 | +754 / -423 | Passed: PyPI Contract Validate, Windows Contract Validate, macOS Contract Validate, SonarCloud | Complete |
+| Out-of-band - Apache-2.0 license normalization | [#17](https://github.com/SSobol77/ecli/pull/17) | `cc30717` | 135 | +1677 / -411 | Passed: CI, PyPI Contract Validate, Windows Contract Validate, macOS Contract Validate, SonarCloud | Complete |
+
+Line deltas and file counts are from merged PR metadata.
+
+## Acceptance Status
+
+### Workstream A - macOS Universal2 DMG
+
+Status: complete.
+
+- [x] Canonical PyInstaller spec retained at `packaging/pyinstaller/ecli.spec`.
+- [x] Root-level stale `ecli.spec` path removed from the implementation path.
+- [x] `scripts/build-and-package-macos.sh` builds a Universal2 artifact by
+  combining arm64 and x86_64 legs on `macos-14`.
+- [x] DMG output follows canonical naming:
+  `ecli_<version>_macos_universal2.dmg`.
+- [x] `.sha256` sidecar uses basename-only coreutils-compatible format.
+- [x] CI mounts the DMG, locates the binary, checks `lipo -info` for both
+  `x86_64` and `arm64`, and runs `codesign --verify --verbose`.
+- [x] User-facing macOS install documentation explains first-launch Gatekeeper
+  behavior honestly.
+- [x] Notarization, hardened runtime, Developer ID signing, and stapling are
+  deferred to Phase 2.
+
+### Workstream B - PyPI Tag Publish and SBOM
+
+Status: complete.
+
+- [x] PyPI distribution name is `ecli-editor`; import package and CLI remain
+  `ecli`.
+- [x] Tag-triggered `release.yml` publishes through
+  `pypa/gh-action-pypi-publish` using static `secrets.PYPI_API_TOKEN`.
+- [x] PyPI Trusted Publishers / OIDC migration is explicitly deferred to v0.2.
+- [x] Release path runs `python3 -m build` and `twine check --strict`.
+- [x] CycloneDX SBOM is generated in JSON schema version 1.5 with validation.
+- [x] SBOM artifact names are:
+  `dist/ecli-editor-<version>.cdx.json` and `.sha256`.
+- [x] SBOM is uploaded as a workflow artifact and attached to the GitHub
+  Release.
+- [x] SBOM is not uploaded to PyPI.
+
+### Workstream C - Windows Portable EXE and NSIS Installer
+
+Status: complete.
+
+- [x] `scripts/build-and-package-windows.ps1` is the only Windows packaging
+  script remaining under `scripts/`.
+- [x] Duplicate `scripts/build_pyinstaller_windows.ps1` was audited, superior
+  root/build-dir/strict-output behavior was merged, and the duplicate was
+  deleted.
+- [x] Portable EXE output:
+  `ecli_<version>_win_x86_64.exe`.
+- [x] NSIS installer output:
+  `ecli_<version>_win_x86_64_setup.exe`.
+- [x] Both EXEs receive `.sha256` sidecars in ASCII, LF-terminated,
+  basename-only coreutils format.
+- [x] `releases/<version>/.win.env` records `WIN_ARCH`, portable filename, and
+  installer filename.
+- [x] `validate-windows-contract` was extended through
+  `package-windows-assert` to validate both Windows artifacts.
+- [x] Windows CI proves both EXEs are well-formed without running the curses
+  application.
+- [x] Windows CI verifies NSIS Programs & Features registration through silent
+  install/uninstall and registry assertions.
+- [x] User-facing Windows documentation explains SmartScreen warnings and the
+  unsigned v0.1.0 status.
+- [x] Windows code signing, MSI/WiX, and ARM64 Windows are deferred to Phase 2.
+
+### Workstream D - FreeBSD Polish
+
+Status: deferred.
+
+- [ ] FreeBSD `.pkg` manifest polish is not included in Phase 1.
+- [ ] Canonical naming audit for the FreeBSD package internals is deferred.
+- [x] Existing Phase 0 FreeBSD packaging remains functional through
+  `scripts/build-and-package-freebsd.sh` and the release workflow's FreeBSD VM
+  job.
+
+### Out-of-Band Scope - License Normalization
+
+Status: complete.
+
+- [x] Apache-2.0 SPDX headers normalized across project-owned source, script,
+  documentation, and config files.
+- [x] Project-owned MIT metadata was replaced with Apache-2.0.
+- [x] Generated/cache/binary artifacts were not given fake headers.
+- [x] `.gitignore` was tightened for release outputs, runtime logs, and
+  generated AppImage staging content.
+
+## v0.1.0 Release Readiness Checklist
+
+- [x] macOS Universal2 DMG (ad-hoc signed) builds and verifies in CI.
+- [x] PyPI publish workflow is tag-triggered using static `PYPI_API_TOKEN`.
+- [x] CycloneDX SBOM (schema 1.5) is generated and attached to GitHub Release.
+- [x] Windows portable EXE + NSIS installer build, both unsigned.
+- [x] User documentation (macOS, Windows) explains first-launch warnings
+  honestly.
+- [x] License headers are Apache-2.0 across all source files.
+- [x] All Phase 0 contracts (naming, sidecars, exit codes) honored.
+- [x] No real PyPI publish or production release performed.
+
+## Phase 2 / v0.2 Follow-Up Items
+
+- Apple Developer Program enrollment.
+- macOS Developer ID signing, hardened runtime, notarization, and stapling.
+- PyPI Trusted Publishers / OIDC migration to remove the static token
+  requirement.
+- Windows code signing through Azure Trusted Signing or EV certificate.
+- MSI/WiX installer alternative.
+- ARM64 Windows binary.
+- Workstream D: FreeBSD `.pkg` manifest polish and canonical naming audit.
+  Current FreeBSD packaging remains functional but is not Gate 2 polished.
+
+## v0.1.0 Maintainer Tag-Push Procedure
+
+Only the maintainer should execute this procedure. It intentionally creates the
+first production tag-triggered publish path for v0.1.0.
+
+### Pre-Flight Verification
+
+```sh
+git switch main
+git fetch --prune --tags origin
+git status --short --branch
+git log --oneline -5
+git tag -l v0.1.0
+```
+
+Expected:
+
+- `main` is clean and aligned with `origin/main`.
+- `cc30717` or a later approved commit is at the top of `main`.
+- `git tag -l v0.1.0` prints nothing.
+
+Run local static checks:
+
+```sh
+python3 -m compileall -q src main.py
+python3 - <<'PY'
+import tomllib
+from pathlib import Path
+
+for path in [Path("pyproject.toml")]:
+    with path.open("rb") as f:
+        tomllib.load(f)
+    print(f"OK: {path}")
+PY
+python3 -m pytest tests/test_smoke.py -v
+git diff --check
+```
+
+Verify PyPI publish secret presence:
+
+```sh
+gh secret list --repo SSobol77/ecli | grep '^PYPI_API_TOKEN'
+```
+
+Optional dry-run orientation:
+
+```sh
+make -n validate-gate2
+gh workflow list
+```
+
+Do not run local publish targets. The tag push is the release trigger.
+
+### Tag Creation
+
+```sh
+git tag -a v0.1.0 -m "ECLI v0.1.0"
+```
+
+### Tag Push
+
+```sh
+git push origin v0.1.0
+```
+
+### Post-Push Monitoring
+
+The tag push starts `.github/workflows/release.yml` (`Release`). Monitor it:
+
+```sh
+gh run list --workflow Release --limit 5
+gh run watch <run-id>
+```
+
+Expected release workflow jobs:
+
+- `Build Python distributions`
+- `Build Linux packages`
+- `Build FreeBSD package`
+- `Build macOS DMG`
+- `Build Windows artifacts`
+- `Publish to PyPI`
+- `Publish GitHub release`
+
+Expected GitHub Release assets for `v0.1.0`:
+
+- Python: wheel and source distribution.
+- SBOM: `ecli-editor-0.1.0.cdx.json` and `.sha256`.
+- Linux: `.deb`, `.rpm`, `.tar.gz`, and `.sha256` sidecars.
+- FreeBSD: `.pkg` and `.sha256`.
+- macOS: `ecli_0.1.0_macos_universal2.dmg` and `.sha256`.
+- Windows: `ecli_0.1.0_win_x86_64.exe`,
+  `ecli_0.1.0_win_x86_64_setup.exe`, and both `.sha256` sidecars.
+
+Post-publish inspection:
+
+```sh
+gh release view v0.1.0 --web
+python3 -m pip index versions ecli-editor
+```
+
+If `Publish to PyPI` fails after artifacts build successfully, do not re-tag.
+Fix the secret or workflow issue and rerun the failed workflow job from GitHub
+Actions when the failure mode is safe to retry.
+
+## Residual Risks
+
+- Static `PYPI_API_TOKEN` is sufficient for v0.1.0 but remains a secret
+  exposure risk until PyPI Trusted Publishers is enabled.
+- macOS ad-hoc signing verifies binary integrity in CI but does not provide
+  notarized first-launch trust. Users will still see Gatekeeper friction.
+- Windows artifacts are unsigned, so SmartScreen friction is expected.
+- FreeBSD remains operational but lacks the deferred manifest polish and
+  canonical naming audit.
+- `config.toml` currently fails strict TOML parsing due to a pre-existing
+  malformed model value. This is outside Phase 1 release packaging scope but
+  should be corrected before relying on config validation as a release gate.
+- `scripts/build_freebsd_port.sh` has a pre-existing Bash parse failure around a
+  Python heredoc fallback. It is not the canonical FreeBSD package flow used by
+  Phase 1 release CI, but should be repaired in the FreeBSD polish workstream.

--- a/docs/planning/risk-register.md
+++ b/docs/planning/risk-register.md
@@ -17,16 +17,26 @@ See the LICENSE file in the project root for full license text.
 | Risk | Likelihood | Impact | Severity | Detection | Mitigation | Owner | Status |
 |---|---|---|---|---|---|---|---|
 | Undo/redo regressions during refactor | Medium | High | High | invariant test failures, bug reports | characterization + invariant suites | Core maintainers | Open |
-| Artifact naming/packaging drift | Medium | High | High | release CI contract gate | enforce artifact contract checks | Release maintainers | Open |
+| Artifact naming/packaging drift | Low | High | Medium | release CI contract gate | Phase 0 contract targets plus Phase 1 macOS/Windows/PyPI release workflow validation | Release maintainers | Mitigated in Phase 1 |
 | Config schema ambiguity | High | High | Critical | schema validation failures, startup warnings | canonical schema + migration policy | Config maintainers | Open |
 | Orchestrator coupling blocks safe change | High | Medium/High | High | review churn, regression density | service extraction with parity tests | Core maintainers | Open |
 | Concurrency/event contract gaps | Medium | High | High | queue payload/runtime handling errors | typed payload contracts + gateway rules | Core + Integration maintainers | Open |
 | Contributor workflow drift | Medium | Medium | Medium | setup/build docs mismatch reports | command verification policy | Contributor maintainers | Open |
 | Extension safety boundary ambiguity | Medium | Medium | Medium | extension integration defects | extension guardrails + review checks | Extension maintainers | Open |
+| Static PyPI token exposure | Medium | High | High | secret scanning, release workflow audit, PyPI project event history | keep token scoped to `ecli-editor`; migrate to PyPI Trusted Publishers/OIDC in v0.2 | Release maintainers | New Phase 1 residual |
+| Unsigned Windows binary user friction | High | Medium | Medium | user install reports, SmartScreen prompts | document SmartScreen path for v0.1.0; add Azure Trusted Signing or EV certificate in v0.2 | Release maintainers | New Phase 1 residual |
+| macOS non-notarized first launch friction | High | Medium | Medium | user install reports, Gatekeeper prompts | document Gatekeeper workaround for v0.1.0; add Developer ID signing, hardened runtime, notarization, and stapling in v0.2 | Release maintainers | New Phase 1 residual |
+| FreeBSD package polish deferred | Medium | Medium | Medium | FreeBSD release validation, package metadata audit | keep canonical Phase 0 FreeBSD package flow functional; schedule manifest polish and canonical naming audit in Workstream D | Release maintainers | Deferred |
+| License metadata drift | Low | Medium | Low | SPDX/header scan, package metadata review | PR #17 normalized Apache-2.0 headers and project-owned license metadata | Release maintainers | Mitigated in Phase 1 |
 
 ## Contingency Notes
 
 - Critical/High risks block release if tied to artifact contract, config parse safety, or core mutation invariants.
+- v0.1.0 accepts documented trust-friction risk for unsigned Windows artifacts
+  and ad-hoc signed macOS artifacts. These risks must be closed before claiming
+  production-grade first-launch trust.
+- Static PyPI token exposure is acceptable only as a Phase 1 bridge. Treat OIDC
+  migration as a v0.2 release-readiness item, not a long-term architecture.
 
 ## Related Contract References
 


### PR DESCRIPTION
## Summary

Adds the final Gate 2 Phase 1 implementation report after workstreams A, B, and C merged to `main`, plus the out-of-band Apache-2.0 license normalization PR.

## Contents

- Adds `docs/planning/phase1-implementation-report.md` with:
  - per-workstream summary for PRs #14, #15, #16, and #17
  - file counts, line deltas, merge SHAs, CI status, and PR links
  - acceptance criteria status for macOS, PyPI/SBOM, Windows, deferred FreeBSD polish, and license normalization
  - v0.1.0 readiness checklist
  - Phase 2 / v0.2 deferred work list
  - maintainer tag-push procedure for `v0.1.0`
  - expected release workflow jobs and artifacts
  - residual risk notes
- Updates `docs/planning/risk-register.md` for Phase 1 mitigations and new residual risks:
  - static PyPI token exposure
  - unsigned Windows user friction
  - non-notarized macOS first-launch friction
  - deferred FreeBSD polish
  - mitigated license metadata drift

## Validation

- `git diff --check`
- Manual metadata checks through `gh pr view` for PRs #14, #15, #16, and #17
- Existing repository evidence from release workflows and Phase 1 implementation logs

No tag push, PyPI publish, GitHub Release creation, or merge was performed.
