### PR TITLE
feat: implement Phase 1B AuditLogService JSONL redaction

### DIFF
--- a/src/ecli/services/__init__.py
+++ b/src/ecli/services/__init__.py
@@ -13,6 +13,7 @@
 
 """Core service foundations for ECLI."""
 
+from ecli.services.audit_log_service import AuditLogService
 from ecli.services.command_plan_service import CommandPlanService
 from ecli.services.config_service import ConfigService
 from ecli.services.policy import BuiltInPolicyEngine, PolicyContext, PolicyEngine
@@ -20,6 +21,7 @@ from ecli.services.project_service import ProjectService, UnsafeProjectPathError
 
 
 __all__ = [
+    "AuditLogService",
     "BuiltInPolicyEngine",
     "CommandPlanService",
     "ConfigService",

--- a/src/ecli/services/audit_log_service.py
+++ b/src/ecli/services/audit_log_service.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/audit_log_service.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Append-only JSONL audit logging with mandatory redaction."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+from dataclasses import replace
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+from ecli.services.models.audit import AuditActor, AuditEventType, AuditRecord
+from ecli.services.models.plan import CommandPlan, PolicyDecision
+
+
+AUDIT_SCHEMA_VERSION = 1
+REDACTION_TEXT = "***REDACTED***"
+SENSITIVE_KEY_TOKENS: tuple[str, ...] = (
+    "password",
+    "passwd",
+    "token",
+    "api_key",
+    "apikey",
+    "secret",
+    "private_key",
+    "credential",
+    "authorization",
+    "bearer",
+    "x-api-key",
+    "access_key",
+    "secret_key",
+    "session_key",
+)
+
+_KEY_VALUE_SECRET_RE = re.compile(
+    r"(?P<key>password|passwd|token|api_key|apikey|secret|private_key|credential|"
+    r"authorization|bearer|x-api-key|access_key|secret_key|session_key)"
+    r"(?P<sep>\s*[=:]\s*)"
+    r"(?P<value>[^\s,;&]+)",
+    re.IGNORECASE,
+)
+
+
+class AuditLogError(RuntimeError):
+    """Base error for audit log service failures."""
+
+
+class AuditRedactionError(AuditLogError):
+    """Raised when audit redaction fails closed before writing."""
+
+
+class AuditWriteError(AuditLogError):
+    """Raised when an audit record cannot be written."""
+
+
+class AuditLogService:
+    """Append-only JSONL audit log service."""
+
+    def __init__(self, audit_dir: Path | None = None) -> None:
+        """Initialize without creating audit directories or files."""
+        self._logs_root = _repo_logs_root()
+        self._audit_dir = self._resolve_audit_dir(audit_dir)
+
+    @property
+    def audit_dir(self) -> Path:
+        """Return the resolved audit directory."""
+        return self._audit_dir
+
+    def redact_sensitive(self, value: Any) -> tuple[Any, list[str]]:
+        """Redact sensitive fields and return deterministic redacted paths."""
+        return _redact_value(value, "")
+
+    def append(self, record: AuditRecord) -> AuditRecord:
+        """Redact and append one audit record to the daily JSONL file."""
+        try:
+            redacted_payload, redacted_paths = self.redact_sensitive(
+                {"details": record.details, "metadata": record.metadata}
+            )
+            redacted_fields = _deduplicate_paths(
+                [*record.redacted_fields, *redacted_paths]
+            )
+            redacted_record = replace(
+                record,
+                details=redacted_payload["details"],
+                metadata=redacted_payload["metadata"],
+                redacted_fields=redacted_fields,
+            )
+            line = _record_to_json_line(redacted_record)
+        except Exception as exc:
+            raise AuditRedactionError(
+                "Audit redaction failed; record was not written"
+            ) from exc
+
+        audit_file = self.audit_file_for(redacted_record.timestamp)
+        self._assert_path_under_logs(audit_file)
+        try:
+            self._audit_dir.mkdir(parents=True, exist_ok=True)
+            _chmod_if_supported(self._audit_dir, 0o700)
+            _append_jsonl_line(audit_file, line)
+        except OSError as exc:
+            raise AuditWriteError(f"Audit write failed for {audit_file}") from exc
+        return redacted_record
+
+    def log_plan_created(
+        self,
+        plan: CommandPlan,
+        actor: str = AuditActor.USER.value,
+    ) -> AuditRecord:
+        """Record that a command plan was created."""
+        record = self.build_record(
+            event_type=AuditEventType.PLAN_CREATED,
+            actor=actor,
+            plan=plan,
+            details={
+                "title": plan.title,
+                "command_count": len(plan.commands),
+                "rollback_count": len(plan.rollback),
+                "affected_resources": list(plan.affected_resources),
+            },
+        )
+        return self.append(record)
+
+    def log_policy_evaluated(
+        self,
+        plan: CommandPlan,
+        decision: PolicyDecision,
+        actor: str = AuditActor.SERVICE.value,
+    ) -> AuditRecord:
+        """Record a policy evaluation decision for a command plan."""
+        event_type = (
+            AuditEventType.POLICY_EVALUATED
+            if decision.allowed
+            else AuditEventType.POLICY_DENIED
+        )
+        record = self.build_record(
+            event_type=event_type,
+            actor=actor,
+            plan=plan,
+            details={"decision": decision.as_dict()},
+            metadata={
+                "policy_id": decision.policy_id,
+                "violated_rules": list(decision.violated_rules),
+                "override_allowed": decision.override_allowed,
+            },
+        )
+        return self.append(record)
+
+    def log_execution_result(
+        self,
+        plan: CommandPlan,
+        success: bool,
+        actor: str = AuditActor.SERVICE.value,
+        details: dict[str, Any] | None = None,
+    ) -> AuditRecord:
+        """Record a future execution result without performing execution."""
+        record = self.build_record(
+            event_type=(
+                AuditEventType.PLAN_EXECUTION_COMPLETED
+                if success
+                else AuditEventType.PLAN_EXECUTION_FAILED
+            ),
+            actor=actor,
+            plan=plan,
+            details={"success": success, **({} if details is None else details)},
+        )
+        return self.append(record)
+
+    def build_record(  # noqa: PLR0913
+        self,
+        event_type: AuditEventType | str,
+        actor: AuditActor | str,
+        details: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+        plan: CommandPlan | None = None,
+        event_id: str | None = None,
+        timestamp: datetime | str | None = None,
+    ) -> AuditRecord:
+        """Build an audit record without writing it."""
+        event_timestamp = _utc_now() if timestamp is None else timestamp
+        return AuditRecord(
+            schema_version=AUDIT_SCHEMA_VERSION,
+            event_id=event_id or _new_event_id(event_timestamp),
+            timestamp=event_timestamp,
+            event_type=_enum_or_str(event_type),
+            actor=_enum_or_str(actor),
+            details={} if details is None else dict(details),
+            metadata={} if metadata is None else dict(metadata),
+            plan_id=None if plan is None else plan.plan_id,
+            category=None if plan is None else plan.category.value,
+            risk=None if plan is None else plan.risk.value,
+            source=None if plan is None else plan.source.value,
+        )
+
+    def audit_file_for(self, timestamp: datetime | str | date) -> Path:
+        """Return the deterministic daily audit JSONL path for a timestamp."""
+        return self._audit_dir / f"audit-{_date_string(timestamp)}.jsonl"
+
+    def read_records_for_day(self, day: date) -> list[dict[str, Any]]:
+        """Read audit records for tests and diagnostics."""
+        audit_file = self.audit_file_for(day)
+        if not audit_file.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in audit_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+    def _resolve_audit_dir(self, audit_dir: Path | None) -> Path:
+        if audit_dir is None:
+            resolved = (self._logs_root / "audit").resolve(strict=False)
+        else:
+            resolved = Path(audit_dir).resolve(strict=False)
+        if not _is_relative_to(resolved, self._logs_root):
+            raise ValueError("Audit directory must be under repository-level logs/")
+        return resolved
+
+    def _assert_path_under_logs(self, path: Path) -> None:
+        if not _is_relative_to(path.resolve(strict=False), self._logs_root):
+            raise AuditWriteError("Audit path escaped repository-level logs/")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _repo_logs_root() -> Path:
+    return (_repo_root() / "logs").resolve(strict=False)
+
+
+def _redact_value(value: Any, path: str) -> tuple[Any, list[str]]:
+    if isinstance(value, dict):
+        return _redact_dict(value, path)
+    if isinstance(value, list):
+        return _redact_sequence(value, path)
+    if isinstance(value, tuple):
+        return _redact_sequence(list(value), path)
+    if isinstance(value, str):
+        return _redact_string(value, path)
+    return value, []
+
+
+def _redact_dict(value: dict[Any, Any], path: str) -> tuple[dict[str, Any], list[str]]:
+    redacted: dict[str, Any] = {}
+    redacted_paths: list[str] = []
+    for key, item in value.items():
+        key_text = str(key)
+        child_path = _join_path(path, key_text)
+        if _is_sensitive_key(key_text):
+            redacted[key_text] = REDACTION_TEXT
+            redacted_paths.append(child_path)
+            continue
+        redacted_item, child_paths = _redact_value(item, child_path)
+        redacted[key_text] = redacted_item
+        redacted_paths.extend(child_paths)
+    return redacted, redacted_paths
+
+
+def _redact_sequence(value: list[Any], path: str) -> tuple[list[Any], list[str]]:
+    redacted: list[Any] = []
+    redacted_paths: list[str] = []
+    for index, item in enumerate(value):
+        child_path = f"{path}[{index}]" if path else f"[{index}]"
+        redacted_item, child_paths = _redact_value(item, child_path)
+        redacted.append(redacted_item)
+        redacted_paths.extend(child_paths)
+    return redacted, redacted_paths
+
+
+def _redact_string(value: str, path: str) -> tuple[str, list[str]]:
+    if not _KEY_VALUE_SECRET_RE.search(value):
+        return value, []
+    return _KEY_VALUE_SECRET_RE.sub(
+        lambda match: f"{match.group('key')}{match.group('sep')}{REDACTION_TEXT}",
+        value,
+    ), [path]
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.lower()
+    return any(token in normalized for token in SENSITIVE_KEY_TOKENS)
+
+
+def _join_path(parent: str, child: str) -> str:
+    return child if not parent else f"{parent}.{child}"
+
+
+def _deduplicate_paths(paths: list[str]) -> list[str]:
+    deduplicated: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        if path and path not in seen:
+            deduplicated.append(path)
+            seen.add(path)
+    return deduplicated
+
+
+def _record_to_json_line(record: AuditRecord) -> str:
+    return json.dumps(
+        record.as_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def _append_jsonl_line(path: Path, line: str) -> None:
+    fd = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+    try:
+        with os.fdopen(fd, "a", encoding="utf-8") as handle:
+            handle.write(line)
+            handle.write("\n")
+    finally:
+        _chmod_if_supported(path, 0o600)
+
+
+def _chmod_if_supported(path: Path, mode: int) -> None:
+    try:
+        path.chmod(mode)
+    except OSError:
+        pass
+
+
+def _new_event_id(timestamp: datetime | str) -> str:
+    return f"audit-{_timestamp_for_id(timestamp)}-{secrets.token_hex(4)}"
+
+
+def _timestamp_for_id(timestamp: datetime | str) -> str:
+    if isinstance(timestamp, str):
+        return (
+            timestamp.replace("-", "")
+            .replace(":", "")
+            .replace("+", "")
+            .replace("Z", "Z")
+        )
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+    return timestamp.astimezone(UTC).replace(microsecond=0).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _date_string(timestamp: datetime | str | date) -> str:
+    if isinstance(timestamp, datetime):
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=UTC)
+        return timestamp.astimezone(UTC).date().isoformat()
+    if isinstance(timestamp, date):
+        return timestamp.isoformat()
+    return timestamp[:10]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def _enum_or_str(value: Any) -> str:
+    return value.value if hasattr(value, "value") else str(value)
+
+
+def _is_relative_to(candidate: Path, root: Path) -> bool:
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False
+    return True

--- a/src/ecli/services/models/__init__.py
+++ b/src/ecli/services/models/__init__.py
@@ -13,6 +13,7 @@
 
 """Typed service model definitions."""
 
+from ecli.services.models.audit import AuditActor, AuditEventType, AuditRecord
 from ecli.services.models.config import (
     AIConfig,
     AIProviderConfig,
@@ -50,6 +51,9 @@ from ecli.services.models.project import (
 
 
 __all__ = [
+    "AuditActor",
+    "AuditEventType",
+    "AuditRecord",
     "AIConfig",
     "AIProviderConfig",
     "ConfigDiagnostic",

--- a/src/ecli/services/models/audit.py
+++ b/src/ecli/services/models/audit.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/models/audit.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Typed audit log models for the Phase 1B AuditLogService."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+
+class AuditActor(StrEnum):
+    """Actor categories recorded in audit events."""
+
+    USER = "user"
+    SERVICE = "service"
+    AI_ASSISTANT = "ai_assistant"
+    DOCTOR = "doctor"
+    SYSTEM = "system"
+
+
+class AuditEventType(StrEnum):
+    """Audit event types owned by Phase 1 service foundations."""
+
+    PLAN_CREATED = "plan.created"
+    PLAN_VALIDATED = "plan.validated"
+    PLAN_POLICY_CHECKED = "plan.policy_checked"
+    PLAN_VIEWED = "plan.viewed"
+    PLAN_CONFIRMED = "plan.confirmed"
+    PLAN_REJECTED = "plan.rejected"
+    PLAN_CANCELLED = "plan.cancelled"
+    PLAN_EXECUTION_STARTED = "plan.execution_started"
+    PLAN_STEP_STARTED = "plan.step_started"
+    PLAN_STEP_COMPLETED = "plan.step_completed"
+    PLAN_STEP_FAILED = "plan.step_failed"
+    PLAN_EXECUTION_COMPLETED = "plan.execution_completed"
+    PLAN_EXECUTION_FAILED = "plan.execution_failed"
+    PLAN_ROLLBACK_AVAILABLE = "plan.rollback_available"
+    PLAN_ROLLBACK_STARTED = "plan.rollback_started"
+    PLAN_ROLLBACK_COMPLETED = "plan.rollback_completed"
+    PLAN_ROLLBACK_FAILED = "plan.rollback_failed"
+    AUDIT_REDACTION_FAILED = "audit.redaction_failed"
+    AUDIT_WRITE_FAILED = "audit.write_failed"
+    POLICY_EVALUATED = "policy.evaluated"
+    POLICY_DENIED = "policy.denied"
+    SERVICE_REFUSED = "service.refused"
+
+
+@dataclass(frozen=True)
+class AuditRecord:
+    """One append-only JSONL audit event record."""
+
+    schema_version: int
+    event_id: str
+    timestamp: datetime | str
+    event_type: str
+    actor: str
+    details: dict[str, Any]
+    metadata: dict[str, Any]
+    plan_id: str | None = None
+    category: str | None = None
+    risk: str | None = None
+    source: str | None = None
+    redacted_fields: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible audit record dictionary."""
+        return {
+            "schema_version": self.schema_version,
+            "event_id": self.event_id,
+            "timestamp": _serialize_timestamp(self.timestamp),
+            "event_type": self.event_type,
+            "actor": self.actor,
+            "details": _json_safe_copy(self.details),
+            "metadata": _json_safe_copy(self.metadata),
+            "plan_id": self.plan_id,
+            "category": self.category,
+            "risk": self.risk,
+            "source": self.source,
+            "redacted_fields": list(self.redacted_fields),
+        }
+
+
+def _serialize_timestamp(value: datetime | str) -> str:
+    if isinstance(value, str):
+        return value
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _json_safe_copy(value: Any) -> Any:
+    primitive_types = str | int | float | bool
+    if isinstance(value, dict):
+        return {str(key): _json_safe_copy(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe_copy(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_safe_copy(item) for item in value]
+    if isinstance(value, StrEnum):
+        return value.value
+    if isinstance(value, datetime):
+        return _serialize_timestamp(value)
+    return value if isinstance(value, primitive_types) or value is None else str(value)

--- a/tests/services/test_audit_log_service.py
+++ b/tests/services/test_audit_log_service.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/services/test_audit_log_service.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for append-only JSONL AuditLogService behavior."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from ecli.services.audit_log_service import (
+    REDACTION_TEXT,
+    AuditLogService,
+    AuditRedactionError,
+)
+from ecli.services.models.audit import AuditActor, AuditEventType, AuditRecord
+from ecli.services.models.plan import (
+    CommandPlan,
+    CommandStep,
+    PlanCategory,
+    PlanRisk,
+    PlanSource,
+    PolicyDecision,
+)
+
+
+FIXED_TIME = datetime(2026, 5, 16, 10, 11, 12, tzinfo=UTC)
+
+
+@pytest.fixture
+def audit_dir(request: pytest.FixtureRequest) -> Iterator[Path]:
+    safe_name = request.node.name.replace("/", "_").replace(":", "_")
+    path = Path.cwd() / "logs" / f"test-audit-{safe_name}"
+    shutil.rmtree(path, ignore_errors=True)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def sample_step(
+    *,
+    requires_privilege: bool = False,
+    destructive: bool = False,
+) -> CommandStep:
+    return CommandStep(
+        step_id="step-001",
+        title="Inspect",
+        argv=["echo", "ok"],
+        display="echo ok",
+        requires_privilege=requires_privilege,
+        destructive=destructive,
+    )
+
+
+def sample_plan() -> CommandPlan:
+    return CommandPlan(
+        plan_id="plan-20260516T101112Z-abcdef12",
+        title="Audit test plan",
+        category=PlanCategory.SYSTEM,
+        risk=PlanRisk.HIGH,
+        commands=[sample_step(requires_privilege=True)],
+        created_at=FIXED_TIME,
+        created_by="tester",
+        source=PlanSource.USER,
+        confirmation_required=True,
+        requires_privilege=True,
+        affected_resources=["cluster/prod/database"],
+        metadata={"owner": "qa"},
+    )
+
+
+def sample_record(**overrides) -> AuditRecord:
+    values = {
+        "schema_version": 1,
+        "event_id": "audit-fixed-001",
+        "timestamp": FIXED_TIME,
+        "event_type": AuditEventType.PLAN_CREATED.value,
+        "actor": AuditActor.USER.value,
+        "details": {"message": "created"},
+        "metadata": {"owner": "qa"},
+        "plan_id": "plan-20260516T101112Z-abcdef12",
+        "category": "SYSTEM",
+        "risk": "HIGH",
+        "source": "USER",
+    }
+    values.update(overrides)
+    return AuditRecord(**values)
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_audit_record_serializes_to_json_compatible_dict() -> None:
+    payload = sample_record().as_dict()
+
+    json.dumps(payload)
+    assert payload["timestamp"] == "2026-05-16T10:11:12Z"
+    assert payload["event_type"] == "plan.created"
+    assert payload["redacted_fields"] == []
+
+
+def test_append_creates_daily_jsonl_under_logs(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+    service.append(sample_record())
+
+    audit_file = audit_dir / "audit-2026-05-16.jsonl"
+    assert audit_file.is_file()
+    assert audit_file.resolve(strict=False).is_relative_to(
+        (Path.cwd() / "logs").resolve(strict=False)
+    )
+
+
+def test_each_audit_event_is_one_valid_json_object_per_line(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+    service.append(sample_record())
+
+    audit_file = audit_dir / "audit-2026-05-16.jsonl"
+    lines = audit_file.read_text(encoding="utf-8").splitlines()
+
+    assert len(lines) == 1
+    assert json.loads(lines[0])["event_id"] == "audit-fixed-001"
+
+
+def test_append_only_behavior_writes_multiple_lines(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+    service.append(sample_record(event_id="audit-fixed-001"))
+    service.append(sample_record(event_id="audit-fixed-002"))
+
+    records = read_jsonl(audit_dir / "audit-2026-05-16.jsonl")
+
+    assert [record["event_id"] for record in records] == [
+        "audit-fixed-001",
+        "audit-fixed-002",
+    ]
+
+
+def test_required_fields_exist_in_each_record(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+    service.append(sample_record())
+
+    record = read_jsonl(audit_dir / "audit-2026-05-16.jsonl")[0]
+
+    for key in (
+        "schema_version",
+        "event_id",
+        "timestamp",
+        "event_type",
+        "actor",
+        "details",
+        "metadata",
+        "redacted_fields",
+    ):
+        assert key in record
+
+
+def test_sensitive_values_are_redacted_before_write(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+    service.append(
+        sample_record(
+            details={"env": {"API_KEY": "raw-secret"}},
+            metadata={"authorization": "Bearer raw-token"},
+        )
+    )
+
+    raw_text = (audit_dir / "audit-2026-05-16.jsonl").read_text(encoding="utf-8")
+    record = json.loads(raw_text)
+
+    assert "raw-secret" not in raw_text
+    assert "raw-token" not in raw_text
+    assert record["details"]["env"]["API_KEY"] == REDACTION_TEXT
+    assert record["metadata"]["authorization"] == REDACTION_TEXT
+
+
+def test_nested_sensitive_fields_are_redacted(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+    returned = service.append(
+        sample_record(
+            details={
+                "items": [
+                    {"safe": "value"},
+                    {"private_key": "raw-private-key"},
+                ]
+            },
+            metadata={"nested": {"session_key": "raw-session"}},
+        )
+    )
+
+    assert returned.details["items"][1]["private_key"] == REDACTION_TEXT
+    assert returned.metadata["nested"]["session_key"] == REDACTION_TEXT
+
+
+def test_redacted_fields_contains_deterministic_paths(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+    returned = service.append(
+        sample_record(
+            details={"env": {"API_KEY": "raw-secret"}},
+            metadata={"authorization": "Bearer raw-token"},
+        )
+    )
+
+    assert returned.redacted_fields == [
+        "details.env.API_KEY",
+        "metadata.authorization",
+    ]
+
+
+def test_key_value_sensitive_material_in_string_is_redacted(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+    returned = service.append(
+        sample_record(details={"stderr": "failed token=raw-token api_key:raw-key"})
+    )
+
+    assert returned.details["stderr"] == (
+        f"failed token={REDACTION_TEXT} api_key:{REDACTION_TEXT}"
+    )
+    assert returned.redacted_fields == ["details.stderr"]
+
+
+def test_redaction_failure_fails_closed_and_writes_nothing(
+    audit_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+
+    def fail_redaction(value):
+        raise ValueError("redaction failed")
+
+    monkeypatch.setattr(service, "redact_sensitive", fail_redaction)
+
+    with pytest.raises(AuditRedactionError):
+        service.append(sample_record(details={"token": "raw-token"}))
+
+    assert not audit_dir.exists()
+
+
+def test_log_plan_created_writes_plan_created_event(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+
+    record = service.log_plan_created(sample_plan())
+
+    assert record.event_type == "plan.created"
+    assert read_jsonl(service.audit_file_for(record.timestamp))[0]["event_type"] == (
+        "plan.created"
+    )
+
+
+def test_log_policy_evaluated_redacts_decision_metadata(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+    decision = PolicyDecision(
+        allowed=False,
+        reason="denied",
+        policy_id="BUILTIN-001",
+        violated_rules=["BUILTIN-001"],
+        metadata={"api_key": "raw-key"},
+    )
+
+    record = service.log_policy_evaluated(sample_plan(), decision)
+    raw_text = service.audit_file_for(record.timestamp).read_text(encoding="utf-8")
+
+    assert record.event_type == "policy.denied"
+    assert "raw-key" not in raw_text
+    assert json.loads(raw_text)["details"]["decision"]["metadata"]["api_key"] == (
+        REDACTION_TEXT
+    )
+
+
+def test_log_execution_result_writes_execution_result_metadata(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+
+    record = service.log_execution_result(
+        sample_plan(),
+        success=False,
+        details={"exit_code": 1, "stderr": "password=raw-password"},
+    )
+
+    assert record.event_type == "plan.execution_failed"
+    assert record.details["success"] is False
+    assert record.details["exit_code"] == 1
+    assert record.details["stderr"] == f"password={REDACTION_TEXT}"
+
+
+def test_audit_service_rejects_paths_outside_logs() -> None:
+    with pytest.raises(ValueError):
+        AuditLogService(audit_dir=Path.cwd() / "tests" / "audit-output")
+
+
+def test_audit_service_source_does_not_import_subprocess_or_network_modules() -> None:
+    source = Path("src/ecli/services/audit_log_service.py").read_text(encoding="utf-8")
+
+    assert "subprocess" not in source
+    assert "requests" not in source
+    assert "socket" not in source
+
+
+def test_deterministic_json_for_identical_fixed_records(audit_dir: Path) -> None:
+    service = AuditLogService(audit_dir=audit_dir)
+    record = sample_record()
+    service.append(record)
+    service.append(record)
+
+    lines = (
+        (audit_dir / "audit-2026-05-16.jsonl").read_text(encoding="utf-8").splitlines()
+    )
+
+    assert len(lines) == 2
+    assert lines[0] == lines[1]


### PR DESCRIPTION
Closes #46

Implemented Phase 1B AuditLogService JSONL with mandatory redaction.

Scope:
- append-only JSONL audit logging
- default audit file layout under logs/audit/audit-YYYY-MM-DD.jsonl
- AuditActor, AuditEventType, and AuditRecord models
- repository logs/ confinement for audit writes
- recursive redaction before write
- fail-closed redaction behavior
- owner-only file and directory mode where supported
- helper methods:
  - append()
  - redact_sensitive()
  - log_plan_created()
  - log_policy_evaluated()
  - log_execution_result()
  - build_record()
  - audit_file_for()
  - read_records_for_day()
- focused AuditLogService tests

Not included:
- no execution logic
- no subprocess usage
- no network calls
- no telemetry
- no CLI wiring
- no ServiceRegistry wiring
- no Ecli.py changes
- no __main__.py changes
- no UI changes
- no VMLab changes
- no PrivilegedActionService implementation
- no SystemDoctor integration
- no new dependencies

Validation:
- python3 -m pytest tests/services/test_audit_log_service.py -v
- python3 -m pytest tests/services/test_policy_engine.py -v
- python3 -m pytest tests/services/test_command_plan_models.py -v
- python3 -m pytest tests/services/test_plan_validation.py -v
- python3 -m pytest tests/services/test_command_plan_exports.py -v
- python3 -m pytest tests/services/test_config_service.py -v
- python3 -m pytest tests/services/test_config_migration.py -v
- python3 -m pytest tests/services/test_project_service.py -v
- python3 -m pytest tests/test_smoke.py -v
- python3 -m compileall src
- ruff check src/ecli/services tests/services
- ruff format --check src/ecli/services tests/services
- ./scripts/check-log-invariant.sh
- git diff --check
