### PR TITLE
docs(report): remove config.toml residual risk after PR #19

### DIFF
--- a/docs/planning/phase1-implementation-report.md
+++ b/docs/planning/phase1-implementation-report.md
@@ -175,7 +175,7 @@ python3 - <<'PY'
 import tomllib
 from pathlib import Path
 
-for path in [Path("pyproject.toml")]:
+for path in [Path("pyproject.toml"), Path("config.toml")]:
     with path.open("rb") as f:
         tomllib.load(f)
     print(f"OK: {path}")
@@ -260,9 +260,6 @@ Actions when the failure mode is safe to retry.
 - Windows artifacts are unsigned, so SmartScreen friction is expected.
 - FreeBSD remains operational but lacks the deferred manifest polish and
   canonical naming audit.
-- `config.toml` currently fails strict TOML parsing due to a pre-existing
-  malformed model value. This is outside Phase 1 release packaging scope but
-  should be corrected before relying on config validation as a release gate.
 - `scripts/build_freebsd_port.sh` has a pre-existing Bash parse failure around a
   Python heredoc fallback. It is not the canonical FreeBSD package flow used by
   Phase 1 release CI, but should be repaired in the FreeBSD polish workstream.


### PR DESCRIPTION
config.toml strict-parsing failure was fixed in PR #19. Updates Phase 1 implementation report:

- Pre-flight verification now includes config.toml in the tomllib loop.
- Removes config.toml entry from Residual Risks section.

build_freebsd_port.sh remains in residual risks (deferred to Workstream D / v0.2).

This is the final pre-tag-push doc update before v0.1.0 release.