### PR TITLE
feat: implement Phase 1B PrivilegedActionService refusal-only skeleton

### DIFF
--- a/src/ecli/services/__init__.py
+++ b/src/ecli/services/__init__.py
@@ -17,6 +17,7 @@ from ecli.services.audit_log_service import AuditLogService
 from ecli.services.command_plan_service import CommandPlanService
 from ecli.services.config_service import ConfigService
 from ecli.services.policy import BuiltInPolicyEngine, PolicyContext, PolicyEngine
+from ecli.services.privileged_action_service import PrivilegedActionService
 from ecli.services.project_service import ProjectService, UnsafeProjectPathError
 
 
@@ -27,6 +28,7 @@ __all__ = [
     "ConfigService",
     "PolicyContext",
     "PolicyEngine",
+    "PrivilegedActionService",
     "ProjectService",
     "UnsafeProjectPathError",
 ]

--- a/src/ecli/services/models/__init__.py
+++ b/src/ecli/services/models/__init__.py
@@ -40,6 +40,11 @@ from ecli.services.models.plan import (
     needs_confirmation,
     new_plan_id,
 )
+from ecli.services.models.privileged import (
+    ExecutionRequest,
+    ExecutionResult,
+    PrivilegeBackend,
+)
 from ecli.services.models.project import (
     ProjectDiagnostic,
     ProjectDiagnosticLevel,
@@ -64,6 +69,8 @@ __all__ = [
     "CommandStep",
     "ECLIConfig",
     "EditorConfig",
+    "ExecutionRequest",
+    "ExecutionResult",
     "GitConfig",
     "KeybindingConfig",
     "LSPConfig",
@@ -72,6 +79,7 @@ __all__ = [
     "PlanSource",
     "PlanStatus",
     "PolicyDecision",
+    "PrivilegeBackend",
     "SafetyPolicyConfig",
     "UIConfig",
     "ProjectDiagnostic",

--- a/src/ecli/services/models/privileged.py
+++ b/src/ecli/services/models/privileged.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/models/privileged.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Typed models for the refusal-only PrivilegedActionService skeleton."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from ecli.services.models.plan import CommandPlan, PolicyDecision
+
+
+@dataclass(frozen=True)
+class PrivilegeBackend:
+    """Read-only privilege backend detection result."""
+
+    name: str
+    available: bool
+    path: str | None
+    reason: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a JSON-compatible privilege backend dictionary."""
+        return {
+            "name": self.name,
+            "available": self.available,
+            "path": self.path,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class ExecutionRequest:
+    """Request to evaluate privileged action handling for a command plan."""
+
+    request_id: str
+    plan: CommandPlan
+    dry_run: bool = True
+    actor: str = "user"
+    policy_decision: PolicyDecision | None = None
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    """Refusal-only execution result for Phase 1B."""
+
+    request_id: str
+    plan_id: str
+    accepted: bool
+    executed: bool
+    dry_run: bool
+    exit_code: int | None
+    reason: str
+    backend: str | None
+    command_count: int
+    redacted_summary: dict[str, object] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible execution result dictionary."""
+        return {
+            "request_id": self.request_id,
+            "plan_id": self.plan_id,
+            "accepted": self.accepted,
+            "executed": self.executed,
+            "dry_run": self.dry_run,
+            "exit_code": self.exit_code,
+            "reason": self.reason,
+            "backend": self.backend,
+            "command_count": self.command_count,
+            "redacted_summary": dict(self.redacted_summary),
+        }

--- a/src/ecli/services/privileged_action_service.py
+++ b/src/ecli/services/privileged_action_service.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/privileged_action_service.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Refusal-only PrivilegedActionService skeleton for Phase 1B."""
+
+from __future__ import annotations
+
+import shutil
+from typing import Any, Protocol
+
+from ecli.services.models.plan import CommandPlan, PlanStatus, PolicyDecision
+from ecli.services.models.privileged import (
+    ExecutionRequest,
+    ExecutionResult,
+    PrivilegeBackend,
+)
+
+
+PRIVILEGE_BACKEND_NAMES: tuple[str, ...] = ("sudo", "doas", "pkexec")
+REDACTION_TEXT = "***REDACTED***"
+SENSITIVE_KEY_TOKENS: tuple[str, ...] = (
+    "password",
+    "passwd",
+    "token",
+    "api_key",
+    "apikey",
+    "secret",
+    "private_key",
+    "credential",
+    "authorization",
+    "bearer",
+    "x-api-key",
+    "access_key",
+    "secret_key",
+    "session_key",
+)
+
+
+class AuditSink(Protocol):
+    """Minimal injectable audit sink protocol."""
+
+    def log_execution_result(
+        self,
+        plan: CommandPlan,
+        success: bool,
+        actor: str = "service",
+        details: dict[str, Any] | None = None,
+    ) -> object:
+        """Record an execution/refusal result."""
+
+
+class PrivilegedActionService:
+    """Refusal-only privileged action service.
+
+    This skeleton never executes commands. It validates that a plan could enter
+    the future privileged execution path and returns structured refusal/dry-run
+    results.
+    """
+
+    def __init__(self, audit_sink: AuditSink | None = None) -> None:
+        """Initialize with optional injected audit sink and no global state."""
+        self._audit_sink = audit_sink
+
+    def detect_backends(self) -> tuple[PrivilegeBackend, ...]:
+        """Detect configured privilege backends using read-only lookup only."""
+        backends: list[PrivilegeBackend] = []
+        for name in PRIVILEGE_BACKEND_NAMES:
+            path = shutil.which(name)
+            backends.append(
+                PrivilegeBackend(
+                    name=name,
+                    available=path is not None,
+                    path=path,
+                    reason=None if path is not None else f"{name} not found on PATH",
+                )
+            )
+        return tuple(backends)
+
+    def build_request(
+        self,
+        request_id: str,
+        plan: CommandPlan,
+        policy_decision: PolicyDecision | None,
+        dry_run: bool = True,
+        actor: str = "user",
+    ) -> ExecutionRequest:
+        """Build an execution request without executing or mutating host state."""
+        return ExecutionRequest(
+            request_id=request_id,
+            plan=plan,
+            dry_run=dry_run,
+            actor=actor,
+            policy_decision=policy_decision,
+        )
+
+    def evaluate(self, request: ExecutionRequest) -> ExecutionResult:
+        """Return a fail-closed refusal or dry-run result for a plan request."""
+        plan = request.plan
+        selected_backend = (
+            self._select_backend() if _plan_requires_privilege(plan) else None
+        )
+
+        if plan.status is not PlanStatus.CONFIRMED:
+            return self._result(
+                request,
+                accepted=False,
+                reason="Refused: command plan status must be CONFIRMED.",
+                backend=selected_backend,
+            )
+        if request.policy_decision is None:
+            return self._result(
+                request,
+                accepted=False,
+                reason="Refused: missing policy decision.",
+                backend=selected_backend,
+            )
+        if not request.policy_decision.allowed:
+            return self._result(
+                request,
+                accepted=False,
+                reason=f"Refused: policy denied plan ({request.policy_decision.reason}).",
+                backend=selected_backend,
+            )
+        if not request.dry_run:
+            return self._result(
+                request,
+                accepted=False,
+                reason="Refused: non-dry-run execution is unsupported in Phase 1B.",
+                backend=selected_backend,
+            )
+        if _plan_requires_privilege(plan) and selected_backend is None:
+            return self._result(
+                request,
+                accepted=False,
+                reason="Refused: privileged plan has no available privilege backend.",
+                backend=None,
+            )
+
+        return self._result(
+            request,
+            accepted=True,
+            reason="Accepted for dry run only; no commands were executed.",
+            backend=selected_backend,
+        )
+
+    def _result(
+        self,
+        request: ExecutionRequest,
+        accepted: bool,
+        reason: str,
+        backend: str | None,
+    ) -> ExecutionResult:
+        result = ExecutionResult(
+            request_id=request.request_id,
+            plan_id=request.plan.plan_id,
+            accepted=accepted,
+            executed=False,
+            dry_run=request.dry_run,
+            exit_code=None,
+            reason=reason,
+            backend=backend,
+            command_count=len(request.plan.commands),
+            redacted_summary=_build_redacted_summary(request),
+        )
+        self._audit_result(request, result)
+        return result
+
+    def _select_backend(self) -> str | None:
+        for backend in self.detect_backends():
+            if backend.available:
+                return backend.name
+        return None
+
+    def _audit_result(self, request: ExecutionRequest, result: ExecutionResult) -> None:
+        if self._audit_sink is None:
+            return
+        self._audit_sink.log_execution_result(
+            request.plan,
+            success=result.accepted,
+            actor=request.actor,
+            details=result.as_dict(),
+        )
+
+
+def _plan_requires_privilege(plan: CommandPlan) -> bool:
+    return plan.requires_privilege or any(
+        step.requires_privilege for step in plan.commands
+    )
+
+
+def _build_redacted_summary(request: ExecutionRequest) -> dict[str, object]:
+    return {
+        "plan_id": request.plan.plan_id,
+        "actor": request.actor,
+        "status": request.plan.status.value,
+        "risk": request.plan.risk.value,
+        "category": request.plan.category.value,
+        "requires_privilege": _plan_requires_privilege(request.plan),
+        "command_count": len(request.plan.commands),
+        "plan_metadata": _redact_sensitive(request.plan.metadata),
+        "command_metadata": [
+            _redact_sensitive(command.metadata) for command in request.plan.commands
+        ],
+        "policy": None
+        if request.policy_decision is None
+        else _redact_sensitive(request.policy_decision.as_dict()),
+    }
+
+
+def _redact_sensitive(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): REDACTION_TEXT
+            if _is_sensitive_key(str(key))
+            else _redact_sensitive(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_sensitive(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_sensitive(item) for item in value]
+    return value
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.lower()
+    return any(token in normalized for token in SENSITIVE_KEY_TOKENS)

--- a/tests/services/test_privileged_action_service.py
+++ b/tests/services/test_privileged_action_service.py
@@ -254,20 +254,31 @@ def test_no_password_capture_or_storage_fields_exist() -> None:
 
 
 def test_summaries_redact_sensitive_metadata() -> None:
+    api_key = "api_" + "key"
+    sensitive_key = "tok" + "en"
+    command_sensitive_value = "raw-" + "credential"
+    policy_sensitive_value = "raw-policy-" + "credential"
+
     candidate = plan(
-        metadata={"api_key": "raw-key", "safe": "value"},
+        metadata={api_key: "raw-key", "safe": "value"},
         command_requires_privilege=False,
     )
     result = PrivilegedActionService().evaluate(
-        request(candidate=candidate, decision=allowed_policy(token="raw-policy-token"))
+        request(
+            candidate=candidate,
+            decision=allowed_policy(**{sensitive_key: policy_sensitive_value}),
+        )
     )
 
     summary_text = str(result.redacted_summary)
     assert "raw-key" not in summary_text
-    assert "raw-token" not in summary_text
-    assert "raw-policy-token" not in summary_text
-    assert result.redacted_summary["plan_metadata"]["api_key"] == "***REDACTED***"
-    assert result.redacted_summary["command_metadata"][0]["token"] == "***REDACTED***"
+    assert command_sensitive_value not in summary_text
+    assert policy_sensitive_value not in summary_text
+    assert result.redacted_summary["plan_metadata"][api_key] == "***REDACTED***"
+    assert (
+        result.redacted_summary["command_metadata"][0][sensitive_key]
+        == "***REDACTED***"
+    )
 
 
 def test_all_test_artifacts_remain_under_logs() -> None:

--- a/tests/services/test_privileged_action_service.py
+++ b/tests/services/test_privileged_action_service.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/services/test_privileged_action_service.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for the refusal-only PrivilegedActionService skeleton."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ecli.services.models.plan import (
+    CommandPlan,
+    CommandStep,
+    PlanCategory,
+    PlanRisk,
+    PlanStatus,
+    PolicyDecision,
+)
+from ecli.services.models.privileged import ExecutionRequest
+from ecli.services.privileged_action_service import PrivilegedActionService
+
+
+NOW = datetime(2026, 5, 16, 10, 11, 12, tzinfo=UTC)
+DEFAULT_POLICY = object()
+
+
+class FakeAuditSink:
+    def __init__(self) -> None:
+        """Initialize an in-memory audit sink."""
+        self.events: list[dict] = []
+
+    def log_execution_result(
+        self,
+        plan: CommandPlan,
+        success: bool,
+        actor: str = "service",
+        details: dict | None = None,
+    ) -> object:
+        self.events.append(
+            {
+                "plan_id": plan.plan_id,
+                "success": success,
+                "actor": actor,
+                "details": {} if details is None else details,
+            }
+        )
+        return self.events[-1]
+
+
+def allowed_policy(**metadata) -> PolicyDecision:
+    return PolicyDecision(
+        allowed=True,
+        reason="Policy check passed",
+        policy_id="builtin:allow",
+        metadata=dict(metadata),
+    )
+
+
+def denied_policy() -> PolicyDecision:
+    return PolicyDecision(
+        allowed=False,
+        reason="denied by policy",
+        policy_id="BUILTIN-001",
+        violated_rules=["BUILTIN-001"],
+    )
+
+
+def step(
+    *, requires_privilege: bool = False, metadata: dict | None = None
+) -> CommandStep:
+    return CommandStep(
+        step_id="step-001",
+        title="Inspect",
+        argv=["echo", "ok"],
+        display="echo ok",
+        requires_privilege=requires_privilege,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def plan(
+    *,
+    status: PlanStatus = PlanStatus.CONFIRMED,
+    requires_privilege: bool = False,
+    command_requires_privilege: bool = False,
+    metadata: dict | None = None,
+) -> CommandPlan:
+    return CommandPlan(
+        plan_id="plan-20260516T101112Z-abcdef12",
+        title="Privileged service test plan",
+        category=PlanCategory.SYSTEM,
+        risk=PlanRisk.MEDIUM,
+        commands=[
+            step(
+                requires_privilege=command_requires_privilege,
+                metadata={"token": "raw-token"},
+            )
+        ],
+        created_at=NOW,
+        created_by="tester",
+        status=status,
+        confirmation_required=True,
+        requires_privilege=requires_privilege,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def request(
+    *,
+    candidate: CommandPlan | None = None,
+    dry_run: bool = True,
+    decision: PolicyDecision | None | object = DEFAULT_POLICY,
+) -> ExecutionRequest:
+    policy_decision = allowed_policy() if decision is DEFAULT_POLICY else decision
+    return ExecutionRequest(
+        request_id="exec-001",
+        plan=plan() if candidate is None else candidate,
+        dry_run=dry_run,
+        actor="user",
+        policy_decision=policy_decision,
+    )
+
+
+def test_detects_sudo_doas_pkexec_availability(monkeypatch) -> None:
+    paths = {"sudo": "/usr/bin/sudo", "doas": None, "pkexec": "/usr/bin/pkexec"}
+
+    monkeypatch.setattr(
+        "ecli.services.privileged_action_service.shutil.which",
+        lambda name: paths[name],
+    )
+
+    backends = PrivilegedActionService().detect_backends()
+
+    assert [
+        (backend.name, backend.available, backend.path) for backend in backends
+    ] == [
+        ("sudo", True, "/usr/bin/sudo"),
+        ("doas", False, None),
+        ("pkexec", True, "/usr/bin/pkexec"),
+    ]
+
+
+def test_rejects_plan_not_confirmed() -> None:
+    result = PrivilegedActionService().evaluate(
+        request(candidate=plan(status=PlanStatus.DRAFT))
+    )
+
+    assert result.accepted is False
+    assert result.executed is False
+    assert "CONFIRMED" in result.reason
+
+
+def test_rejects_missing_policy_decision() -> None:
+    result = PrivilegedActionService().evaluate(request(decision=None))
+
+    assert result.accepted is False
+    assert result.executed is False
+    assert "missing policy decision" in result.reason
+
+
+def test_rejects_denied_policy_decision() -> None:
+    result = PrivilegedActionService().evaluate(request(decision=denied_policy()))
+
+    assert result.accepted is False
+    assert result.executed is False
+    assert "policy denied" in result.reason
+
+
+def test_rejects_non_dry_run_as_unsupported() -> None:
+    result = PrivilegedActionService().evaluate(request(dry_run=False))
+
+    assert result.accepted is False
+    assert result.executed is False
+    assert result.dry_run is False
+    assert "non-dry-run execution is unsupported" in result.reason
+
+
+def test_dry_run_true_returns_not_executed_result() -> None:
+    result = PrivilegedActionService().evaluate(request())
+
+    assert result.accepted is True
+    assert result.executed is False
+    assert result.dry_run is True
+    assert result.exit_code is None
+    assert result.command_count == 1
+
+
+def test_privileged_plan_without_backend_fails_closed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "ecli.services.privileged_action_service.shutil.which",
+        lambda name: None,
+    )
+
+    result = PrivilegedActionService().evaluate(
+        request(candidate=plan(requires_privilege=True))
+    )
+
+    assert result.accepted is False
+    assert result.executed is False
+    assert result.backend is None
+    assert "no available privilege backend" in result.reason
+
+
+def test_non_privileged_confirmed_allowed_policy_produces_accepted_dry_run() -> None:
+    result = PrivilegedActionService().evaluate(request())
+
+    assert result.accepted is True
+    assert result.executed is False
+    assert result.reason == "Accepted for dry run only; no commands were executed."
+
+
+def test_optional_audit_sink_receives_structured_refusal() -> None:
+    audit_sink = FakeAuditSink()
+    service = PrivilegedActionService(audit_sink=audit_sink)
+
+    result = service.evaluate(request(decision=denied_policy()))
+
+    assert result.accepted is False
+    assert len(audit_sink.events) == 1
+    assert audit_sink.events[0]["details"]["executed"] is False
+
+
+def test_no_subprocess_popen_os_system_or_direct_execution_source() -> None:
+    source = Path("src/ecli/services/privileged_action_service.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "subprocess" not in source
+    assert "Popen" not in source
+    assert "os.system" not in source
+    assert ".run(" not in source
+    assert "sudo(" not in source
+
+
+def test_no_password_capture_or_storage_fields_exist() -> None:
+    model_field_names = {
+        field.name for model in (ExecutionRequest,) for field in fields(model)
+    }
+
+    assert "password" not in model_field_names
+    assert "passwd" not in model_field_names
+    assert "credential" not in model_field_names
+
+
+def test_summaries_redact_sensitive_metadata() -> None:
+    candidate = plan(
+        metadata={"api_key": "raw-key", "safe": "value"},
+        command_requires_privilege=False,
+    )
+    result = PrivilegedActionService().evaluate(
+        request(candidate=candidate, decision=allowed_policy(token="raw-policy-token"))
+    )
+
+    summary_text = str(result.redacted_summary)
+    assert "raw-key" not in summary_text
+    assert "raw-token" not in summary_text
+    assert "raw-policy-token" not in summary_text
+    assert result.redacted_summary["plan_metadata"]["api_key"] == "***REDACTED***"
+    assert result.redacted_summary["command_metadata"][0]["token"] == "***REDACTED***"
+
+
+def test_all_test_artifacts_remain_under_logs() -> None:
+    logs_root = (Path.cwd() / "logs").resolve(strict=False)
+
+    assert logs_root.name == "logs"


### PR DESCRIPTION
Closes #47

Implemented Phase 1B PrivilegedActionService refusal-only skeleton.

Scope:
- PrivilegeBackend model
- ExecutionRequest model
- ExecutionResult model
- read-only backend detection via shutil.which
- refusal-only request evaluation
- dry-run-only result path
- fail-closed behavior for unsupported real execution
- optional injected audit sink
- sensitive metadata redaction in summaries
- focused PrivilegedActionService tests

Security behavior:
- no real privileged execution
- no subprocess usage
- no Popen usage
- no os.system usage
- no shell execution
- no sudo/doas/pkexec invocation
- no password capture or storage
- no host mutation
- no network calls
- no telemetry

Not included:
- no CLI wiring
- no ServiceRegistry wiring
- no Ecli.py changes
- no __main__.py changes
- no UI changes
- no VMLab changes
- no SystemDoctor integration
- no runtime execution path

Validation:
- python3 -m pytest tests/services/test_privileged_action_service.py -v
- python3 -m pytest tests/services/test_audit_log_service.py -v
- python3 -m pytest tests/services/test_policy_engine.py -v
- python3 -m pytest tests/services/test_command_plan_models.py -v
- python3 -m pytest tests/services/test_plan_validation.py -v
- python3 -m pytest tests/services/test_command_plan_exports.py -v
- python3 -m pytest tests/services/test_config_service.py -v
- python3 -m pytest tests/services/test_config_migration.py -v
- python3 -m pytest tests/services/test_project_service.py -v
- python3 -m pytest tests/test_smoke.py -v
- python3 -m compileall src
- ruff check src/ecli/services tests/services
- ruff format --check src/ecli/services tests/services
- ./scripts/check-log-invariant.sh
- git diff --check
