### PR TITLE
docs: fix contract markdown cleanup issues

### DIFF
--- a/docs/architecture/command-plan-service.md
+++ b/docs/architecture/command-plan-service.md
@@ -1119,7 +1119,7 @@ These rules are non-negotiable:
 - JSON export;
 - shell export;
 - Markdown export;
-- - basic non-executing CLI commands: `plan list`, `plan show`, `plan validate`, `plan explain`, `plan export`, `plan cancel`;
+- basic non-executing CLI commands: `plan list`, `plan show`, `plan validate`, `plan explain`, `plan export`, `plan cancel`;
 - audit integration;
 - privileged execution handoff;
 - TUI confirmation dialog.

--- a/docs/extensions/vmlab-implementation-prompt.md
+++ b/docs/extensions/vmlab-implementation-prompt.md
@@ -44,7 +44,7 @@ Critical scope limitation:
 This is not a full VMLab implementation.
 
 This is a minimal, safe, testable skeleton that validates architecture contracts.
-````
+```
 
 The goal is to prove that:
 

--- a/docs/extensions/vmlab-profile-schema.md
+++ b/docs/extensions/vmlab-profile-schema.md
@@ -514,7 +514,7 @@ Rules:
 
 Development note:
 
-During skeleton development, profile-defined log paths must not be used as write targets. They may be parsed and validated, but all actual development logs must be redirected to repository-level `logs/`.
+During skeleton development, profile-defined QMP socket paths may be parsed and validated, but they must not be used as write targets. All runtime/dev QMP socket output or temporary artifacts should be redirected to the repository-level `logs/` directory instead.
 
 ---
 

--- a/docs/extensions/vmlab-qmp-client.md
+++ b/docs/extensions/vmlab-qmp-client.md
@@ -55,7 +55,7 @@ Critical rule:
 The QMP client never mutates VM state directly from UI code.
 Read-only queries may be executed directly.
 Mutating QMP commands require CommandPlanService mediation and explicit authorization.
-````
+```
 
 ---
 

--- a/docs/extensions/vmlab-security-model.md
+++ b/docs/extensions/vmlab-security-model.md
@@ -699,8 +699,7 @@ graph TD
 | --------------------------- | --------------------------------------------------- | ------------- | --------------------- | -------------- |
 | Validate profile            | `VMLabService`                                      | No            | No                    | optional/debug |
 | Generate QEMU argv          | `VMLabService`                                      | No            | No                    | optional/debug |
-| Start VM                    | `CommandPlanService` → `VMSupervisor`               | Yes           | Policy-based          |                |
-| Yes                         |                                                     |               |                       |                |
+| Start VM                    | `CommandPlanService` → `VMSupervisor`               | Yes           | Policy-based          | Yes            |
 | Stop VM gracefully          | `CommandPlanService` → `VMSupervisor` / `QMPClient` | Yes           | Policy-based          | Yes            |
 | Force stop VM               | `CommandPlanService`                                | Yes           | Yes                   | Yes            |
 | Attach serial               | `ConsoleAndLogsService`                             | No            | No                    | Yes            |


### PR DESCRIPTION
Small follow-up cleanup for architecture contract Markdown formatting and VMLab logs/QMP wording.

Fixes:
- malformed Markdown list item in command-plan-service.md
- incorrect code fence endings in VMLab docs
- VMLab QMP socket development-artifact wording
- malformed Start VM table row in security model

No implementation code changes.