### PR TITLE
feat: implement Phase 1A CommandPlan models and exports

### DIFF
--- a/src/ecli/services/__init__.py
+++ b/src/ecli/services/__init__.py
@@ -13,8 +13,14 @@
 
 """Core service foundations for ECLI."""
 
+from ecli.services.command_plan_service import CommandPlanService
 from ecli.services.config_service import ConfigService
 from ecli.services.project_service import ProjectService, UnsafeProjectPathError
 
 
-__all__ = ["ConfigService", "ProjectService", "UnsafeProjectPathError"]
+__all__ = [
+    "CommandPlanService",
+    "ConfigService",
+    "ProjectService",
+    "UnsafeProjectPathError",
+]

--- a/src/ecli/services/command_plan_service.py
+++ b/src/ecli/services/command_plan_service.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/command_plan_service.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Service-owned export behavior for command plans."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from typing import Any
+
+from ecli.services.models.plan import CommandPlan, CommandStep
+from ecli.services.validators.plan_validator import SENSITIVE_METADATA_KEYS
+
+
+REDACTION_TEXT = "<redacted>"
+
+
+class CommandPlanService:
+    """Command plan service utilities for Phase 1A."""
+
+    def export_json(self, plan: CommandPlan) -> str:
+        """Export a command plan as deterministic redacted JSON."""
+        return json.dumps(
+            _redact_sensitive(plan.as_dict()),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def export_shell(self, plan: CommandPlan) -> str:
+        """Export a command plan as a non-executed bash script string."""
+        lines = [
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            "",
+            f"# plan_id: {_safe_comment(plan.plan_id)}",
+            f"# title: {_safe_comment(plan.title)}",
+            f"# category: {plan.category.value}",
+            f"# risk: {plan.risk.value}",
+            f"# source: {plan.source.value}",
+        ]
+        if plan.metadata:
+            lines.append(
+                f"# metadata: {_safe_comment(json.dumps(_redact_sensitive(plan.metadata), sort_keys=True))}"
+            )
+        lines.append("")
+
+        for index, step in enumerate(plan.commands, start=1):
+            lines.extend(_shell_step_lines(index, step))
+        return "\n".join(lines).rstrip() + "\n"
+
+    def export_markdown(self, plan: CommandPlan) -> str:
+        """Export a command plan as redacted human-readable markdown."""
+        lines = [
+            f"# Command Plan: {_markdown_text(plan.title)}",
+            "",
+            f"- Plan ID: `{_markdown_text(plan.plan_id)}`",
+            f"- Category: `{plan.category.value}`",
+            f"- Risk: `{plan.risk.value}`",
+            f"- Status: `{plan.status.value}`",
+            f"- Source: `{plan.source.value}`",
+            f"- Requires privilege: `{plan.requires_privilege}`",
+            f"- Confirmation required: `{plan.confirmation_required}`",
+            "",
+        ]
+        if plan.description:
+            lines.extend([_markdown_text(plan.description), ""])
+        if plan.metadata:
+            metadata = json.dumps(_redact_sensitive(plan.metadata), sort_keys=True)
+            lines.extend(["## Metadata", "", f"```json\n{metadata}\n```", ""])
+
+        lines.extend(["## Command Steps", ""])
+        for index, step in enumerate(plan.commands, start=1):
+            lines.extend(_markdown_step_lines(index, step))
+        return "\n".join(lines).rstrip() + "\n"
+
+
+def _shell_step_lines(index: int, step: CommandStep) -> list[str]:
+    lines = [
+        f"# step {index}: {_safe_comment(step.title)}",
+        f"# display: {_safe_comment(step.display)}",
+    ]
+    if step.requires_privilege:
+        lines.append("# WARNING: this step requires privilege")
+    if step.destructive:
+        lines.append("# WARNING: this step is destructive")
+    if step.metadata:
+        metadata = json.dumps(_redact_sensitive(step.metadata), sort_keys=True)
+        lines.append(f"# metadata: {_safe_comment(metadata)}")
+    lines.extend([shlex.join(step.argv), ""])
+    return lines
+
+
+def _markdown_step_lines(index: int, step: CommandStep) -> list[str]:
+    warnings: list[str] = []
+    if step.requires_privilege:
+        warnings.append("requires privilege")
+    if step.destructive:
+        warnings.append("destructive")
+
+    lines = [
+        f"### {index}. {_markdown_text(step.title)}",
+        "",
+        f"- Step ID: `{_markdown_text(step.step_id)}`",
+        f"- Display: `{_markdown_text(step.display)}`",
+        f"- Command: `{_markdown_text(shlex.join(step.argv))}`",
+    ]
+    if warnings:
+        lines.append(f"- Warnings: {', '.join(warnings)}")
+    if step.metadata:
+        metadata = json.dumps(_redact_sensitive(step.metadata), sort_keys=True)
+        lines.extend(["", f"```json\n{metadata}\n```"])
+    lines.append("")
+    return lines
+
+
+def _redact_sensitive(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if key_text.lower() in SENSITIVE_METADATA_KEYS:
+                redacted[key_text] = REDACTION_TEXT
+            else:
+                redacted[key_text] = _redact_sensitive(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_sensitive(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_sensitive(item) for item in value]
+    return value
+
+
+def _safe_comment(value: str) -> str:
+    return value.replace("\r", " ").replace("\n", " ")
+
+
+def _markdown_text(value: str) -> str:
+    return value.replace("`", "\\`")

--- a/src/ecli/services/models/__init__.py
+++ b/src/ecli/services/models/__init__.py
@@ -28,6 +28,17 @@ from ecli.services.models.config import (
     SafetyPolicyConfig,
     UIConfig,
 )
+from ecli.services.models.plan import (
+    CommandPlan,
+    CommandStep,
+    PlanCategory,
+    PlanRisk,
+    PlanSource,
+    PlanStatus,
+    PolicyDecision,
+    needs_confirmation,
+    new_plan_id,
+)
 from ecli.services.models.project import (
     ProjectDiagnostic,
     ProjectDiagnosticLevel,
@@ -45,11 +56,18 @@ __all__ = [
     "ConfigDiagnosticLevel",
     "ConfigLoadResult",
     "ConfigSource",
+    "CommandPlan",
+    "CommandStep",
     "ECLIConfig",
     "EditorConfig",
     "GitConfig",
     "KeybindingConfig",
     "LSPConfig",
+    "PlanCategory",
+    "PlanRisk",
+    "PlanSource",
+    "PlanStatus",
+    "PolicyDecision",
     "SafetyPolicyConfig",
     "UIConfig",
     "ProjectDiagnostic",
@@ -58,4 +76,6 @@ __all__ = [
     "ProjectMarker",
     "ProjectMetadata",
     "ProjectPathResolutionResult",
+    "needs_confirmation",
+    "new_plan_id",
 ]

--- a/src/ecli/services/models/plan.py
+++ b/src/ecli/services/models/plan.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/models/plan.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Typed command plan models for Phase 1A services."""
+
+from __future__ import annotations
+
+import re
+import secrets
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+
+class PlanRisk(StrEnum):
+    """Risk classification for command plans."""
+
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+class PlanStatus(StrEnum):
+    """Lifecycle status for command plans."""
+
+    DRAFT = "DRAFT"
+    VALIDATED = "VALIDATED"
+    POLICY_CHECKED = "POLICY_CHECKED"
+    CONFIRMED = "CONFIRMED"
+    EXECUTING = "EXECUTING"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+    REJECTED = "REJECTED"
+
+
+class PlanCategory(StrEnum):
+    """Operational category for command plans."""
+
+    GENERAL = "GENERAL"
+    SYSTEM = "SYSTEM"
+    FILE = "FILE"
+    VM = "VM"
+    KUBERNETES = "KUBERNETES"
+    TERRAFORM = "TERRAFORM"
+    ANSIBLE = "ANSIBLE"
+    CI = "CI"
+    DOCTOR = "DOCTOR"
+
+
+class PlanSource(StrEnum):
+    """Source that produced a command plan."""
+
+    USER = "USER"
+    DOCTOR = "DOCTOR"
+    AI_ASSISTANT = "AI_ASSISTANT"
+    SERVICE = "SERVICE"
+
+
+@dataclass(frozen=True)
+class CommandStep:
+    """One argv-first command step in a command plan."""
+
+    step_id: str
+    title: str
+    argv: list[str]
+    display: str
+    requires_privilege: bool = False
+    destructive: bool = False
+    expected_exit_codes: list[int] = field(default_factory=lambda: [0])
+    timeout_seconds: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable command step dictionary."""
+        return {
+            "step_id": self.step_id,
+            "title": self.title,
+            "argv": list(self.argv),
+            "display": self.display,
+            "requires_privilege": self.requires_privilege,
+            "destructive": self.destructive,
+            "expected_exit_codes": list(self.expected_exit_codes),
+            "timeout_seconds": self.timeout_seconds,
+            "metadata": _json_safe_copy(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Policy decision attached to future command plan evaluation."""
+
+    allowed: bool
+    reason: str
+    policy_id: str | None = None
+    violated_rules: list[str] = field(default_factory=list)
+    override_allowed: bool = False
+    confirmation_required: bool = False
+    route_via: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable policy decision dictionary."""
+        return {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "policy_id": self.policy_id,
+            "violated_rules": list(self.violated_rules),
+            "override_allowed": self.override_allowed,
+            "confirmation_required": self.confirmation_required,
+            "route_via": self.route_via,
+            "metadata": _json_safe_copy(self.metadata),
+        }
+
+
+@dataclass(frozen=True, kw_only=True)
+class CommandPlan:
+    """Pure typed command plan data model."""
+
+    plan_id: str
+    title: str
+    category: PlanCategory
+    risk: PlanRisk
+    commands: list[CommandStep]
+    created_at: datetime
+    created_by: str
+    schema_version: int = 1
+    description: str = ""
+    status: PlanStatus = PlanStatus.DRAFT
+    rollback: list[CommandStep] = field(default_factory=list)
+    confirmation_required: bool = False
+    requires_privilege: bool = False
+    source: PlanSource = PlanSource.USER
+    affected_resources: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable command plan dictionary."""
+        return {
+            "schema_version": self.schema_version,
+            "plan_id": self.plan_id,
+            "title": self.title,
+            "description": self.description,
+            "category": self.category.value,
+            "risk": self.risk.value,
+            "status": self.status.value,
+            "commands": [command.as_dict() for command in self.commands],
+            "rollback": [command.as_dict() for command in self.rollback],
+            "confirmation_required": self.confirmation_required,
+            "requires_privilege": self.requires_privilege,
+            "created_at": _format_datetime(self.created_at),
+            "created_by": self.created_by,
+            "source": self.source.value,
+            "affected_resources": list(self.affected_resources),
+            "metadata": _json_safe_copy(self.metadata),
+        }
+
+
+def new_plan_id(
+    now: datetime | None = None,
+    random_suffix: str | None = None,
+) -> str:
+    """Create a command plan identifier with deterministic test injection."""
+    timestamp = _format_plan_id_time(datetime.now(UTC) if now is None else now)
+    suffix = secrets.token_hex(4) if random_suffix is None else random_suffix.lower()
+    if not re.fullmatch(r"[0-9a-f]{8}", suffix):
+        raise ValueError("random_suffix must contain exactly 8 hexadecimal characters")
+    return f"plan-{timestamp}-{suffix}"
+
+
+def needs_confirmation(plan: CommandPlan) -> bool:
+    """Return true when a plan requires explicit user confirmation."""
+    if plan.confirmation_required:
+        return True
+    if plan.risk in {PlanRisk.HIGH, PlanRisk.CRITICAL}:
+        return True
+    if plan.requires_privilege:
+        return True
+    if any(command.requires_privilege for command in plan.commands):
+        return True
+    if any(command.destructive for command in plan.commands):
+        return True
+    return plan.source is PlanSource.AI_ASSISTANT and plan.risk in {
+        PlanRisk.MEDIUM,
+        PlanRisk.HIGH,
+        PlanRisk.CRITICAL,
+    }
+
+
+def _format_plan_id_time(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    value = value.astimezone(UTC).replace(microsecond=0)
+    return value.strftime("%Y%m%dT%H%M%SZ")
+
+
+def _format_datetime(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _json_safe_copy(value: Any) -> Any:
+    primitive_types = str | int | float | bool
+    if isinstance(value, dict):
+        return {str(key): _json_safe_copy(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe_copy(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_safe_copy(item) for item in value]
+    if isinstance(value, StrEnum):
+        return value.value
+    if isinstance(value, datetime):
+        return _format_datetime(value)
+    return value if isinstance(value, primitive_types) or value is None else str(value)

--- a/src/ecli/services/validators/__init__.py
+++ b/src/ecli/services/validators/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/validators/__init__.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Service validation helpers."""
+
+from ecli.services.validators.plan_validator import (
+    SENSITIVE_METADATA_KEYS,
+    validate_command_plan,
+    validate_command_step,
+)
+
+
+__all__ = [
+    "SENSITIVE_METADATA_KEYS",
+    "validate_command_plan",
+    "validate_command_step",
+]

--- a/src/ecli/services/validators/plan_validator.py
+++ b/src/ecli/services/validators/plan_validator.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/validators/plan_validator.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Validation helpers for command plan models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ecli.services.models.plan import (
+    CommandPlan,
+    CommandStep,
+    PlanRisk,
+    needs_confirmation,
+)
+
+
+SENSITIVE_METADATA_KEYS: frozenset[str] = frozenset(
+    {
+        "password",
+        "passwd",
+        "token",
+        "api_key",
+        "apikey",
+        "secret",
+        "private_key",
+        "credential",
+        "authorization",
+        "bearer",
+        "x-api-key",
+        "access_key",
+        "secret_key",
+        "session_key",
+    }
+)
+
+SHELL_OPERATOR_TOKENS: frozenset[str] = frozenset(
+    {";", "&&", "||", "|", ">", ">>", "<", "$()", "`"}
+)
+
+
+def validate_command_step(step: CommandStep) -> list[str]:
+    """Validate one command step and return human-readable diagnostics."""
+    diagnostics: list[str] = []
+
+    if not step.step_id.strip():
+        diagnostics.append("step_id must be non-empty and stable")
+    if not step.display.strip():
+        diagnostics.append("display must be non-empty")
+    if step.timeout_seconds is not None and step.timeout_seconds <= 0:
+        diagnostics.append("timeout_seconds must be None or > 0")
+    argv_valid, argv_diagnostics = _validate_argv(step.argv)
+    diagnostics.extend(argv_diagnostics)
+    if argv_valid:
+        diagnostics.extend(_validate_shell_tokens(step.argv))
+    diagnostics.extend(_validate_expected_exit_codes(step.expected_exit_codes))
+    diagnostics.extend(_validate_metadata_keys(step.metadata, "metadata"))
+    return diagnostics
+
+
+def validate_command_plan(plan: CommandPlan) -> list[str]:
+    """Validate a command plan and return human-readable diagnostics."""
+    diagnostics: list[str] = []
+
+    if not plan.commands:
+        diagnostics.append("plan.commands must be non-empty")
+    for index, command in enumerate(plan.commands):
+        for diagnostic in validate_command_step(command):
+            diagnostics.append(f"commands[{index}]: {diagnostic}")
+    for index, command in enumerate(plan.rollback):
+        for diagnostic in validate_command_step(command):
+            diagnostics.append(f"rollback[{index}]: {diagnostic}")
+
+    has_privileged_command = any(
+        command.requires_privilege for command in plan.commands
+    )
+    has_destructive_command = any(command.destructive for command in plan.commands)
+
+    if (
+        has_privileged_command or has_destructive_command
+    ) and plan.risk is PlanRisk.LOW:
+        diagnostics.append("destructive or privileged commands cannot remain LOW risk")
+    if plan.risk is PlanRisk.CRITICAL and not plan.confirmation_required:
+        diagnostics.append("CRITICAL plans must require confirmation")
+    if has_privileged_command and not plan.requires_privilege:
+        diagnostics.append(
+            "plan.requires_privilege must be true if any step requires privilege"
+        )
+    if needs_confirmation(plan) and not plan.confirmation_required:
+        diagnostics.append(
+            "plan.confirmation_required should be true when confirmation is needed"
+        )
+    diagnostics.extend(_validate_metadata_keys(plan.metadata, "metadata"))
+    return diagnostics
+
+
+def _validate_shell_tokens(argv: list[str]) -> list[str]:
+    diagnostics: list[str] = []
+    for token in argv:
+        if token in SHELL_OPERATOR_TOKENS:
+            diagnostics.append(
+                f"argv contains standalone shell-like operator token: {token}"
+            )
+        elif token.startswith("`") and token.endswith("`"):
+            diagnostics.append(
+                "argv contains standalone backtick command substitution token"
+            )
+        elif token.startswith("$(") and token.endswith(")"):
+            diagnostics.append("argv contains standalone command substitution token")
+    return diagnostics
+
+
+def _validate_argv(argv: list[str]) -> tuple[bool, list[str]]:
+    if not isinstance(argv, list) or not all(isinstance(item, str) for item in argv):
+        return False, ["argv must be list[str]"]
+    if not argv:
+        return False, ["argv must be non-empty"]
+    if not argv[0].strip():
+        return False, ["argv[0] must not be empty"]
+    return True, []
+
+
+def _validate_expected_exit_codes(expected_exit_codes: list[int]) -> list[str]:
+    diagnostics: list[str] = []
+    if not expected_exit_codes:
+        return ["expected_exit_codes must not be empty"]
+    for exit_code in expected_exit_codes:
+        if not isinstance(exit_code, int) or isinstance(exit_code, bool):
+            diagnostics.append("expected_exit_codes values must be integers")
+            continue
+        if exit_code < 0 or exit_code > 255:
+            diagnostics.append("expected_exit_codes values must be in 0..255")
+    return diagnostics
+
+
+def _validate_metadata_keys(metadata: dict[str, Any], prefix: str) -> list[str]:
+    diagnostics: list[str] = []
+    for key, value in metadata.items():
+        key_text = str(key)
+        path = f"{prefix}.{key_text}"
+        if _is_sensitive_key(key_text):
+            diagnostics.append(f"{path} contains secret-like metadata key")
+        if isinstance(value, dict):
+            diagnostics.extend(_validate_metadata_keys(value, path))
+    return diagnostics
+
+
+def _is_sensitive_key(key: str) -> bool:
+    return key.lower() in SENSITIVE_METADATA_KEYS

--- a/tests/services/test_command_plan_exports.py
+++ b/tests/services/test_command_plan_exports.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/services/test_command_plan_exports.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for service-owned command plan exports."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from ecli.services.command_plan_service import CommandPlanService
+from ecli.services.models.plan import (
+    CommandPlan,
+    CommandStep,
+    PlanCategory,
+    PlanRisk,
+    PlanSource,
+)
+
+
+NOW = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def export_plan() -> CommandPlan:
+    return CommandPlan(
+        plan_id="plan-20260515T120000Z-abcdef12",
+        title="Export plan",
+        category=PlanCategory.SYSTEM,
+        risk=PlanRisk.HIGH,
+        commands=[
+            CommandStep(
+                step_id="step-001",
+                title="Quoted command",
+                argv=["printf", "hello world"],
+                display="printf 'hello world'",
+                metadata={"token": "do-not-export", "safe": "value"},
+            ),
+            CommandStep(
+                step_id="step-002",
+                title="Privileged destructive command",
+                argv=["sudo", "rm", "-rf", "/example"],
+                display="sudo rm -rf /example",
+                requires_privilege=True,
+                destructive=True,
+            ),
+        ],
+        created_at=NOW,
+        created_by="tester",
+        source=PlanSource.USER,
+        confirmation_required=True,
+        requires_privilege=True,
+        metadata={"api_key": "secret", "owner": "qa"},
+    )
+
+
+def test_json_export_is_deterministic() -> None:
+    service = CommandPlanService()
+    plan = export_plan()
+
+    assert service.export_json(plan) == service.export_json(plan)
+
+
+def test_json_export_redacts_secrets() -> None:
+    payload = json.loads(CommandPlanService().export_json(export_plan()))
+
+    assert payload["metadata"]["api_key"] == "<redacted>"
+    assert payload["commands"][0]["metadata"]["token"] == "<redacted>"
+    assert "secret" not in json.dumps(payload)
+    assert "do-not-export" not in json.dumps(payload)
+
+
+def test_shell_export_contains_shebang_and_strict_mode() -> None:
+    exported = CommandPlanService().export_shell(export_plan())
+
+    assert exported.startswith("#!/usr/bin/env bash\nset -euo pipefail\n")
+
+
+def test_shell_export_uses_shlex_style_quoting() -> None:
+    exported = CommandPlanService().export_shell(export_plan())
+
+    assert "printf 'hello world'" in exported
+
+
+def test_shell_export_includes_privileged_and_destructive_warnings() -> None:
+    exported = CommandPlanService().export_shell(export_plan())
+
+    assert "# WARNING: this step requires privilege" in exported
+    assert "# WARNING: this step is destructive" in exported
+
+
+def test_markdown_export_includes_summary_and_redacted_metadata() -> None:
+    exported = CommandPlanService().export_markdown(export_plan())
+
+    assert "# Command Plan: Export plan" in exported
+    assert "- Plan ID: `plan-20260515T120000Z-abcdef12`" in exported
+    assert "- Category: `SYSTEM`" in exported
+    assert "- Risk: `HIGH`" in exported
+    assert "<redacted>" in exported
+    assert "secret" not in exported
+    assert "do-not-export" not in exported

--- a/tests/services/test_command_plan_models.py
+++ b/tests/services/test_command_plan_models.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/services/test_command_plan_models.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for command plan data models."""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+
+from ecli.services.models.plan import (
+    CommandPlan,
+    CommandStep,
+    PlanCategory,
+    PlanRisk,
+    PlanSource,
+    PlanStatus,
+    needs_confirmation,
+    new_plan_id,
+)
+
+
+FIXED_NOW = datetime(2026, 5, 15, 12, 34, 56, tzinfo=UTC)
+
+
+def make_step(
+    *,
+    requires_privilege: bool = False,
+    destructive: bool = False,
+) -> CommandStep:
+    return CommandStep(
+        step_id="step-001",
+        title="List files",
+        argv=["ls", "-la"],
+        display="ls -la",
+        requires_privilege=requires_privilege,
+        destructive=destructive,
+    )
+
+
+def make_plan(
+    *,
+    risk: PlanRisk = PlanRisk.LOW,
+    source: PlanSource = PlanSource.USER,
+    confirmation_required: bool = False,
+    requires_privilege: bool = False,
+    step: CommandStep | None = None,
+) -> CommandPlan:
+    return CommandPlan(
+        plan_id="plan-20260515T123456Z-abcdef12",
+        title="Inspect workspace",
+        category=PlanCategory.GENERAL,
+        risk=risk,
+        commands=[make_step() if step is None else step],
+        created_at=FIXED_NOW,
+        created_by="tester",
+        source=source,
+        confirmation_required=confirmation_required,
+        requires_privilege=requires_privilege,
+    )
+
+
+def test_valid_command_step_defaults() -> None:
+    step = make_step()
+
+    assert step.step_id == "step-001"
+    assert step.expected_exit_codes == [0]
+    assert step.timeout_seconds is None
+    assert step.metadata == {}
+
+
+def test_valid_command_plan_defaults() -> None:
+    plan = make_plan()
+
+    assert plan.schema_version == 1
+    assert plan.status is PlanStatus.DRAFT
+    assert plan.rollback == []
+    assert plan.affected_resources == []
+    assert plan.metadata == {}
+
+
+def test_enum_string_values_are_stable() -> None:
+    assert PlanRisk.HIGH.value == "HIGH"
+    assert str(PlanStatus.DRAFT) == "DRAFT"
+    assert PlanCategory.KUBERNETES.value == "KUBERNETES"
+    assert PlanSource.AI_ASSISTANT.value == "AI_ASSISTANT"
+
+
+def test_command_plan_as_dict_serializes_enums_and_datetime() -> None:
+    plan = make_plan(risk=PlanRisk.MEDIUM)
+
+    payload = plan.as_dict()
+
+    assert payload["risk"] == "MEDIUM"
+    assert payload["category"] == "GENERAL"
+    assert payload["created_at"] == "2026-05-15T12:34:56Z"
+
+
+def test_new_plan_id_matches_format() -> None:
+    plan_id = new_plan_id()
+
+    assert re.fullmatch(r"plan-\d{8}T\d{6}Z-[0-9a-f]{8}", plan_id)
+
+
+def test_new_plan_id_is_deterministic_with_fixed_inputs() -> None:
+    assert new_plan_id(now=FIXED_NOW, random_suffix="ABCDEF12") == (
+        "plan-20260515T123456Z-abcdef12"
+    )
+
+
+def test_low_non_privileged_non_destructive_user_plan_needs_no_confirmation() -> None:
+    assert needs_confirmation(make_plan()) is False
+
+
+def test_high_risk_plan_needs_confirmation() -> None:
+    assert needs_confirmation(make_plan(risk=PlanRisk.HIGH)) is True
+
+
+def test_critical_risk_plan_needs_confirmation() -> None:
+    assert needs_confirmation(make_plan(risk=PlanRisk.CRITICAL)) is True
+
+
+def test_privileged_step_needs_confirmation() -> None:
+    assert (
+        needs_confirmation(make_plan(step=make_step(requires_privilege=True))) is True
+    )
+
+
+def test_destructive_step_needs_confirmation() -> None:
+    assert needs_confirmation(make_plan(step=make_step(destructive=True))) is True
+
+
+def test_ai_assistant_medium_plan_needs_confirmation() -> None:
+    assert (
+        needs_confirmation(
+            make_plan(risk=PlanRisk.MEDIUM, source=PlanSource.AI_ASSISTANT)
+        )
+        is True
+    )

--- a/tests/services/test_plan_validation.py
+++ b/tests/services/test_plan_validation.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/services/test_plan_validation.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for command plan validators."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ecli.services.models.plan import CommandPlan, CommandStep, PlanCategory, PlanRisk
+from ecli.services.validators.plan_validator import (
+    validate_command_plan,
+    validate_command_step,
+)
+
+
+NOW = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def step(**overrides) -> CommandStep:
+    values = {
+        "step_id": "step-001",
+        "title": "Echo",
+        "argv": ["echo", "hello"],
+        "display": "echo hello",
+    }
+    values.update(overrides)
+    return CommandStep(**values)
+
+
+def plan(**overrides) -> CommandPlan:
+    values = {
+        "plan_id": "plan-20260515T120000Z-abcdef12",
+        "title": "Validation plan",
+        "category": PlanCategory.GENERAL,
+        "risk": PlanRisk.MEDIUM,
+        "commands": [step()],
+        "created_at": NOW,
+        "created_by": "tester",
+        "confirmation_required": True,
+    }
+    values.update(overrides)
+    return CommandPlan(**values)
+
+
+def test_validate_command_plan_rejects_empty_commands() -> None:
+    diagnostics = validate_command_plan(plan(commands=[]))
+
+    assert any("plan.commands must be non-empty" in item for item in diagnostics)
+
+
+def test_validate_command_step_rejects_empty_argv() -> None:
+    diagnostics = validate_command_step(step(argv=[]))
+
+    assert any("argv must be non-empty" in item for item in diagnostics)
+
+
+def test_validate_command_step_flags_standalone_shell_operators() -> None:
+    diagnostics = validate_command_step(step(argv=["echo", "safe;literal", "&&", "ok"]))
+
+    assert any(
+        "standalone shell-like operator token: &&" in item for item in diagnostics
+    )
+    assert not any("safe;literal" in item for item in diagnostics)
+
+
+def test_validate_command_step_rejects_invalid_expected_exit_codes() -> None:
+    diagnostics = validate_command_step(step(expected_exit_codes=[0, 256, -1]))
+
+    assert (
+        sum(
+            "expected_exit_codes values must be in 0..255" in item
+            for item in diagnostics
+        )
+        == 2
+    )
+
+
+def test_validate_command_plan_rejects_low_risk_privileged_command() -> None:
+    diagnostics = validate_command_plan(
+        plan(
+            risk=PlanRisk.LOW,
+            commands=[step(requires_privilege=True)],
+            requires_privilege=True,
+            confirmation_required=True,
+        )
+    )
+
+    assert any("cannot remain LOW risk" in item for item in diagnostics)
+
+
+def test_validate_command_plan_requires_privilege_field_consistency() -> None:
+    diagnostics = validate_command_plan(
+        plan(commands=[step(requires_privilege=True)], requires_privilege=False)
+    )
+
+    assert any("plan.requires_privilege must be true" in item for item in diagnostics)
+
+
+def test_validate_command_plan_requires_critical_confirmation() -> None:
+    diagnostics = validate_command_plan(
+        plan(risk=PlanRisk.CRITICAL, confirmation_required=False)
+    )
+
+    assert any(
+        "CRITICAL plans must require confirmation" in item for item in diagnostics
+    )
+
+
+def test_validate_command_plan_flags_secret_like_metadata_keys() -> None:
+    diagnostics = validate_command_plan(
+        plan(metadata={"token": "secret", "nested": {"api_key": "secret"}})
+    )
+
+    assert any(
+        "metadata.token contains secret-like metadata key" in item
+        for item in diagnostics
+    )
+    assert any(
+        "metadata.nested.api_key contains secret-like metadata key" in item
+        for item in diagnostics
+    )


### PR DESCRIPTION
Closes #44

Implemented Phase 1A CommandPlan models, validators, and service-owned exports.

Scope:
- typed stdlib dataclass models for CommandPlan, CommandStep, PolicyDecision, and enums
- deterministic plan ID helper
- needs_confirmation() helper
- command step validation
- command plan validation
- CommandPlanService export_json()
- CommandPlanService export_shell()
- CommandPlanService export_markdown()
- deterministic redaction for export output
- shlex.join() shell rendering
- focused model, validation, and export tests

Architecture decisions:
- CommandPlan remains a pure data model.
- Export behavior lives in CommandPlanService.
- Pydantic was not added because it is not an existing runtime dependency.
- No execution path was added.

Not included:
- no real plan execution
- no subprocess spawning
- no PolicyEngine implementation
- no AuditLogService implementation
- no PrivilegedActionService wiring
- no CLI wiring
- no ServiceRegistry wiring
- no Ecli.py changes
- no VMLab changes

Validation:
- python3 -m pytest tests/services/test_command_plan_models.py -v
- python3 -m pytest tests/services/test_plan_validation.py -v
- python3 -m pytest tests/services/test_command_plan_exports.py -v
- python3 -m pytest tests/services/test_config_service.py -v
- python3 -m pytest tests/services/test_config_migration.py -v
- python3 -m pytest tests/services/test_project_service.py -v
- python3 -m pytest tests/test_smoke.py -v
- python3 -m compileall src
- ruff check src/ecli/services tests/services
- ruff format --check src/ecli/services tests/services
- ./scripts/check-log-invariant.sh
- git diff --check
