### PR TITLE
feat: connect SystemDoctor findings to CommandPlan generation

### DIFF
--- a/src/ecli/services/command_plan_service.py
+++ b/src/ecli/services/command_plan_service.py
@@ -15,11 +15,22 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import shlex
+from datetime import UTC, datetime
 from typing import Any
 
-from ecli.services.models.plan import CommandPlan, CommandStep
+from ecli.services.models.doctor import DoctorFinding, DoctorSeverity
+from ecli.services.models.plan import (
+    CommandPlan,
+    CommandStep,
+    PlanCategory,
+    PlanRisk,
+    PlanSource,
+    PlanStatus,
+    new_plan_id,
+)
 from ecli.services.validators.plan_validator import SENSITIVE_METADATA_KEYS
 
 
@@ -28,6 +39,38 @@ REDACTION_TEXT = "<redacted>"
 
 class CommandPlanService:
     """Command plan service utilities for Phase 1A."""
+
+    def create_plan_from_doctor_finding(
+        self,
+        finding: DoctorFinding,
+        *,
+        actor: str = "system-doctor",
+    ) -> CommandPlan | None:
+        """Create a draft-only remediation preview plan from a doctor finding."""
+        if not finding.remediation_available:
+            return None
+
+        command = _doctor_finding_step(finding)
+        requires_privilege = _doctor_finding_requires_privilege(finding)
+        return CommandPlan(
+            plan_id=finding.remediation_plan_id or _doctor_plan_id(finding),
+            title=f"Doctor remediation preview: {finding.title}",
+            description=(
+                "Preview-only remediation plan generated from SystemDoctor finding "
+                f"{finding.finding_id}: {finding.description}"
+            ),
+            category=_plan_category_for_finding(finding),
+            risk=_plan_risk_for_finding(finding),
+            status=PlanStatus.DRAFT,
+            commands=[command],
+            confirmation_required=_doctor_finding_requires_confirmation(finding),
+            requires_privilege=requires_privilege,
+            created_at=_doctor_plan_time(),
+            created_by=actor,
+            source=PlanSource.DOCTOR,
+            affected_resources=list(finding.affected_resources),
+            metadata=_doctor_trace_metadata(finding),
+        )
 
     def export_json(self, plan: CommandPlan) -> str:
         """Export a command plan as deterministic redacted JSON."""
@@ -147,3 +190,96 @@ def _safe_comment(value: str) -> str:
 
 def _markdown_text(value: str) -> str:
     return value.replace("`", "\\`")
