### PR TITLE
fix(release): unblock v0.1.1 release pipeline

### DIFF
--- a/.github/workflows/pypi-validate.yml
+++ b/.github/workflows/pypi-validate.yml
@@ -72,7 +72,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          wheel_sha="dist/ecli_editor-0.1.0-py3-none-any.whl.sha256"
+          wheel_sha="$(python3 - <<'PY'
+          import tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              project = tomllib.load(f)["project"]
+
+          wheel_name = project["name"].replace("-", "_")
+          version = project["version"]
+          print(f"dist/{wheel_name}-{version}-py3-none-any.whl.sha256")
+          PY
+          )"
           cp "$wheel_sha" "$wheel_sha.bak"
           awk '{print "ffff" substr($1, 5) "  " $2}' "$wheel_sha.bak" > "$wheel_sha"
           set +e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,16 @@ jobs:
       - name: Build Debian package in Docker
         run: make package-deb-docker
 
+      - name: Reset ownership after Docker DEB build
+        run: |
+          set -euo pipefail
+          # Docker containers in package-deb-docker run as root and leave
+          # root-owned files in build/ and dist/. The next make target invokes
+          # 'make clean' on the host under the runner user, which fails on
+          # root-owned paths. Reset ownership defensively before continuing.
+          if [ -d build ]; then sudo chown -R "$(id -u):$(id -g)" build/; fi
+          if [ -d dist ]; then sudo chown -R "$(id -u):$(id -g)" dist/; fi
+
       - name: Build RPM package in Docker
         run: make package-rpm-docker
 
@@ -147,7 +157,7 @@ jobs:
             # dependency) has no FreeBSD prebuilt wheel and must be
             # compiled from source. Other build essentials cover any
             # additional native deps that may need on-VM compilation.
-            env ASSUME_ALWAYS_YES=yes pkg install -y rust cargo pkgconf
+            env ASSUME_ALWAYS_YES=yes pkg install -y rust pkgconf
             rustc --version
             cargo --version
           run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ecli-editor"
-version = "0.1.0"
+version = "0.1.1"
 description = "ECLI — fast terminal code editor"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Fixes Bug 5 (FreeBSD cargo) and Bug 6 (Linux root-owned files) that emerged during the v0.1.0 release attempt. Bumps version to 0.1.1.

PyPI 0.1.0 was published successfully during the v0.1.0 attempt (visible at pypi.org/project/ecli-editor/0.1.0/). The aggregate workflow failed AFTER that publish, so PyPI 0.1.0 is immutable. Maintainer decision: forward strategy. v0.1.1 becomes the first complete release across all platforms.

Additional CI fix included: PyPI Contract Validate had a 0.1.0 wheel sidecar path hardcoded in its tamper test. This PR makes that path derive from pyproject.toml so future version bumps do not break the validation workflow.

After merge, maintainer pushes tag v0.1.1 to trigger the full release pipeline.

Validation:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); yaml.safe_load(open('.github/workflows/pypi-validate.yml'))" && echo "YAML OK"`
- `python3 -c "import tomllib; ..."`
- `grep -n "pkg install -y rust" .github/workflows/release.yml`
- `grep -n "Reset ownership" .github/workflows/release.yml`
- `python3 -m pytest tests/test_smoke.py -v`
- `git diff --check`
