### PR TITLE
feat: implement Phase 1A BuiltInPolicyEngine deterministic rules

### DIFF
--- a/src/ecli/services/__init__.py
+++ b/src/ecli/services/__init__.py
@@ -15,12 +15,16 @@
 
 from ecli.services.command_plan_service import CommandPlanService
 from ecli.services.config_service import ConfigService
+from ecli.services.policy import BuiltInPolicyEngine, PolicyContext, PolicyEngine
 from ecli.services.project_service import ProjectService, UnsafeProjectPathError
 
 
 __all__ = [
+    "BuiltInPolicyEngine",
     "CommandPlanService",
     "ConfigService",
+    "PolicyContext",
+    "PolicyEngine",
     "ProjectService",
     "UnsafeProjectPathError",
 ]

--- a/src/ecli/services/policy/__init__.py
+++ b/src/ecli/services/policy/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/policy/__init__.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Policy engine interfaces and built-in deterministic policy rules."""
+
+from ecli.services.policy.builtin import BuiltInPolicyEngine
+from ecli.services.policy.engine import PolicyContext, PolicyEngine, PolicyRuleResult
+
+
+__all__ = [
+    "BuiltInPolicyEngine",
+    "PolicyContext",
+    "PolicyEngine",
+    "PolicyRuleResult",
+]

--- a/src/ecli/services/policy/builtin.py
+++ b/src/ecli/services/policy/builtin.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/policy/builtin.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Built-in deterministic policy engine rules."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from ecli.services.models.plan import CommandPlan, PlanRisk, PlanSource, PolicyDecision
+from ecli.services.policy.engine import PolicyContext, PolicyEngine, PolicyRuleResult
+
+
+RuleCallable = Callable[[CommandPlan, PolicyContext], PolicyRuleResult]
+
+
+class BuiltInPolicyEngine(PolicyEngine):
+    """Deterministic built-in policy engine for Phase 1A."""
+
+    def __init__(self) -> None:
+        """Initialize built-in rules in stable evaluation order."""
+        self._rules: tuple[tuple[str, RuleCallable], ...] = (
+            ("BUILTIN-001", _block_ai_high_risk_no_review),
+            ("BUILTIN-002", _require_confirmation_for_critical),
+            ("BUILTIN-003", _require_privileged_path),
+            ("BUILTIN-004", _block_destructive_production),
+            ("BUILTIN-005", _block_forbidden_resources),
+            ("BUILTIN-006", _require_audit_on_override),
+        )
+
+    async def evaluate(
+        self,
+        plan: CommandPlan,
+        context: PolicyContext,
+    ) -> PolicyDecision:
+        """Evaluate a command plan against deterministic built-in rules."""
+        violated_rules: list[str] = []
+        first_deny: PolicyRuleResult | None = None
+
+        for rule_id, rule in self._rules:
+            result = rule(plan, context)
+            if result.rule_id != rule_id:
+                raise RuntimeError(
+                    f"Policy rule returned unexpected ID: {result.rule_id}"
+                )
+            if result.matched and not result.allowed:
+                violated_rules.append(result.rule_id)
+                if first_deny is None:
+                    first_deny = result
+
+        if first_deny is not None:
+            return PolicyDecision(
+                allowed=False,
+                reason=first_deny.reason,
+                policy_id=first_deny.rule_id,
+                violated_rules=violated_rules,
+                override_allowed=first_deny.override_allowed,
+            )
+
+        return PolicyDecision(
+            allowed=True,
+            reason="Policy check passed",
+            policy_id="builtin:allow",
+            violated_rules=[],
+            override_allowed=False,
+        )
+
+    def get_registered_rules(self) -> tuple[str, ...]:
+        """Return built-in policy rule IDs in deterministic evaluation order."""
+        return tuple(rule_id for rule_id, _rule in self._rules)
+
+
+def _block_ai_high_risk_no_review(
+    plan: CommandPlan,
+    context: PolicyContext,
+) -> PolicyRuleResult:
+    matched = (
+        plan.source is PlanSource.AI_ASSISTANT
+        and plan.risk in {PlanRisk.HIGH, PlanRisk.CRITICAL}
+        and not context.human_reviewed
+    )
+    return _deny_if_matched(
+        rule_id="BUILTIN-001",
+        matched=matched,
+        reason="AI-generated high-risk plans require explicit human review.",
+        override_allowed=False,
+    )
+
+
+def _require_confirmation_for_critical(
+    plan: CommandPlan,
+    context: PolicyContext,
+) -> PolicyRuleResult:
+    del context
+    matched = plan.risk is PlanRisk.CRITICAL and not plan.confirmation_required
+    return _deny_if_matched(
+        rule_id="BUILTIN-002",
+        matched=matched,
+        reason="Critical operations require explicit confirmation.",
+        override_allowed=False,
+    )
+
+
+def _require_privileged_path(
+    plan: CommandPlan,
+    context: PolicyContext,
+) -> PolicyRuleResult:
+    matched = (
+        any(step.requires_privilege for step in plan.commands)
+        and not context.privileged_route_available
+    )
+    return _deny_if_matched(
+        rule_id="BUILTIN-003",
+        matched=matched,
+        reason="Privileged steps must route through PrivilegedActionService.",
+        override_allowed=False,
+    )
+
+
+def _block_destructive_production(
+    plan: CommandPlan,
+    context: PolicyContext,
+) -> PolicyRuleResult:
+    matched = (
+        context.environment == "production"
+        and any(step.destructive for step in plan.commands)
+        and not context.override_approved
+    )
+    return _deny_if_matched(
+        rule_id="BUILTIN-004",
+        matched=matched,
+        reason="Destructive production operations require explicit policy override.",
+        override_allowed=True,
+    )
+
+
+def _block_forbidden_resources(
+    plan: CommandPlan,
+    context: PolicyContext,
+) -> PolicyRuleResult:
+    matched = any(
+        _resource_matches_pattern(resource, pattern)
+        for resource in plan.affected_resources
+        for pattern in context.forbidden_resource_patterns
+    )
+    return _deny_if_matched(
+        rule_id="BUILTIN-005",
+        matched=matched,
+        reason="Plan affects forbidden resource.",
+        override_allowed=False,
+    )
+
+
+def _require_audit_on_override(
+    plan: CommandPlan,
+    context: PolicyContext,
+) -> PolicyRuleResult:
+    del plan
+    matched = context.override_approved and not _has_text(context.override_reason)
+    return _deny_if_matched(
+        rule_id="BUILTIN-006",
+        matched=matched,
+        reason="Policy override requires actor and reason for auditability.",
+        override_allowed=False,
+    )
+
+
+def _deny_if_matched(
+    rule_id: str,
+    matched: bool,
+    reason: str,
+    override_allowed: bool,
+) -> PolicyRuleResult:
+    return PolicyRuleResult(
+        rule_id=rule_id,
+        matched=matched,
+        allowed=not matched,
+        reason=reason if matched else "",
+        override_allowed=override_allowed if matched else False,
+    )
+
+
+def _resource_matches_pattern(resource: str, pattern: str) -> bool:
+    if pattern.endswith("/*"):
+        return resource.startswith(pattern[:-1])
+    return resource == pattern
+
+
+def _has_text(value: str | None) -> bool:
+    return value is not None and bool(value.strip())

--- a/src/ecli/services/policy/engine.py
+++ b/src/ecli/services/policy/engine.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/policy/engine.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Mockable policy engine interface and typed policy context."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from ecli.services.models.plan import CommandPlan, PolicyDecision
+
+
+@dataclass(frozen=True)
+class PolicyContext:
+    """Policy evaluation context supplied by future service wiring."""
+
+    actor: str = "user"
+    environment: str = "local"
+    human_reviewed: bool = False
+    privileged_route_available: bool = False
+    override_approved: bool = False
+    override_reason: str | None = None
+    forbidden_resource_patterns: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Freeze mutable context containers for deterministic evaluation."""
+        object.__setattr__(
+            self,
+            "forbidden_resource_patterns",
+            tuple(self.forbidden_resource_patterns),
+        )
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+
+@dataclass(frozen=True)
+class PolicyRuleResult:
+    """Result of evaluating one deterministic policy rule."""
+
+    rule_id: str
+    matched: bool
+    allowed: bool
+    reason: str = ""
+    override_allowed: bool = False
+
+
+class PolicyEngine(ABC):
+    """Abstract async policy engine interface."""
+
+    @abstractmethod
+    async def evaluate(
+        self,
+        plan: CommandPlan,
+        context: PolicyContext,
+    ) -> PolicyDecision:
+        """Evaluate a plan against a policy context."""
+
+    @abstractmethod
+    def get_registered_rules(self) -> tuple[str, ...]:
+        """Return registered policy rule IDs in deterministic evaluation order."""