+
+
+def _doctor_finding_step(finding: DoctorFinding) -> CommandStep:
+    if finding.finding_id == "DOCTOR-CONFIG-001":
+        target = finding.affected_resources[0] if finding.affected_resources else "logs"
+        return CommandStep(
+            step_id=_doctor_step_id(finding),
+            title="Create repository logs directory",
+            argv=["mkdir", "-p", target],
+            display=f"mkdir -p {target}",
+            requires_privilege=False,
+            destructive=False,
+            metadata=_doctor_trace_metadata(finding),
+        )
+
+    category = _safe_token(finding.category)
+    return CommandStep(
+        step_id=_doctor_step_id(finding),
+        title=f"Preview remediation for {finding.finding_id}",
+        argv=["ecli-doctor-remediation-preview", category, finding.finding_id],
+        display=f"Preview remediation for {finding.finding_id}",
+        requires_privilege=_doctor_finding_requires_privilege(finding),
+        destructive=False,
+        metadata=_doctor_trace_metadata(finding),
+    )
+
+
+def _doctor_trace_metadata(finding: DoctorFinding) -> dict[str, Any]:
+    return {
+        "doctor_finding_id": finding.finding_id,
+        "doctor_finding_category": finding.category,
+        "doctor_finding_severity": finding.severity.value,
+        "doctor_remediation_source": "system_doctor",
+        "finding_id": finding.finding_id,
+        "readonly": True,
+    }
+
+
+def _plan_risk_for_finding(finding: DoctorFinding) -> PlanRisk:
+    if finding.severity is DoctorSeverity.CRITICAL:
+        return PlanRisk.CRITICAL
+    if finding.severity is DoctorSeverity.ERROR:
+        return (
+            PlanRisk.HIGH
+            if _doctor_finding_requires_privilege(finding)
+            else PlanRisk.MEDIUM
+        )
+    if _doctor_finding_requires_privilege(finding):
+        return PlanRisk.MEDIUM
+    return PlanRisk.LOW
+
+
+def _plan_category_for_finding(finding: DoctorFinding) -> PlanCategory:
+    return {
+        "config": PlanCategory.DOCTOR,
+        "permissions": PlanCategory.SYSTEM,
+        "tooling": PlanCategory.SYSTEM,
+        "virtualization": PlanCategory.VM,
+        "path-policy": PlanCategory.FILE,
+    }.get(finding.category, PlanCategory.DOCTOR)
+
+
+def _doctor_finding_requires_confirmation(finding: DoctorFinding) -> bool:
+    return finding.severity is DoctorSeverity.CRITICAL or finding.category in {
+        "config",
+        "permissions",
+        "tooling",
+        "virtualization",
+        "path-policy",
+    }
+
+
+def _doctor_finding_requires_privilege(finding: DoctorFinding) -> bool:
+    return finding.category in {"permissions", "virtualization"}
+
+
+def _doctor_plan_id(finding: DoctorFinding) -> str:
+    suffix = hashlib.sha256(finding.finding_id.encode("utf-8")).hexdigest()[:8]
+    return new_plan_id(now=_doctor_plan_time(), random_suffix=suffix)
+
+
+def _doctor_step_id(finding: DoctorFinding) -> str:
+    return f"doctor-remediation-{_safe_token(finding.finding_id)}"
+
+
+def _doctor_plan_time() -> datetime:
+    return datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+
+
+def _safe_token(value: str) -> str:
+    return "".join(
+        character.lower() if character.isalnum() else "-" for character in value
+    ).strip("-")

--- a/src/ecli/services/system_doctor.py
+++ b/src/ecli/services/system_doctor.py
@@ -21,14 +21,10 @@ import shutil
 from datetime import UTC, datetime
 from pathlib import Path
 
+from ecli.services.command_plan_service import CommandPlanService
 from ecli.services.models.doctor import DoctorContext, DoctorFinding, DoctorSeverity
 from ecli.services.models.plan import (
     CommandPlan,
-    CommandStep,
-    PlanCategory,
-    PlanRisk,
-    PlanSource,
-    PlanStatus,
     new_plan_id,
 )
 
@@ -206,47 +202,9 @@ class SystemDoctor:
 
     def propose_remediation(self, finding: DoctorFinding) -> CommandPlan | None:
         """Return a proposed CommandPlan for supported findings without execution."""
