### PR TITLE
feat: implement Phase 1 ProjectService with workspace discovery

### DIFF
--- a/src/ecli/services/__init__.py
+++ b/src/ecli/services/__init__.py
@@ -14,6 +14,7 @@
 """Core service foundations for ECLI."""
 
 from ecli.services.config_service import ConfigService
+from ecli.services.project_service import ProjectService, UnsafeProjectPathError
 
 
-__all__ = ["ConfigService"]
+__all__ = ["ConfigService", "ProjectService", "UnsafeProjectPathError"]

--- a/src/ecli/services/models/__init__.py
+++ b/src/ecli/services/models/__init__.py
@@ -28,6 +28,14 @@ from ecli.services.models.config import (
     SafetyPolicyConfig,
     UIConfig,
 )
+from ecli.services.models.project import (
+    ProjectDiagnostic,
+    ProjectDiagnosticLevel,
+    ProjectDiscoveryResult,
+    ProjectMarker,
+    ProjectMetadata,
+    ProjectPathResolutionResult,
+)
 
 
 __all__ = [
@@ -44,4 +52,10 @@ __all__ = [
     "LSPConfig",
     "SafetyPolicyConfig",
     "UIConfig",
+    "ProjectDiagnostic",
+    "ProjectDiagnosticLevel",
+    "ProjectDiscoveryResult",
+    "ProjectMarker",
+    "ProjectMetadata",
+    "ProjectPathResolutionResult",
 ]

--- a/src/ecli/services/models/project.py
+++ b/src/ecli/services/models/project.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/models/project.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Typed project discovery models for the Phase 1 ProjectService."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+
+class ProjectDiagnosticLevel(StrEnum):
+    """Severity for project service diagnostics."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class ProjectDiagnostic:
+    """Structured, user-readable project service diagnostic."""
+
+    level: ProjectDiagnosticLevel
+    message: str
+    path: str | None = None
+    code: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable diagnostic dictionary."""
+        return {
+            "level": self.level.value,
+            "message": self.message,
+            "path": self.path,
+            "code": self.code,
+        }
+
+
+@dataclass(frozen=True)
+class ProjectMarker:
+    """Project root marker found during upward discovery."""
+
+    name: str
+    path: Path
+    priority: int
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable marker dictionary."""
+        return {"name": self.name, "path": str(self.path), "priority": self.priority}
+
+
+@dataclass(frozen=True)
+class ProjectMetadata:
+    """Typed metadata extracted from a discovered project root."""
+
+    name: str
+    root: Path
+    vcs: str | None
+    markers: tuple[str, ...]
+    primary_language_hints: tuple[str, ...]
+    project_config_path: Path | None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable project metadata dictionary."""
+        return {
+            "name": self.name,
+            "root": str(self.root),
+            "vcs": self.vcs,
+            "markers": list(self.markers),
+            "primary_language_hints": list(self.primary_language_hints),
+            "project_config_path": (
+                None
+                if self.project_config_path is None
+                else str(self.project_config_path)
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class ProjectDiscoveryResult:
+    """Result of deterministic project root discovery."""
+
+    root: Path
+    metadata: ProjectMetadata
+    diagnostics: tuple[ProjectDiagnostic, ...] = field(default_factory=tuple)
+    discovered: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable discovery result dictionary."""
+        return {
+            "root": str(self.root),
+            "metadata": self.metadata.as_dict(),
+            "diagnostics": [diagnostic.as_dict() for diagnostic in self.diagnostics],
+            "discovered": self.discovered,
+        }
+
+
+@dataclass(frozen=True)
+class ProjectPathResolutionResult:
+    """Structured result for project-aware path resolution."""
+
+    path: Path
+    inside_root: bool
+    diagnostics: tuple[ProjectDiagnostic, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable path resolution result dictionary."""
+        return {
+            "path": str(self.path),
+            "inside_root": self.inside_root,
+            "diagnostics": [diagnostic.as_dict() for diagnostic in self.diagnostics],
+        }

--- a/src/ecli/services/project_service.py
+++ b/src/ecli/services/project_service.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/project_service.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Phase 1 project discovery and workspace context service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ecli.services.config_service import ConfigService
+from ecli.services.models.project import (
+    ProjectDiagnostic,
+    ProjectDiagnosticLevel,
+    ProjectDiscoveryResult,
+    ProjectMarker,
+    ProjectMetadata,
+)
+
+
+PROJECT_MARKERS: tuple[str, ...] = (
+    ".ecli.toml",
+    ".ecli",
+    "pyproject.toml",
+    "setup.cfg",
+    "setup.py",
+    ".git",
+)
+
+LANGUAGE_HINT_MARKERS: tuple[tuple[str, str], ...] = (
+    ("pyproject.toml", "python"),
+    ("setup.py", "python"),
+    ("setup.cfg", "python"),
+    ("package.json", "javascript/typescript"),
+    ("Cargo.toml", "rust"),
+    ("go.mod", "go"),
+    ("pom.xml", "java"),
+    ("build.gradle", "java"),
+    ("Makefile", "make"),
+    ("Dockerfile", "docker"),
+)
+
+FORBIDDEN_PATH_EXPANSIONS: tuple[str, ...] = ("$HOME", "${HOME}", "$(", "`")
+
+
+class UnsafeProjectPathError(ValueError):
+    """Raised when project-safe path resolution rejects an unsafe path."""
+
+
+class ProjectService:
+    """Project workspace discovery and path normalization service."""
+
+    def __init__(
+        self,
+        discovery: ProjectDiscoveryResult,
+        diagnostics: tuple[ProjectDiagnostic, ...] = (),
+    ) -> None:
+        """Initialize ProjectService from a discovery result."""
+        self._discovery = discovery
+        self._diagnostics = (*discovery.diagnostics, *diagnostics)
+
+    @classmethod
+    def discover(cls, start_path: Path | str | None = None) -> ProjectDiscoveryResult:
+        """Discover project root and metadata from a file or directory path."""
+        start = Path.cwd() if start_path is None else Path(start_path)
+        start_dir = _normalize_start_directory(start)
+        diagnostics: list[ProjectDiagnostic] = []
+
+        for candidate in _walk_up(start_dir):
+            markers = _find_project_markers(candidate)
+            if markers:
+                metadata = _build_metadata(candidate, markers)
+                diagnostics.append(
+                    ProjectDiagnostic(
+                        level=ProjectDiagnosticLevel.INFO,
+                        path=str(candidate),
+                        code="project.discovery.marker_found",
+                        message=(
+                            f"Discovered project root from marker {metadata.markers[0]}"
+                        ),
+                    )
+                )
+                return ProjectDiscoveryResult(
+                    root=candidate,
+                    metadata=metadata,
+                    diagnostics=tuple(diagnostics),
+                    discovered=True,
+                )
+
+        metadata = _build_metadata(start_dir, ())
+        diagnostics.append(
+            ProjectDiagnostic(
+                level=ProjectDiagnosticLevel.INFO,
+                path=str(start_dir),
+                code="project.discovery.fallback",
+                message="No project marker found; using normalized start directory",
+            )
+        )
+        return ProjectDiscoveryResult(
+            root=start_dir,
+            metadata=metadata,
+            diagnostics=tuple(diagnostics),
+            discovered=False,
+        )
+
+    @classmethod
+    def from_discovery(cls, discovery: ProjectDiscoveryResult) -> ProjectService:
+        """Create a service instance from an existing discovery result."""
+        return cls(discovery)
+
+    @property
+    def root(self) -> Path:
+        """Absolute path to the project root."""
+        return self._discovery.root
+
+    @property
+    def metadata(self) -> ProjectMetadata:
+        """Return project metadata captured during discovery."""
+        return self._discovery.metadata
+
+    @property
+    def diagnostics(self) -> tuple[ProjectDiagnostic, ...]:
+        """Return service diagnostics accumulated so far."""
+        return self._diagnostics
+
+    def resolve_path(self, relative_or_absolute: str | Path) -> Path:
+        """Resolve a project-relative or absolute path without root confinement."""
+        raw_path = _reject_shell_expansion(relative_or_absolute)
+        if raw_path.is_absolute():
+            return raw_path.resolve(strict=False)
+        return (self.root / raw_path).resolve(strict=False)
+
+    def resolve_path_safe(self, relative_or_absolute: str | Path) -> Path:
+        """Resolve a path and reject paths escaping the project root."""
+        resolved = self.resolve_path(relative_or_absolute)
+        root = self.root.resolve(strict=False)
+        if _is_relative_to(resolved, root):
+            return resolved
+        raise UnsafeProjectPathError(
+            f"Resolved path escapes project root: {resolved} is outside {root}"
+        )
+
+    def get_project_config_path(self) -> Path | None:
+        """Return the project-local ECLI config path if present."""
+        return self.metadata.project_config_path
+
+    def get_effective_config(self, user_config: ConfigService) -> ConfigService:
+        """Return effective config bridge for Phase 1 ProjectService.
+
+        The current ConfigService does not retain the source path for the already
+        loaded user configuration. Re-loading with only project_config_path would
+        discard that caller-provided user layer, so Phase 1 preserves the supplied
+        ConfigService and records an integration diagnostic for ServiceRegistry.
+        """
+        project_config_path = self.get_project_config_path()
+        if project_config_path is not None:
+            self._diagnostics = (
+                *self._diagnostics,
+                ProjectDiagnostic(
+                    level=ProjectDiagnosticLevel.WARNING,
+                    path=str(project_config_path),
+                    code="project.config.integration_deferred",
+                    message=(
+                        "Project-local config was discovered, but full user/project "
+                        "merge is deferred until ServiceRegistry wires source paths"
+                    ),
+                ),
+            )
+        return user_config
+
+
+def _normalize_start_directory(start: Path) -> Path:
+    normalized = start
+    if normalized.exists() and normalized.is_file():
+        normalized = normalized.parent
+    return normalized.resolve(strict=False)
+
+
+def _walk_up(start_dir: Path) -> tuple[Path, ...]:
+    directories = [start_dir]
+    directories.extend(start_dir.parents)
+    return tuple(directories)
+
+
+def _find_project_markers(root: Path) -> tuple[ProjectMarker, ...]:
+    markers: list[ProjectMarker] = []
+    for priority, marker_name in enumerate(PROJECT_MARKERS):
+        marker_path = root / marker_name
+        if marker_path.exists():
+            markers.append(
+                ProjectMarker(name=marker_name, path=marker_path, priority=priority)
+            )
+    return tuple(markers)
+
+
+def _build_metadata(root: Path, markers: tuple[ProjectMarker, ...]) -> ProjectMetadata:
+    marker_names = tuple(marker.name for marker in markers)
+    return ProjectMetadata(
+        name=root.name or str(root),
+        root=root,
+        vcs="git" if ".git" in marker_names else None,
+        markers=marker_names,
+        primary_language_hints=_extract_language_hints(root),
+        project_config_path=_project_config_path(root),
+    )
+
+
+def _extract_language_hints(root: Path) -> tuple[str, ...]:
+    hints: list[str] = []
+    for marker_name, language in LANGUAGE_HINT_MARKERS:
+        if (root / marker_name).exists() and language not in hints:
+            hints.append(language)
+    return tuple(hints)
+
+
+def _project_config_path(root: Path) -> Path | None:
+    config_path = root / ".ecli.toml"
+    if config_path.is_file():
+        return config_path
+    return None
+
+
+def _reject_shell_expansion(path_value: str | Path) -> Path:
+    raw = str(path_value)
+    if raw.startswith("~"):
+        raise UnsafeProjectPathError("Shell-style home expansion is not allowed")
+    if any(token in raw for token in FORBIDDEN_PATH_EXPANSIONS):
+        raise UnsafeProjectPathError(
+            "Shell-style variable or command expansion is not allowed"
+        )
+    return Path(raw)
+
+
+def _is_relative_to(candidate: Path, root: Path) -> bool:
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False
+    return True

--- a/tests/services/test_project_service.py
+++ b/tests/services/test_project_service.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/services/test_project_service.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for Phase 1 ProjectService workspace discovery."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from ecli.services.config_service import ConfigService
+from ecli.services.project_service import ProjectService, UnsafeProjectPathError
+
+
+PYPROJECT_CONTENT = '[project]\nname = "demo"\n'
+
+
+@pytest.fixture
+def workspace(request: pytest.FixtureRequest) -> Iterator[Path]:
+    repo_logs = Path.cwd() / "logs" / "test-project-service"
+    test_root = repo_logs / request.node.name.replace("/", "_").replace(":", "_")
+    shutil.rmtree(test_root, ignore_errors=True)
+    test_root.mkdir(parents=True)
+    try:
+        yield test_root
+    finally:
+        shutil.rmtree(test_root, ignore_errors=True)
+
+
+def snapshot_tree(root: Path) -> set[str]:
+    return {str(path.relative_to(root)) for path in root.rglob("*")}
+
+
+def test_discovers_root_from_git_marker(workspace: Path) -> None:
+    project = workspace / "repo"
+    nested = project / "src" / "pkg"
+    nested.mkdir(parents=True)
+    (project / ".git").mkdir()
+
+    discovery = ProjectService.discover(nested)
+
+    assert discovery.discovered is True
+    assert discovery.root == project.resolve(strict=False)
+    assert discovery.metadata.vcs == "git"
+    assert discovery.metadata.markers == (".git",)
+
+
+def test_discovers_root_from_pyproject_marker(workspace: Path) -> None:
+    project = workspace / "python-repo"
+    nested = project / "src" / "pkg"
+    nested.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(PYPROJECT_CONTENT, encoding="utf-8")
+
+    discovery = ProjectService.discover(nested)
+
+    assert discovery.discovered is True
+    assert discovery.root == project.resolve(strict=False)
+    assert discovery.metadata.markers == ("pyproject.toml",)
+    assert "python" in discovery.metadata.primary_language_hints
+
+
+def test_falls_back_to_start_directory_when_no_marker_exists(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    start = workspace / "plain"
+    start.mkdir()
+    monkeypatch.setattr("ecli.services.project_service.PROJECT_MARKERS", ())
+
+    discovery = ProjectService.discover(start)
+
+    assert discovery.discovered is False
+    assert discovery.root == start.resolve(strict=False)
+    assert discovery.metadata.markers == ()
+
+
+def test_start_path_file_uses_parent_directory(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = workspace / "standalone"
+    directory.mkdir()
+    source_file = directory / "main.py"
+    source_file.write_text("print('ok')\n", encoding="utf-8")
+    monkeypatch.setattr("ecli.services.project_service.PROJECT_MARKERS", ())
+
+    discovery = ProjectService.discover(source_file)
+
+    assert discovery.discovered is False
+    assert discovery.root == directory.resolve(strict=False)
+
+
+def test_project_local_ecli_toml_is_detected(workspace: Path) -> None:
+    project = workspace / "repo"
+    project.mkdir()
+    project_config = project / ".ecli.toml"
+    project_config.write_text("[editor]\ntab_size = 2\n", encoding="utf-8")
+
+    discovery = ProjectService.discover(project)
+    service = ProjectService.from_discovery(discovery)
+
+    assert discovery.discovered is True
+    assert discovery.metadata.markers == (".ecli.toml",)
+    assert service.get_project_config_path() == project_config.resolve(strict=False)
+
+
+def test_resolve_path_resolves_relative_path_against_project_root(
+    workspace: Path,
+) -> None:
+    project = workspace / "repo"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(PYPROJECT_CONTENT, encoding="utf-8")
+    service = ProjectService.from_discovery(ProjectService.discover(project))
+
+    resolved = service.resolve_path("src/main.py")
+
+    assert resolved == (project / "src" / "main.py").resolve(strict=False)
+
+
+def test_resolve_path_safe_allows_paths_inside_root(workspace: Path) -> None:
+    project = workspace / "repo"
+    inside = project / "src"
+    inside.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(PYPROJECT_CONTENT, encoding="utf-8")
+    service = ProjectService.from_discovery(ProjectService.discover(project))
+
+    resolved = service.resolve_path_safe("src/module.py")
+
+    assert resolved == (project / "src" / "module.py").resolve(strict=False)
+
+
+def test_resolve_path_safe_rejects_parent_escape(workspace: Path) -> None:
+    project = workspace / "repo"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(PYPROJECT_CONTENT, encoding="utf-8")
+    service = ProjectService.from_discovery(ProjectService.discover(project))
+
+    with pytest.raises(UnsafeProjectPathError):
+        service.resolve_path_safe("../outside.txt")
+
+
+@pytest.mark.parametrize(
+    "unsafe_path",
+    ["~/secret", "$HOME/secret", "${HOME}/secret", "$(pwd)/secret", "`pwd`/secret"],
+)
+def test_resolve_path_safe_rejects_shell_expansion(
+    workspace: Path,
+    unsafe_path: str,
+) -> None:
+    project = workspace / "repo"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(PYPROJECT_CONTENT, encoding="utf-8")
+    service = ProjectService.from_discovery(ProjectService.discover(project))
+
+    with pytest.raises(UnsafeProjectPathError):
+        service.resolve_path_safe(unsafe_path)
+
+
+def test_symlink_escape_is_rejected_when_supported(workspace: Path) -> None:
+    project = workspace / "repo"
+    outside = workspace / "outside"
+    project.mkdir()
+    outside.mkdir()
+    (project / "pyproject.toml").write_text(PYPROJECT_CONTENT, encoding="utf-8")
+    (outside / "secret.txt").write_text("secret\n", encoding="utf-8")
+    link = project / "link"
+    try:
+        os.symlink(outside, link, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation is not supported: {exc}")
+
+    service = ProjectService.from_discovery(ProjectService.discover(project))
+
+    with pytest.raises(UnsafeProjectPathError):
+        service.resolve_path_safe("link/secret.txt")
+
+
+def test_metadata_includes_name_root_markers_vcs_and_language_hints(
+    workspace: Path,
+) -> None:
+    project = workspace / "metadata-repo"
+    project.mkdir()
+    (project / ".git").mkdir()
+    (project / "pyproject.toml").write_text(PYPROJECT_CONTENT, encoding="utf-8")
+    (project / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    (project / "Makefile").write_text("all:\n\t@true\n", encoding="utf-8")
+
+    discovery = ProjectService.discover(project)
+
+    assert discovery.metadata.name == "metadata-repo"
+    assert discovery.metadata.root == project.resolve(strict=False)
+    assert discovery.metadata.markers == ("pyproject.toml", ".git")
+    assert discovery.metadata.vcs == "git"
+    assert discovery.metadata.primary_language_hints == ("python", "make", "docker")
+
+
+def test_discovery_does_not_mutate_filesystem(workspace: Path) -> None:
+    project = workspace / "repo"
+    nested = project / "src"
+    nested.mkdir(parents=True)
+    (project / ".git").mkdir()
+    before = snapshot_tree(workspace)
+
+    ProjectService.discover(nested)
+
+    assert snapshot_tree(workspace) == before
+    assert not (project / ".ecli").exists()
+
+
+def test_test_workspaces_are_under_logs(workspace: Path) -> None:
+    logs_dir = (Path.cwd() / "logs").resolve(strict=False)
+
+    assert workspace.resolve(strict=False).is_relative_to(logs_dir)
+
+
+def test_get_effective_config_is_conservative_until_registry_integration(
+    workspace: Path,
+) -> None:
+    project = workspace / "repo"
+    project.mkdir()
+    (project / ".ecli.toml").write_text("[editor]\ntab_size = 2\n", encoding="utf-8")
+    user_config = ConfigService(ConfigService.load(env={}).config)
+    service = ProjectService.from_discovery(ProjectService.discover(project))
+
+    effective = service.get_effective_config(user_config)
+
+    assert effective is user_config
+    assert any(
+        diagnostic.code == "project.config.integration_deferred"
+        for diagnostic in service.diagnostics
+    )


### PR DESCRIPTION
Closes #43

Implemented Phase 1 ProjectService foundation.

Scope:
- project root discovery
- project metadata extraction
- project-local .ecli.toml detection
- deterministic path resolution
- safe root-confined path resolution
- shell expansion rejection
- symlink escape rejection
- ProjectService model exports
- focused ProjectService tests

Not included:
- no Ecli.py wiring
- no __main__.py wiring
- no CLI wiring
- no ServiceRegistry wiring
- no CommandPlanService wiring
- no VMLab
- no runtime mutation

Validation:
- python3 -m pytest tests/services/test_project_service.py -v
- python3 -m pytest tests/services/test_config_service.py -v
- python3 -m pytest tests/services/test_config_migration.py -v
- python3 -m pytest tests/test_smoke.py -v
- python3 -m compileall src
- ruff check src/ecli/services tests/services
- ruff format --check src/ecli/services tests/services
- ./scripts/check-log-invariant.sh
- git diff --check
