### PR TITLE
feat: implement Phase 1C SystemDoctor read-only skeleton

### DIFF
--- a/src/ecli/services/__init__.py
+++ b/src/ecli/services/__init__.py
@@ -19,6 +19,7 @@ from ecli.services.config_service import ConfigService
 from ecli.services.policy import BuiltInPolicyEngine, PolicyContext, PolicyEngine
 from ecli.services.privileged_action_service import PrivilegedActionService
 from ecli.services.project_service import ProjectService, UnsafeProjectPathError
+from ecli.services.system_doctor import SystemDoctor
 
 
 __all__ = [
@@ -30,5 +31,6 @@ __all__ = [
     "PolicyEngine",
     "PrivilegedActionService",
     "ProjectService",
+    "SystemDoctor",
     "UnsafeProjectPathError",
 ]

--- a/src/ecli/services/models/__init__.py
+++ b/src/ecli/services/models/__init__.py
@@ -29,6 +29,11 @@ from ecli.services.models.config import (
     SafetyPolicyConfig,
     UIConfig,
 )
+from ecli.services.models.doctor import (
+    DoctorContext,
+    DoctorFinding,
+    DoctorSeverity,
+)
 from ecli.services.models.plan import (
     CommandPlan,
     CommandStep,
@@ -67,6 +72,9 @@ __all__ = [
     "ConfigSource",
     "CommandPlan",
     "CommandStep",
+    "DoctorContext",
+    "DoctorFinding",
+    "DoctorSeverity",
     "ECLIConfig",
     "EditorConfig",
     "ExecutionRequest",

--- a/src/ecli/services/models/doctor.py
+++ b/src/ecli/services/models/doctor.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/models/doctor.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Typed models for the read-only SystemDoctor skeleton."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+
+class DoctorSeverity(StrEnum):
+    """Severity level for SystemDoctor findings."""
+
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
+
+@dataclass(frozen=True)
+class DoctorFinding:
+    """One structured read-only SystemDoctor finding."""
+
+    finding_id: str
+    title: str
+    severity: DoctorSeverity
+    category: str
+    description: str
+    affected_resources: tuple[str, ...] = ()
+    remediation_available: bool = False
+    remediation_plan_id: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Normalize mutable inputs into stable immutable containers."""
+        object.__setattr__(
+            self,
+            "affected_resources",
+            tuple(str(resource) for resource in self.affected_resources),
+        )
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable doctor finding dictionary."""
+        return {
+            "finding_id": self.finding_id,
+            "title": self.title,
+            "severity": self.severity.value,
+            "category": self.category,
+            "description": self.description,
+            "affected_resources": list(self.affected_resources),
+            "remediation_available": self.remediation_available,
+            "remediation_plan_id": self.remediation_plan_id,
+            "metadata": _json_safe_copy(dict(self.metadata)),
+        }
+
+
+@dataclass(frozen=True)
+class DoctorContext:
+    """Read-only SystemDoctor execution context."""
+
+    user: str = "user"
+    project_root: Path | str | None = None
+    categories: tuple[str, ...] = ()
+    verbosity: int = 0
+    dry_run: bool = True
+    environment: str = "local"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Normalize mutable inputs into stable immutable containers."""
+        object.__setattr__(
+            self,
+            "categories",
+            tuple(str(category) for category in self.categories),
+        )
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+
+def _json_safe_copy(value: Any) -> Any:
+    primitive_types = str | int | float | bool
+    if isinstance(value, dict | Mapping):
+        return {str(key): _json_safe_copy(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_safe_copy(item) for item in value]
+    if isinstance(value, StrEnum):
+        return value.value
+    if isinstance(value, Path) or not isinstance(value, primitive_types | None):
+        return str(value)
+    return value

--- a/src/ecli/services/system_doctor.py
+++ b/src/ecli/services/system_doctor.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/services/system_doctor.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Read-only SystemDoctor skeleton for Phase 1C."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ecli.services.models.doctor import DoctorContext, DoctorFinding, DoctorSeverity
+from ecli.services.models.plan import (
+    CommandPlan,
+    CommandStep,
+    PlanCategory,
+    PlanRisk,
+    PlanSource,
+    PlanStatus,
+    new_plan_id,
+)
+
+
+SUPPORTED_CATEGORIES: tuple[str, ...] = (
+    "config",
+    "permissions",
+    "tooling",
+    "virtualization",
+    "path-policy",
+)
+
+DEFAULT_TOOL_CHECKS: tuple[str, ...] = ("git",)
+
+
+class SystemDoctor:
+    """Read-only environment inspection service.
+
+    The Phase 1C implementation only reports findings and can propose command
+    plans. It never performs remediation and never invokes external processes.
+    """
+
+    def __init__(
+        self,
+        logs_root: Path | None = None,
+        kvm_path: Path | None = None,
+        tool_checks: tuple[str, ...] = DEFAULT_TOOL_CHECKS,
+    ) -> None:
+        """Initialize read-only check paths without touching the filesystem."""
+        self._logs_root = (
+            _repo_logs_root() if logs_root is None else Path(logs_root)
+        ).resolve(strict=False)
+        self._kvm_path = Path("/dev/kvm") if kvm_path is None else Path(kvm_path)
+        self._tool_checks = tuple(tool_checks)
+
+    def detect_problems(self, context: DoctorContext) -> list[DoctorFinding]:
+        """Run deterministic read-only checks for selected doctor categories."""
+        categories = _selected_categories(context)
+        findings: list[DoctorFinding] = []
+
+        if "config" in categories:
+            findings.extend(self.check_logs_directory(context))
+        if "permissions" in categories:
+            findings.extend(self.check_permissions_context(context))
+        if "tooling" in categories:
+            findings.extend(self.check_tooling(context))
+        if "virtualization" in categories:
+            findings.extend(self.check_virtualization(context))
+        if "path-policy" in categories:
+            findings.extend(self.check_project_root(context))
+
+        return sorted(findings, key=lambda finding: finding.finding_id)
+
+    def check_tool_available(self, tool_name: str) -> bool:
+        """Return whether a tool is present using read-only PATH lookup."""
+        return shutil.which(tool_name) is not None
+
+    def check_kvm_access(self) -> bool:
+        """Return whether /dev/kvm exists and is readable/writable."""
+        return self._kvm_path.exists() and os.access(self._kvm_path, os.R_OK | os.W_OK)
+
+    def check_project_root(self, context: DoctorContext) -> list[DoctorFinding]:
+        """Validate project root presence without creating or modifying paths."""
+        if context.project_root is None:
+            return [
+                DoctorFinding(
+                    finding_id="DOCTOR-PATH-001",
+                    title="Project root is not set",
+                    severity=DoctorSeverity.WARNING,
+                    category="path-policy",
+                    description="SystemDoctor has no project root context to inspect.",
+                    remediation_available=False,
+                    metadata={"check": "project_root"},
+                )
+            ]
+
+        project_root = Path(context.project_root).resolve(strict=False)
+        if not project_root.exists():
+            return [
+                DoctorFinding(
+                    finding_id="DOCTOR-PATH-002",
+                    title="Project root does not exist",
+                    severity=DoctorSeverity.ERROR,
+                    category="path-policy",
+                    description="Configured project root is not present on disk.",
+                    affected_resources=(str(project_root),),
+                    remediation_available=False,
+                    metadata={"check": "project_root"},
+                )
+            ]
+        return []
+
+    def check_logs_directory(self, context: DoctorContext) -> list[DoctorFinding]:
+        """Check repository-level logs/ presence without creating it."""
+        if self._logs_root.exists() and self._logs_root.is_dir():
+            return []
+        plan_id = _remediation_plan_id("DOCTOR-CONFIG-001")
+        return [
+            DoctorFinding(
+                finding_id="DOCTOR-CONFIG-001",
+                title="Repository logs directory is missing",
+                severity=DoctorSeverity.WARNING,
+                category="config",
+                description=(
+                    "Repository-level logs/ is absent; generated diagnostics must "
+                    "remain confined under logs/."
+                ),
+                affected_resources=(str(self._logs_root),),
+                remediation_available=True,
+                remediation_plan_id=plan_id,
+                metadata={"check": "logs_directory", "user": context.user},
+            )
+        ]
+
+    def check_permissions_context(self, context: DoctorContext) -> list[DoctorFinding]:
+        """Report non-dry-run context while keeping the doctor read-only."""
+        if context.dry_run:
+            return []
+        return [
+            DoctorFinding(
+                finding_id="DOCTOR-PERM-001",
+                title="SystemDoctor remains read-only",
+                severity=DoctorSeverity.INFO,
+                category="permissions",
+                description=(
+                    "The supplied context requested non-dry-run mode, but Phase 1C "
+                    "SystemDoctor only performs read-only inspection."
+                ),
+                remediation_available=False,
+                metadata={"check": "dry_run", "environment": context.environment},
+            )
+        ]
+
+    def check_tooling(self, context: DoctorContext) -> list[DoctorFinding]:
+        """Check configured developer tools through read-only PATH lookup."""
+        findings: list[DoctorFinding] = []
+        for tool_name in self._tool_checks:
+            if self.check_tool_available(tool_name):
+                continue
+            findings.append(
+                DoctorFinding(
+                    finding_id=f"DOCTOR-TOOL-001-{tool_name}",
+                    title=f"Required tool is not available: {tool_name}",
+                    severity=DoctorSeverity.WARNING,
+                    category="tooling",
+                    description=(
+                        f"{tool_name} was not found on PATH during read-only lookup."
+                    ),
+                    affected_resources=(tool_name,),
+                    remediation_available=False,
+                    metadata={"check": "tool_available", "user": context.user},
+                )
+            )
+        return findings
+
+    def check_virtualization(self, context: DoctorContext) -> list[DoctorFinding]:
+        """Check KVM device access without changing kernel or user state."""
+        if self.check_kvm_access():
+            return []
+        return [
+            DoctorFinding(
+                finding_id="DOCTOR-VIRT-001",
+                title="KVM access is unavailable",
+                severity=DoctorSeverity.WARNING,
+                category="virtualization",
+                description=(
+                    "KVM device access is unavailable for future virtualization "
+                    "workflows."
+                ),
+                affected_resources=(str(self._kvm_path),),
+                remediation_available=False,
+                metadata={"check": "kvm_access", "environment": context.environment},
+            )
+        ]
+
+    def propose_remediation(self, finding: DoctorFinding) -> CommandPlan | None:
+        """Return a proposed CommandPlan for supported findings without execution."""
+        if not finding.remediation_available:
+            return None
+        if finding.finding_id != "DOCTOR-CONFIG-001":
+            return None
+
+        plan_id = finding.remediation_plan_id or _remediation_plan_id(
+            finding.finding_id
+        )
+        logs_path = (
+            finding.affected_resources[0]
+            if finding.affected_resources
+            else str(self._logs_root)
+        )
+        return CommandPlan(
+            plan_id=plan_id,
+            title="Create repository logs directory",
+            description="Proposed remediation only; SystemDoctor does not execute it.",
+            category=PlanCategory.DOCTOR,
+            risk=PlanRisk.LOW,
+            status=PlanStatus.DRAFT,
+            commands=[
+                CommandStep(
+                    step_id="doctor-create-logs-dir",
+                    title="Create logs directory",
+                    argv=["mkdir", "-p", logs_path],
+                    display=f"mkdir -p {logs_path}",
+                    destructive=False,
+                    metadata={"finding_id": finding.finding_id},
+                )
+            ],
+            confirmation_required=True,
+            requires_privilege=False,
+            created_at=_fixed_doctor_plan_time(),
+            created_by="system_doctor",
+            source=PlanSource.DOCTOR,
+            affected_resources=[logs_path],
+            metadata={
+                "finding_id": finding.finding_id,
+                "service": "SystemDoctor",
+                "readonly": True,
+            },
+        )
+
+
+def _selected_categories(context: DoctorContext) -> tuple[str, ...]:
+    if not context.categories:
+        return SUPPORTED_CATEGORIES
+    selected = []
+    for category in context.categories:
+        if category in SUPPORTED_CATEGORIES and category not in selected:
+            selected.append(category)
+    return tuple(selected)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _repo_logs_root() -> Path:
+    return (_repo_root() / "logs").resolve(strict=False)
+
+
+def _remediation_plan_id(finding_id: str) -> str:
+    suffix = hashlib.sha256(finding_id.encode("utf-8")).hexdigest()[:8]
+    return new_plan_id(now=_fixed_doctor_plan_time(), random_suffix=suffix)
+
+
+def _fixed_doctor_plan_time() -> datetime:
+    return datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)

--- a/tests/services/test_system_doctor.py
+++ b/tests/services/test_system_doctor.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/services/test_system_doctor.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for the read-only SystemDoctor skeleton."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from types import MappingProxyType
+from typing import Iterator
+
+import pytest
+
+from ecli.services.models.doctor import DoctorContext, DoctorFinding, DoctorSeverity
+from ecli.services.models.plan import CommandPlan, PlanSource, PlanStatus
+from ecli.services.system_doctor import SystemDoctor
+
+
+@pytest.fixture
+def workspace(request: pytest.FixtureRequest) -> Iterator[Path]:
+    repo_logs = Path.cwd() / "logs" / "test-system-doctor"
+    test_root = repo_logs / request.node.name.replace("/", "_").replace(":", "_")
+    shutil.rmtree(test_root, ignore_errors=True)
+    test_root.mkdir(parents=True)
+    try:
+        yield test_root
+    finally:
+        shutil.rmtree(test_root, ignore_errors=True)
+
+
+def snapshot_tree(root: Path) -> set[str]:
+    return {str(path.relative_to(root)) for path in root.rglob("*")}
+
+
+def test_doctor_severity_values_are_stable() -> None:
+    assert [severity.value for severity in DoctorSeverity] == [
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "CRITICAL",
+    ]
+
+
+def test_doctor_finding_is_typed_and_json_serializable() -> None:
+    finding = DoctorFinding(
+        finding_id="DOCTOR-TEST-001",
+        title="Example",
+        severity=DoctorSeverity.WARNING,
+        category="config",
+        description="Example finding",
+        affected_resources=("logs",),
+        remediation_available=True,
+        remediation_plan_id="plan-20260101T000000Z-12345678",
+        metadata={"nested": {"path": Path("logs")}},
+    )
+
+    payload = finding.as_dict()
+
+    assert payload["severity"] == "WARNING"
+    assert payload["affected_resources"] == ["logs"]
+    json.dumps(payload, sort_keys=True)
+
+
+def test_doctor_context_copies_mutable_fields() -> None:
+    categories = ["config"]
+    metadata = {"key": "value"}
+    context = DoctorContext(categories=categories, metadata=metadata)
+
+    categories.append("tooling")
+    metadata["key"] = "changed"
+
+    assert context.categories == ("config",)
+    assert isinstance(context.metadata, MappingProxyType)
+    assert context.metadata["key"] == "value"
+    with pytest.raises(TypeError):
+        context.metadata["new"] = "blocked"  # type: ignore[index]
+
+
+def test_detect_problems_returns_findings_list(workspace: Path) -> None:
+    doctor = SystemDoctor(
+        logs_root=workspace,
+        kvm_path=workspace / "missing-kvm",
+        tool_checks=(),
+    )
+
+    findings = doctor.detect_problems(
+        DoctorContext(project_root=workspace, categories=("virtualization",))
+    )
+
+    assert isinstance(findings, list)
+    assert all(isinstance(finding, DoctorFinding) for finding in findings)
+
+
+def test_category_filtering_works_deterministically(workspace: Path) -> None:
+    missing_logs = workspace / "missing-logs"
+    doctor = SystemDoctor(
+        logs_root=missing_logs,
+        kvm_path=workspace / "missing-kvm",
+        tool_checks=("missing-tool",),
+    )
+
+    findings = doctor.detect_problems(DoctorContext(categories=("config",)))
+
+    assert [finding.finding_id for finding in findings] == ["DOCTOR-CONFIG-001"]
+    assert {finding.category for finding in findings} == {"config"}
+
+
+def test_check_tool_available_uses_monkeypatched_shutil_which(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_which(tool_name: str) -> str | None:
+        calls.append(tool_name)
+        return "/usr/bin/git" if tool_name == "git" else None
+
+    monkeypatch.setattr("ecli.services.system_doctor.shutil.which", fake_which)
+
+    doctor = SystemDoctor(tool_checks=())
+
+    assert doctor.check_tool_available("git") is True
+    assert doctor.check_tool_available("missing") is False
+    assert calls == ["git", "missing"]
+
+
+def test_check_kvm_access_handles_missing_device_without_crashing(
+    workspace: Path,
+) -> None:
+    doctor = SystemDoctor(kvm_path=workspace / "missing-kvm")
+
+    assert doctor.check_kvm_access() is False
+
+
+def test_existing_project_root_produces_no_error_finding(workspace: Path) -> None:
+    doctor = SystemDoctor(tool_checks=())
+
+    findings = doctor.check_project_root(DoctorContext(project_root=workspace))
+
+    assert findings == []
+
+
+def test_missing_project_root_produces_structured_finding(workspace: Path) -> None:
+    missing_project = workspace / "does-not-exist"
+    doctor = SystemDoctor(tool_checks=())
+
+    findings = doctor.check_project_root(DoctorContext(project_root=missing_project))
+
+    assert [finding.finding_id for finding in findings] == ["DOCTOR-PATH-002"]
+    assert findings[0].severity is DoctorSeverity.ERROR
+    assert findings[0].affected_resources == (str(missing_project.resolve()),)
+
+
+def test_logs_directory_check_is_read_only_and_does_not_create_files(
+    workspace: Path,
+) -> None:
+    missing_logs = workspace / "missing-logs"
+    doctor = SystemDoctor(logs_root=missing_logs, tool_checks=())
+
+    findings = doctor.check_logs_directory(DoctorContext(project_root=workspace))
+
+    assert [finding.finding_id for finding in findings] == ["DOCTOR-CONFIG-001"]
+    assert findings[0].remediation_available is True
+    assert not missing_logs.exists()
+
+
+def test_propose_remediation_returns_command_plan_without_execution(
+    workspace: Path,
+) -> None:
+    missing_logs = workspace / "missing-logs"
+    doctor = SystemDoctor(logs_root=missing_logs, tool_checks=())
+    finding = doctor.check_logs_directory(DoctorContext(project_root=workspace))[0]
+
+    plan = doctor.propose_remediation(finding)
+
+    assert isinstance(plan, CommandPlan)
+    assert plan.status is PlanStatus.DRAFT
+    assert plan.source is PlanSource.DOCTOR
+    assert plan.confirmation_required is True
+    assert plan.commands[0].argv == ["mkdir", "-p", str(missing_logs.resolve())]
+
+
+def test_proposed_remediation_is_traceable_to_finding_id(workspace: Path) -> None:
+    doctor = SystemDoctor(logs_root=workspace / "missing-logs", tool_checks=())
+    finding = doctor.check_logs_directory(DoctorContext(project_root=workspace))[0]
+
+    plan = doctor.propose_remediation(finding)
+
+    assert plan is not None
+    assert plan.metadata["finding_id"] == finding.finding_id
+    assert plan.commands[0].metadata["finding_id"] == finding.finding_id
+    assert plan.plan_id == finding.remediation_plan_id
+
+
+def test_propose_remediation_returns_none_when_not_available() -> None:
+    finding = DoctorFinding(
+        finding_id="DOCTOR-PATH-001",
+        title="Project root is not set",
+        severity=DoctorSeverity.WARNING,
+        category="path-policy",
+        description="No project root",
+        remediation_available=False,
+    )
+
+    assert SystemDoctor(tool_checks=()).propose_remediation(finding) is None
+
+
+def test_no_mutation_occurs_during_read_only_checks(workspace: Path) -> None:
+    project = workspace / "project"
+    project.mkdir()
+    before = snapshot_tree(workspace)
+    doctor = SystemDoctor(
+        logs_root=workspace,
+        kvm_path=workspace / "missing-kvm",
+        tool_checks=(),
+    )
+
+    doctor.detect_problems(DoctorContext(project_root=project))
+
+    assert snapshot_tree(workspace) == before
+
+
+def test_source_scan_has_no_execution_privilege_or_network_calls() -> None:
+    source = Path("src/ecli/services/system_doctor.py").read_text(encoding="utf-8")
+
+    forbidden_tokens = (
+        "subprocess",
+        "Popen",
+        "os.system",
+        ".run(",
+        "sudo",
+        "doas",
+        "pkexec",
+        "chmod",
+        "chown",
+        "usermod",
+        "modprobe",
+        "socket",
+        "requests",
+        "urllib",
+        "aiohttp",
+    )
+    assert all(token not in source for token in forbidden_tokens)
+
+
+def test_all_test_workspaces_remain_under_logs(workspace: Path) -> None:
+    logs_root = (Path.cwd() / "logs").resolve(strict=False)
+
+    assert workspace.resolve(strict=False).is_relative_to(logs_root)


### PR DESCRIPTION
Closes #48

Implemented Phase 1C SystemDoctor read-only skeleton.

Scope:
- DoctorSeverity model
- DoctorFinding model
- DoctorContext model
- read-only SystemDoctor service
- deterministic category filtering
- read-only tool availability checks via shutil.which
- read-only /dev/kvm existence/access check
- project root diagnostics
- repository logs/ directory diagnostics
- remediation plan proposal only, never execution
- deterministic finding IDs and stable ordering
- focused SystemDoctor tests

Read-only guarantees:
- no real remediation
- no privileged execution
- no subprocess usage
- no Popen usage
- no os.system usage
- no shell execution
- no sudo/doas/pkexec invocation
- no package installation
- no chmod/chown/usermod/modprobe
- no network calls
- no telemetry

Not included:
- no CLI wiring
- no ServiceRegistry wiring
- no Ecli.py changes
- no __main__.py changes
- no UI changes
- no VMLab changes
- no runtime execution path

Validation:
- python3 -m pytest tests/services/test_system_doctor.py -v
- python3 -m pytest tests/services/test_privileged_action_service.py -v
- python3 -m pytest tests/services/test_audit_log_service.py -v
- python3 -m pytest tests/services/test_policy_engine.py -v
- python3 -m pytest tests/services/test_command_plan_models.py -v
- python3 -m pytest tests/services/test_plan_validation.py -v
- python3 -m pytest tests/services/test_command_plan_exports.py -v
- python3 -m pytest tests/services/test_config_service.py -v
- python3 -m pytest tests/services/test_config_migration.py -v
- python3 -m pytest tests/services/test_project_service.py -v
- python3 -m pytest tests/test_smoke.py -v
- python3 -m compileall src
- ruff check src/ecli/services tests/services
- ruff format --check src/ecli/services tests/services
- ./scripts/check-log-invariant.sh
- git diff --check