-        if not finding.remediation_available:
-            return None
-        if finding.finding_id != "DOCTOR-CONFIG-001":
-            return None
-
-        plan_id = finding.remediation_plan_id or _remediation_plan_id(
-            finding.finding_id
-        )
-        logs_path = (
-            finding.affected_resources[0]
-            if finding.affected_resources
-            else str(self._logs_root)
-        )
-        return CommandPlan(
-            plan_id=plan_id,
-            title="Create repository logs directory",
-            description="Proposed remediation only; SystemDoctor does not execute it.",
-            category=PlanCategory.DOCTOR,
-            risk=PlanRisk.LOW,
-            status=PlanStatus.DRAFT,
-            commands=[
-                CommandStep(
-                    step_id="doctor-create-logs-dir",
-                    title="Create logs directory",
-                    argv=["mkdir", "-p", logs_path],
-                    display=f"mkdir -p {logs_path}",
-                    destructive=False,
-                    metadata={"finding_id": finding.finding_id},
-                )
-            ],
-            confirmation_required=True,
-            requires_privilege=False,
-            created_at=_fixed_doctor_plan_time(),
-            created_by="system_doctor",
-            source=PlanSource.DOCTOR,
-            affected_resources=[logs_path],
-            metadata={
-                "finding_id": finding.finding_id,
-                "service": "SystemDoctor",
-                "readonly": True,
-            },
+        return CommandPlanService().create_plan_from_doctor_finding(
+            finding,
+            actor="system_doctor",
         )
 
 

--- a/tests/services/test_doctor_plan_integration.py
+++ b/tests/services/test_doctor_plan_integration.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/services/test_doctor_plan_integration.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for SystemDoctor finding to CommandPlan integration."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from ecli.services.command_plan_service import CommandPlanService
+from ecli.services.models.doctor import DoctorContext, DoctorFinding, DoctorSeverity
+from ecli.services.models.plan import (
+    CommandPlan,
+    PlanCategory,
+    PlanRisk,
+    PlanSource,
+    PlanStatus,
+)
+from ecli.services.system_doctor import SystemDoctor
+from ecli.services.validators.plan_validator import validate_command_plan
+
+
+@pytest.fixture
+def workspace(request: pytest.FixtureRequest) -> Iterator[Path]:
+    repo_logs = Path.cwd() / "logs" / "test-doctor-plan-integration"
+    test_root = repo_logs / request.node.name.replace("/", "_").replace(":", "_")
+    shutil.rmtree(test_root, ignore_errors=True)
+    test_root.mkdir(parents=True)
+    try:
+        yield test_root
+    finally:
+        shutil.rmtree(test_root, ignore_errors=True)
+
+
+def snapshot_tree(root: Path) -> set[str]:
+    return {str(path.relative_to(root)) for path in root.rglob("*")}
+
+
+def finding(
+    *,
+    finding_id: str = "DOCTOR-CONFIG-001",
+    severity: DoctorSeverity = DoctorSeverity.WARNING,
+    category: str = "config",
+    remediation_available: bool = True,
+    affected_resources: tuple[str, ...] = ("logs",),
+) -> DoctorFinding:
+    return DoctorFinding(
+        finding_id=finding_id,
+        title="Repository logs directory is missing",
+        severity=severity,
+        category=category,
+        description="Repository-level logs/ is absent.",
+        affected_resources=affected_resources,
+        remediation_available=remediation_available,
+        remediation_plan_id="plan-20260101T000000Z-12345678"
+        if remediation_available
+        else None,
+        metadata={"check": "logs_directory"},
+    )
+
+
+def test_remediation_available_finding_converts_to_command_plan() -> None:
+    plan = CommandPlanService().create_plan_from_doctor_finding(finding())
+
+    assert isinstance(plan, CommandPlan)
+    assert plan.commands
+    assert plan.commands[0].argv == ["mkdir", "-p", "logs"]
+
+
+def test_remediation_unavailable_finding_returns_none() -> None:
+    plan = CommandPlanService().create_plan_from_doctor_finding(
+        finding(remediation_available=False)
+    )
+
+    assert plan is None
+
+
+def test_plan_metadata_includes_finding_id_category_and_severity() -> None:
+    source_finding = finding(severity=DoctorSeverity.ERROR, category="path-policy")
+
+    plan = CommandPlanService().create_plan_from_doctor_finding(source_finding)
+
+    assert plan is not None
+    assert plan.metadata["doctor_finding_id"] == source_finding.finding_id
+    assert plan.metadata["doctor_finding_category"] == "path-policy"
+    assert plan.metadata["doctor_finding_severity"] == "ERROR"
+    assert plan.metadata["doctor_remediation_source"] == "system_doctor"
+
+
+def test_plan_title_and_description_are_deterministic_preview_context() -> None:
+    source_finding = finding()
+
+    first = CommandPlanService().create_plan_from_doctor_finding(source_finding)
+    second = CommandPlanService().create_plan_from_doctor_finding(source_finding)
+
+    assert first is not None
+    assert second is not None
+    assert first.title == second.title
+    assert first.description == second.description
+    assert "Doctor remediation preview" in first.title
+    assert source_finding.finding_id in first.description
+
+
+def test_plan_status_is_draft_and_non_executing() -> None:
+    plan = CommandPlanService().create_plan_from_doctor_finding(finding())
+
+    assert plan is not None
+    assert plan.status is PlanStatus.DRAFT
+    assert plan.status is not PlanStatus.EXECUTING
+    assert "executed" not in plan.as_dict()
+
+
+def test_plan_source_is_doctor() -> None:
+    plan = CommandPlanService().create_plan_from_doctor_finding(finding())
+
+    assert plan is not None
+    assert plan.source is PlanSource.DOCTOR
+
+
+@pytest.mark.parametrize(
+    ("category", "severity", "expected_category", "expected_risk"),
+    [
+        ("config", DoctorSeverity.WARNING, PlanCategory.DOCTOR, PlanRisk.LOW),
+        ("path-policy", DoctorSeverity.ERROR, PlanCategory.FILE, PlanRisk.MEDIUM),
+        ("permissions", DoctorSeverity.WARNING, PlanCategory.SYSTEM, PlanRisk.MEDIUM),
+        ("virtualization", DoctorSeverity.ERROR, PlanCategory.VM, PlanRisk.HIGH),
+        ("tooling", DoctorSeverity.CRITICAL, PlanCategory.SYSTEM, PlanRisk.CRITICAL),
+    ],
+)
+def test_plan_risk_and_category_mapping_is_deterministic(
+    category: str,
+    severity: DoctorSeverity,
+    expected_category: PlanCategory,
+    expected_risk: PlanRisk,
+) -> None:
+    plan = CommandPlanService().create_plan_from_doctor_finding(
+        finding(
+            finding_id=f"DOCTOR-{category.upper()}-001",
+            category=category,
+            severity=severity,
+        )
+    )
+
+    assert plan is not None
+    assert plan.category is expected_category
+    assert plan.risk is expected_risk
+
+
+def test_critical_finding_produces_confirmation_required_plan() -> None:
+    plan = CommandPlanService().create_plan_from_doctor_finding(
+        finding(severity=DoctorSeverity.CRITICAL, category="tooling")
+    )
+
+    assert plan is not None
+    assert plan.confirmation_required is True
+    assert plan.risk is PlanRisk.CRITICAL
+
+
+def test_informational_finding_does_not_create_privileged_or_destructive_step() -> None:
+    plan = CommandPlanService().create_plan_from_doctor_finding(
+        finding(severity=DoctorSeverity.INFO, category="config")
+    )
+
+    assert plan is not None
+    assert plan.requires_privilege is False
+    assert plan.commands[0].requires_privilege is False
+    assert plan.commands[0].destructive is False
+
+
+def test_generated_plan_has_no_runtime_side_effects(workspace: Path) -> None:
+    before = snapshot_tree(workspace)
+
+    CommandPlanService().create_plan_from_doctor_finding(
+        finding(affected_resources=(str(workspace / "missing-logs"),))
+    )
+
+    assert snapshot_tree(workspace) == before
+    assert not (workspace / "missing-logs").exists()
+
+
+def test_generated_plan_exports_to_json_and_markdown() -> None:
+    service = CommandPlanService()
+    plan = service.create_plan_from_doctor_finding(finding())
+
+    assert plan is not None
+    json_payload = json.loads(service.export_json(plan))
+    markdown = service.export_markdown(plan)
+
+    assert json_payload["metadata"]["doctor_finding_id"] == "DOCTOR-CONFIG-001"
+    assert "# Command Plan: Doctor remediation preview" in markdown
+    assert "doctor_finding_id" in markdown
+
+
+def test_generated_plan_validates_with_existing_plan_validator() -> None:
+    plan = CommandPlanService().create_plan_from_doctor_finding(finding())
+
+    assert plan is not None
+    assert validate_command_plan(plan) == []
+
+
+def test_system_doctor_propose_remediation_delegates_to_command_plan_service(
+    workspace: Path,
+) -> None:
+    doctor = SystemDoctor(logs_root=workspace / "missing-logs", tool_checks=())
+    source_finding = doctor.check_logs_directory(DoctorContext(project_root=workspace))[
+        0
+    ]
+
+    plan = doctor.propose_remediation(source_finding)
+
+    assert plan is not None
+    assert plan.metadata["doctor_finding_id"] == source_finding.finding_id
+    assert plan.commands[0].argv == ["mkdir", "-p", str(workspace / "missing-logs")]
+
+
+def test_source_scan_has_no_execution_privilege_or_network_usage() -> None:
+    combined_source = "\n".join(
+        [
+            Path("src/ecli/services/system_doctor.py").read_text(encoding="utf-8"),
+            Path("src/ecli/services/command_plan_service.py").read_text(
+                encoding="utf-8"
+            ),
+        ]
+    )
+
+    forbidden_tokens = (
+        "subprocess",
+        "Popen",
+        "os.system",
+        ".run(",
+        "sudo",
+        "doas",
+        "pkexec",
+        "chmod",
+        "chown",
+        "usermod",
+        "modprobe",
+        "socket",
+        "requests",
+        "urllib",
+        "aiohttp",
+    )
+    assert all(token not in combined_source for token in forbidden_tokens)
+
+
+def test_all_test_workspaces_remain_under_logs(workspace: Path) -> None:
+    logs_root = (Path.cwd() / "logs").resolve(strict=False)
+
+    assert workspace.resolve(strict=False).is_relative_to(logs_root)


### PR DESCRIPTION
Closes #49

Connected SystemDoctor findings to service-owned CommandPlan generation.

Scope:
- added draft CommandPlan generation from DoctorFinding
- added required traceability metadata:
  - doctor_finding_id
  - doctor_finding_category
  - doctor_finding_severity
  - doctor_remediation_source
- delegated SystemDoctor remediation proposal to CommandPlanService
- deterministic severity/category to plan risk/category mapping
- PlanStatus.DRAFT for generated plans
- PlanSource.DOCTOR for generated plans
- draft-only, preview-only remediation plans
- export compatibility with existing CommandPlanService exports
- validator compatibility tests
- focused DoctorFinding to CommandPlan integration tests

Safety guarantees:
- no real remediation
- no plan execution
- no privileged execution
- no subprocess usage
- no Popen usage
- no os.system usage
- no shell execution
- no sudo/doas/pkexec invocation
- no package installation
- no chmod/chown/usermod/modprobe
- no network calls
- no telemetry

Not included:
- no CLI wiring
- no ServiceRegistry wiring
- no Ecli.py changes
- no __main__.py changes
- no UI changes
- no VMLab changes
- no runtime execution path

Validation:
- python3 -m pytest tests/services/test_doctor_plan_integration.py -v
- python3 -m pytest tests/services/test_system_doctor.py -v
- python3 -m pytest tests/services/test_privileged_action_service.py -v
- python3 -m pytest tests/services/test_audit_log_service.py -v
- python3 -m pytest tests/services/test_policy_engine.py -v
- python3 -m pytest tests/services/test_command_plan_models.py -v
- python3 -m pytest tests/services/test_plan_validation.py -v
- python3 -m pytest tests/services/test_command_plan_exports.py -v
- python3 -m pytest tests/services/test_config_service.py -v
- python3 -m pytest tests/services/test_config_migration.py -v
- python3 -m pytest tests/services/test_project_service.py -v
- python3 -m pytest tests/test_smoke.py -v
- python3 -m compileall src
- ruff check src/ecli/services tests/services
- ruff format --check src/ecli/services tests/services
- ./scripts/check-log-invariant.sh
- git diff --check
