### PR TITLE
fix(release): unblock v0.1.2 release pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Licensed under the Apache License, Version 2.0.
 See the LICENSE file in the project root for full license text.
 -->
 <p align="center">
-  <img src="https://github.com/SSobol77/ecli/blob/main/img/logo_m.png" alt="ecli Logo" width="200"/>
+  <img src="https://raw.githubusercontent.com/SSobol77/ecli/main/img/logo_m.png" alt="ecli Logo" width="200"/>
 </p>
 
 <h1 align="center"><b>ECLI</b></h1>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ecli-editor"
-version = "0.1.1"
+version = "0.1.2"
 description = "ECLI — fast terminal code editor"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/build-and-package-freebsd.sh
+++ b/scripts/build-and-package-freebsd.sh
@@ -124,9 +124,9 @@ set -eu
 
 # -------- Pretty printing ------------------------------------------------------
 print_header() { printf "\033[1;36m==> %s\033[0m\n" "$*"; }
-print_step()   { printf "\033[32m  -> %s\033[0m\n" "$*"; }
-print_warn()   { printf "\033[33mWARN:\033[0m %s\n" "$*"; }
-print_error()  { printf "\033[31mERROR:\033[0m %s\n" "$*"; }
+print_step()   { printf "\033[32m  -> %s\033[0m\n" "$*" >&2; }
+print_warn()   { printf "\033[33mWARN:\033[0m %s\n" "$*" >&2; }
+print_error()  { printf "\033[31mERROR:\033[0m %s\n" "$*" >&2; }
 
 # -------- Paths & meta --------------------------------------------------------
 PROJECT_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"


### PR DESCRIPTION
Two fixes plus version bump:

**Bug 7 — FreeBSD build_binary stdout pollution**
The build_binary() shell function used print_step/print_warn/print_error
helpers that wrote diagnostic messages to stdout. Command substitution
\`EXECUTABLE=\$(build_binary)\` then captured log lines into the
path variable, breaking \`install -m 755 "\$EXECUTABLE"\`.
Fix: redirect all 3 print_ helpers to stderr. Standard Unix idiom.

**Bug 8 — PyPI logo not rendering**
README.md used GitHub blob viewer URL (HTML page) instead of
raw.githubusercontent.com (binary PNG). PyPI got HTML instead of
image. Fix: switch to raw URL.

**Version bump:** 0.1.1 -> 0.1.2.

PyPI 0.1.1 stays as-is per forward strategy. v0.1.2 will be the
first complete release across all platforms (PyPI + GitHub Release
with native packages for Linux/FreeBSD/macOS/Windows).