--- a/tests/services/test_policy_engine.py
+++ b/tests/services/test_policy_engine.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/services/test_policy_engine.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for the deterministic built-in policy engine."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ecli.services.models.plan import (
+    CommandPlan,
+    CommandStep,
+    PlanCategory,
+    PlanRisk,
+    PlanSource,
+)
+from ecli.services.policy import BuiltInPolicyEngine, PolicyContext
+
+
+NOW = datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
+RULE_IDS = (
+    "BUILTIN-001",
+    "BUILTIN-002",
+    "BUILTIN-003",
+    "BUILTIN-004",
+    "BUILTIN-005",
+    "BUILTIN-006",
+)
+
+
+def step(
+    *,
+    requires_privilege: bool = False,
+    destructive: bool = False,
+) -> CommandStep:
+    return CommandStep(
+        step_id="step-001",
+        title="Inspect",
+        argv=["echo", "ok"],
+        display="echo ok",
+        requires_privilege=requires_privilege,
+        destructive=destructive,
+    )
+
+
+def plan(
+    *,
+    risk: PlanRisk = PlanRisk.LOW,
+    source: PlanSource = PlanSource.USER,
+    confirmation_required: bool = False,
+    command: CommandStep | None = None,
+    affected_resources: list[str] | None = None,
+) -> CommandPlan:
+    return CommandPlan(
+        plan_id="plan-20260515T120000Z-abcdef12",
+        title="Policy test plan",
+        category=PlanCategory.GENERAL,
+        risk=risk,
+        commands=[step() if command is None else command],
+        created_at=NOW,
+        created_by="tester",
+        source=source,
+        confirmation_required=confirmation_required,
+        requires_privilege=(
+            command.requires_privilege if command is not None else False
+        ),
+        affected_resources=[] if affected_resources is None else affected_resources,
+    )
+
+
+def test_builtin_policy_engine_exposes_stable_rule_ids() -> None:
+    assert BuiltInPolicyEngine().get_registered_rules() == RULE_IDS
+
+
+@pytest.mark.asyncio
+async def test_low_risk_user_plan_is_allowed() -> None:
+    decision = await BuiltInPolicyEngine().evaluate(plan(), PolicyContext())
+
+    assert decision.allowed is True
+    assert decision.reason == "Policy check passed"
+    assert decision.policy_id == "builtin:allow"
+    assert decision.violated_rules == []
+    assert decision.override_allowed is False
+
+
+@pytest.mark.asyncio
+async def test_ai_high_risk_plan_without_human_review_is_denied_by_builtin_001() -> (
+    None
+):
+    decision = await BuiltInPolicyEngine().evaluate(
+        plan(risk=PlanRisk.HIGH, source=PlanSource.AI_ASSISTANT),
+        PolicyContext(human_reviewed=False),
+    )
+
+    assert decision.allowed is False
+    assert decision.policy_id == "BUILTIN-001"
+    assert decision.violated_rules == ["BUILTIN-001"]
+    assert decision.override_allowed is False
+    assert (
+        decision.reason == "AI-generated high-risk plans require explicit human review."
+    )
+
+
+@pytest.mark.asyncio
+async def test_ai_high_risk_plan_with_human_review_is_allowed() -> None:
+    decision = await BuiltInPolicyEngine().evaluate(
+        plan(
+            risk=PlanRisk.HIGH,
+            source=PlanSource.AI_ASSISTANT,
+            confirmation_required=True,
+        ),
+        PolicyContext(human_reviewed=True),
+    )
+
+    assert decision.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_critical_plan_without_confirmation_is_denied_by_builtin_002() -> None:
+    decision = await BuiltInPolicyEngine().evaluate(
+        plan(risk=PlanRisk.CRITICAL),
+        PolicyContext(),
+    )
+
+    assert decision.allowed is False
+    assert decision.policy_id == "BUILTIN-002"
+    assert decision.violated_rules == ["BUILTIN-002"]
+
+
+@pytest.mark.asyncio
+async def test_privileged_plan_without_privileged_route_is_denied_by_builtin_003() -> (
+    None
+):
+    decision = await BuiltInPolicyEngine().evaluate(
+        plan(
+            risk=PlanRisk.MEDIUM,
+            confirmation_required=True,
+            command=step(requires_privilege=True),
+        ),
+        PolicyContext(privileged_route_available=False),
+    )
+
+    assert decision.allowed is False
+    assert decision.policy_id == "BUILTIN-003"
+    assert decision.violated_rules == ["BUILTIN-003"]
+
+
+@pytest.mark.asyncio
+async def test_privileged_plan_with_privileged_route_is_allowed() -> None:
+    decision = await BuiltInPolicyEngine().evaluate(
+        plan(
+            risk=PlanRisk.MEDIUM,
+            confirmation_required=True,
+            command=step(requires_privilege=True),
+        ),
+        PolicyContext(privileged_route_available=True),
+    )
+
+    assert decision.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_destructive_production_without_override_is_denied_by_builtin_004() -> (
+    None
+):
+    decision = await BuiltInPolicyEngine().evaluate(
+        plan(
+            risk=PlanRisk.MEDIUM,
+            confirmation_required=True,
+            command=step(destructive=True),
+        ),
+        PolicyContext(environment="production", override_approved=False),
+    )
+
+    assert decision.allowed is False
+    assert decision.policy_id == "BUILTIN-004"
+    assert decision.violated_rules == ["BUILTIN-004"]
+    assert decision.override_allowed is True
+
+
+@pytest.mark.asyncio
+async def test_destructive_production_with_override_missing_reason_is_denied_by_builtin_006() -> (
+    None
+):
+    decision = await BuiltInPolicyEngine().evaluate(
+        plan(
+            risk=PlanRisk.MEDIUM,
+            confirmation_required=True,
+            command=step(destructive=True),
+        ),
+        PolicyContext(
+            environment="production",
+            override_approved=True,
+            override_reason=None,
+        ),
+    )
+
+    assert decision.allowed is False
+    assert decision.policy_id == "BUILTIN-006"
+    assert decision.violated_rules == ["BUILTIN-006"]
+
+
+@pytest.mark.asyncio
+async def test_destructive_production_with_override_reason_is_allowed() -> None:
+    decision = await BuiltInPolicyEngine().evaluate(
+        plan(
+            risk=PlanRisk.MEDIUM,
+            confirmation_required=True,
+            command=step(destructive=True),
+        ),
+        PolicyContext(
+            environment="production",
+            override_approved=True,
+            override_reason="approved maintenance window",
+        ),
+    )
+
+    assert decision.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_forbidden_exact_resource_match_is_denied_by_builtin_005() -> None:
+    decision = await BuiltInPolicyEngine().evaluate(
+        plan(affected_resources=["cluster/prod/database"]),
+        PolicyContext(forbidden_resource_patterns=("cluster/prod/database",)),
+    )
+
+    assert decision.allowed is False
+    assert decision.policy_id == "BUILTIN-005"
+    assert decision.violated_rules == ["BUILTIN-005"]
+
+
+@pytest.mark.asyncio
+async def test_forbidden_prefix_pattern_is_denied_by_builtin_005() -> None:
+    decision = await BuiltInPolicyEngine().evaluate(
+        plan(affected_resources=["cluster/prod/database"]),
+        PolicyContext(forbidden_resource_patterns=("cluster/prod/*",)),
+    )
+
+    assert decision.allowed is False
+    assert decision.policy_id == "BUILTIN-005"
+    assert decision.violated_rules == ["BUILTIN-005"]
+
+
+@pytest.mark.asyncio
+async def test_first_hard_deny_behavior_is_deterministic() -> None:
+    policy_engine = BuiltInPolicyEngine()
+    candidate = plan(
+        risk=PlanRisk.CRITICAL,
+        source=PlanSource.AI_ASSISTANT,
+        confirmation_required=False,
+        command=step(requires_privilege=True),
+        affected_resources=["cluster/prod/database"],
+    )
+    context = PolicyContext(
+        human_reviewed=False,
+        privileged_route_available=False,
+        forbidden_resource_patterns=("cluster/prod/*",),
+    )
+
+    first = await policy_engine.evaluate(candidate, context)
+    second = await policy_engine.evaluate(candidate, context)
+
+    assert first.as_dict() == second.as_dict()
+    assert first.policy_id == "BUILTIN-001"
+    assert first.violated_rules == [
+        "BUILTIN-001",
+        "BUILTIN-002",
+        "BUILTIN-003",
+        "BUILTIN-005",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_evaluation_does_not_mutate_command_plan() -> None:
+    candidate = plan(
+        risk=PlanRisk.HIGH,
+        source=PlanSource.AI_ASSISTANT,
+        affected_resources=["cluster/prod/database"],
+    )
+    before = candidate.as_dict()
+
+    await BuiltInPolicyEngine().evaluate(
+        candidate,
+        PolicyContext(forbidden_resource_patterns=("cluster/prod/*",)),
+    )
+
+    assert candidate.as_dict() == before
+
+
+@pytest.mark.asyncio
+async def test_async_evaluate_works_under_pytest() -> None:
+    decision = await BuiltInPolicyEngine().evaluate(plan(), PolicyContext())
+
+    assert decision.allowed is True


### PR DESCRIPTION
Closes #45

Implemented Phase 1A BuiltInPolicyEngine deterministic rules.

Scope:
- PolicyEngine abstract interface
- PolicyContext model
- PolicyRuleResult model
- BuiltInPolicyEngine implementation
- stable built-in rule IDs:
  - BUILTIN-001 block_ai_high_risk_no_review
  - BUILTIN-002 require_confirmation_for_critical
  - BUILTIN-003 require_privileged_path
  - BUILTIN-004 block_destructive_production
  - BUILTIN-005 block_forbidden_resources
  - BUILTIN-006 require_audit_on_override
- deterministic rule order
- first hard deny wins / fail-closed behavior
- override-required propagation
- forbidden resource matching
- policy tests

Not included:
- no execution implementation
- no subprocess usage
- no shell execution
- no network calls
- no CLI wiring
- no ServiceRegistry wiring
- no AuditLogService implementation
- no PrivilegedActionService implementation
- no VMLab changes
- no Ecli.py changes
- no __main__.py changes
- no new dependencies

Validation:
- python3 -m pytest tests/services/test_policy_engine.py -v
- python3 -m pytest tests/services/test_command_plan_models.py -v
- python3 -m pytest tests/services/test_plan_validation.py -v
- python3 -m pytest tests/services/test_command_plan_exports.py -v
- python3 -m pytest tests/services/test_config_service.py -v
- python3 -m pytest tests/services/test_config_migration.py -v
- python3 -m pytest tests/services/test_project_service.py -v
- python3 -m pytest tests/test_smoke.py -v
- python3 -m compileall src
- ruff check src/ecli/services tests/services
- ruff format --check src/ecli/services tests/services
- ./scripts/check-log-invariant.sh
- git diff --check
