### PR TITLE
test: characterize existing TUI panels and keybindings

### DIFF
--- a/tests/characterization/test_existing_editor_entrypoints.py
+++ b/tests/characterization/test_existing_editor_entrypoints.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/characterization/test_existing_editor_entrypoints.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Characterization tests for existing editor/TUI import entrypoints."""
+
+from __future__ import annotations
+
+import importlib
+
+from ecli.core.Ecli import Ecli
+from ecli.ui.TerminalAppMode import TerminalAppMode
+
+
+def test_existing_package_import_smoke_still_works() -> None:
+    package = importlib.import_module("ecli")
+
+    assert hasattr(package, "__version__")
+
+
+def test_editor_and_tui_modules_import_without_constructing_runtime() -> None:
+    modules = [
+        "ecli.core.Ecli",
+        "ecli.ui.KeyBinder",
+        "ecli.ui.PanelManager",
+        "ecli.ui.panels",
+        "ecli.ui.DrawScreen",
+        "ecli.ui.TerminalAppMode",
+    ]
+
+    imported = [importlib.import_module(module) for module in modules]
+
+    assert [module.__name__ for module in imported] == modules
+
+
+def test_existing_editor_methods_for_help_and_panels_are_present() -> None:
+    expected_methods = (
+        "show_help",
+        "show_git_panel",
+        "toggle_widget_panel",
+        "select_ai_provider_and_ask",
+        "toggle_file_browser",
+        "show_ai_panel",
+        "toggle_focus",
+    )
+
+    for method_name in expected_methods:
+        assert callable(getattr(Ecli, method_name))
+
+
+def test_terminal_app_mode_entry_and_exit_methods_remain_available() -> None:
+    mode = TerminalAppMode()
+
+    assert callable(mode.enter)
+    assert callable(mode.exit)

--- a/tests/characterization/test_existing_keybindings.py
+++ b/tests/characterization/test_existing_keybindings.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/characterization/test_existing_keybindings.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Characterization tests for existing TUI keybinding behavior."""
+
+from __future__ import annotations
+
+import curses
+import threading
+from typing import Any
+
+from ecli.core.Ecli import Ecli
+from ecli.ui.KeyBinder import KeyBinder
+
+
+class FakeHistory:
+    def undo(self) -> bool:
+        return True
+
+    def redo(self) -> bool:
+        return True
+
+
+class FakeWindow:
+    def getmaxyx(self) -> tuple[int, int]:
+        return (30, 100)
+
+
+class FakeEditor:
+    def __init__(self) -> None:
+        """Initialize a non-interactive editor double for KeyBinder tests."""
+        self.history = FakeHistory()
+        self.config: dict[str, Any] = {}
+        self.stdscr = FakeWindow()
+        self.is_lightweight = False
+        self.linter_bridge = object()
+        self.async_engine = object()
+        self.status_message = "Ready"
+        self._lexer = None
+        self._state_lock = threading.RLock()
+        self.called: list[str] = []
+
+    def _record(self, name: str) -> bool:
+        self.called.append(name)
+        return True
+
+    def _set_status_message(self, message: str) -> bool:
+        self.status_message = message
+        return True
+
+    def open_file(self) -> bool:
+        return self._record("open_file")
+
+    def save_file(self) -> bool:
+        return self._record("save_file")
+
+    def save_file_as(self) -> bool:
+        return self._record("save_file_as")
+
+    def new_file(self) -> bool:
+        return self._record("new_file")
+
+    def copy(self) -> bool:
+        return self._record("copy")
+
+    def cut(self) -> bool:
+        return self._record("cut")
+
+    def paste(self) -> bool:
+        return self._record("paste")
+
+    def select_all(self) -> bool:
+        return self._record("select_all")
+
+    def handle_delete(self) -> bool:
+        return self._record("handle_delete")
+
+    def exit_editor(self) -> bool:
+        return self._record("exit_editor")
+
+    def handle_home(self) -> bool:
+        return self._record("handle_home")
+
+    def handle_end(self) -> bool:
+        return self._record("handle_end")
+
+    def handle_page_up(self) -> bool:
+        return self._record("handle_page_up")
+
+    def handle_page_down(self) -> bool:
+        return self._record("handle_page_down")
+
+    def extend_selection_up(self) -> bool:
+        return self._record("extend_selection_up")
+
+    def extend_selection_down(self) -> bool:
+        return self._record("extend_selection_down")
+
+    def extend_selection_left(self) -> bool:
+        return self._record("extend_selection_left")
+
+    def extend_selection_right(self) -> bool:
+        return self._record("extend_selection_right")
+
+    def select_to_home(self) -> bool:
+        return self._record("select_to_home")
+
+    def select_to_end(self) -> bool:
+        return self._record("select_to_end")
+
+    def find_prompt(self) -> bool:
+        return self._record("find_prompt")
+
+    def find_next(self) -> bool:
+        return self._record("find_next")
+
+    def search_and_replace(self) -> bool:
+        return self._record("search_and_replace")
+
+    def goto_line(self) -> bool:
+        return self._record("goto_line")
+
+    def handle_smart_tab(self) -> bool:
+        return self._record("handle_smart_tab")
+
+    def handle_smart_unindent(self) -> bool:
+        return self._record("handle_smart_unindent")
+
+    def toggle_comment_block(self) -> bool:
+        return self._record("toggle_comment_block")
+
+    def toggle_insert_mode(self) -> bool:
+        return self._record("toggle_insert_mode")
+
+    def handle_up(self) -> bool:
+        return self._record("handle_up")
+
+    def handle_down(self) -> bool:
+        return self._record("handle_down")
+
+    def handle_left(self) -> bool:
+        return self._record("handle_left")
+
+    def handle_right(self) -> bool:
+        return self._record("handle_right")
+
+    def handle_backspace(self) -> bool:
+        return self._record("handle_backspace")
+
+    def handle_enter(self) -> bool:
+        return self._record("handle_enter")
+
+    def show_help(self) -> bool:
+        return self._record("show_help")
+
+    def handle_escape(self) -> bool:
+        return self._record("handle_escape")
+
+    def toggle_file_browser(self) -> bool:
+        return self._record("toggle_file_browser")
+
+    def toggle_focus(self) -> bool:
+        return self._record("toggle_focus")
+
+    def show_git_panel(self) -> bool:
+        return self._record("show_git_panel")
+
+    def toggle_widget_panel(self) -> bool:
+        return self._record("toggle_widget_panel")
+
+    def run_lint_async(self) -> bool:
+        return self._record("run_lint_async")
+
+    def show_lint_panel(self) -> bool:
+        return self._record("show_lint_panel")
+
+    def handle_resize(self) -> bool:
+        return self._record("handle_resize")
+
+    def insert_text(self, text: str) -> bool:
+        return self._record(f"insert_text:{text}")
+
+
+def make_keybinder() -> KeyBinder:
+    return KeyBinder(FakeEditor())  # type: ignore[arg-type]
+
+
+def method_name_for_key(binder: KeyBinder, key: int | str) -> str:
+    return binder.action_map[key].__name__
+
+
+def test_default_keybinding_definitions_preserve_known_help_and_panel_bindings() -> (
+    None
+):
+    binder = make_keybinder()
+
+    assert curses.KEY_F1 in binder.keybindings["help"]
+    assert curses.KEY_F7 in binder.keybindings["toggle_widget_panel"]
+    assert curses.KEY_F10 in binder.keybindings["toggle_file_browser"]
+    assert curses.KEY_F9 in binder.keybindings["git_menu"]
+    assert curses.KEY_F4 in binder.keybindings["lint"]
+    assert curses.KEY_F8 not in binder.action_map
+
+
+def test_action_map_keeps_existing_help_ai_file_manager_and_git_entrypoints() -> None:
+    binder = make_keybinder()
+
+    assert method_name_for_key(binder, curses.KEY_F1) == "show_help"
+    assert method_name_for_key(binder, curses.KEY_F7) == "toggle_widget_panel"
+    assert method_name_for_key(binder, curses.KEY_F10) == "toggle_file_browser"
+    assert method_name_for_key(binder, curses.KEY_F9) == "show_git_panel"
+
+
+def test_current_f4_behavior_remains_diagnostics_not_git_panel() -> None:
+    binder = make_keybinder()
+
+    assert method_name_for_key(binder, curses.KEY_F4) == "run_lint_async"
+    assert method_name_for_key(binder, curses.KEY_F4) != "show_git_panel"
+
+
+def test_help_text_keeps_existing_panel_and_tool_labels_discoverable() -> None:
+    fake_editor = type("HelpEditor", (), {"config": {}})()
+
+    lines = Ecli._build_help_lines(fake_editor)  # type: ignore[arg-type]
+    rendered = "\n".join(lines)
+
+    assert "F1" in rendered
+    assert "This help screen" in rendered
+    assert "F7" in rendered
+    assert "AI Code Assistant" in rendered
+    assert "F10" in rendered
+    assert "File Manager" in rendered
+    assert "F9" in rendered
+    assert "Git menu" in rendered

--- a/tests/characterization/test_existing_tui_panels.py
+++ b/tests/characterization/test_existing_tui_panels.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/characterization/test_existing_tui_panels.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Characterization tests for existing panel classes and transitions."""
+
+from __future__ import annotations
+
+import curses
+import shutil
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from ecli.ui.PanelManager import PanelManager
+from ecli.ui.panels import AiResponsePanel, BasePanel, FileBrowserPanel, GitPanel
+
+
+class FakeWindow:
+    def __init__(self) -> None:
+        """Initialize a fake curses window."""
+        self.keypad_values: list[bool] = []
+
+    def getmaxyx(self) -> tuple[int, int]:
+        return (30, 100)
+
+    def keypad(self, value: bool) -> None:
+        self.keypad_values.append(value)
+
+    def clear(self) -> None:
+        return None
+
+    def refresh(self) -> None:
+        return None
+
+
+class FakeEditor:
+    def __init__(self, workspace: Path | None = None) -> None:
+        """Initialize a panel-compatible editor double."""
+        self.stdscr = FakeWindow()
+        self.focus = "editor"
+        self._force_full_redraw = False
+        self.colors = {
+            "status": curses.A_BOLD,
+            "keyword": curses.A_BOLD,
+            "default": curses.A_NORMAL,
+            "comment": curses.A_DIM,
+            "function": curses.A_BOLD,
+        }
+        self.config: dict[str, Any] = {}
+        self.status_messages: list[str] = []
+        self.opened_files: list[str] = []
+        self.filename = None
+        self.git = None
+        self.panel_manager: Any = None
+        self.workspace = workspace
+
+    def _set_status_message(self, message: str) -> None:
+        self.status_messages.append(message)
+
+    def open_file(self, path: str) -> None:
+        self.opened_files.append(path)
+
+    def toggle_file_browser(self) -> None:
+        self.status_messages.append("toggle_file_browser")
+
+    def toggle_focus(self) -> None:
+        self.focus = "editor" if self.focus == "panel" else "panel"
+
+    def exit_editor(self) -> None:
+        self.status_messages.append("exit_editor")
+
+
+class DummyPanel(BasePanel):
+    def draw(self) -> None:
+        return None
+
+    def handle_key(self, key: Any) -> bool:
+        return key == "handled"
+
+
+@pytest.fixture
+def workspace(request: pytest.FixtureRequest) -> Iterator[Path]:
+    repo_logs = Path.cwd() / "logs" / "test-existing-tui-panels"
+    test_root = repo_logs / request.node.name.replace("/", "_").replace(":", "_")
+    shutil.rmtree(test_root, ignore_errors=True)
+    test_root.mkdir(parents=True)
+    try:
+        yield test_root
+    finally:
+        shutil.rmtree(test_root, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
+def fake_curses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("ecli.ui.panels.curses.newwin", lambda *args: FakeWindow())
+    monkeypatch.setattr("ecli.ui.panels.curses.curs_set", lambda value: None)
+    monkeypatch.setattr("ecli.ui.PanelManager.curses.curs_set", lambda value: None)
+    monkeypatch.setattr("ecli.ui.panels.curses.init_pair", lambda *args: None)
+    monkeypatch.setattr("ecli.ui.panels.curses.color_pair", lambda pair: pair)
+
+
+def test_panel_manager_default_registry_preserves_existing_panel_names() -> None:
+    editor = FakeEditor()
+
+    manager = PanelManager(editor)  # type: ignore[arg-type]
+
+    assert manager.registered_panels["ai_response"] is AiResponsePanel
+    assert manager.registered_panels["file_browser"] is FileBrowserPanel
+    assert "git" not in manager.registered_panels
+
+
+def test_panel_manager_show_close_and_toggle_transitions_are_stable() -> None:
+    editor = FakeEditor()
+    manager = PanelManager(editor)  # type: ignore[arg-type]
+    manager.registered_panels = {"dummy": DummyPanel}
+
+    manager.show_panel("dummy")
+
+    assert isinstance(manager.active_panel, DummyPanel)
+    assert manager.active_panel.visible is True
+    assert editor.focus == "panel"
+    assert editor._force_full_redraw is True
+    assert manager.is_panel_active() is True
+
+    manager.show_panel("dummy")
+
+    assert manager.active_panel is None
+    assert editor.focus == "editor"
+    assert manager.is_panel_active() is False
+
+
+def test_panel_manager_delegates_keys_to_active_panel() -> None:
+    editor = FakeEditor()
+    manager = PanelManager(editor)  # type: ignore[arg-type]
+    manager.registered_panels = {"dummy": DummyPanel}
+    manager.show_panel("dummy")
+
+    assert manager.handle_key("handled") is True
+    assert manager.handle_key("ignored") is False
+
+
+def test_panel_labels_and_titles_remain_stable() -> None:
+    assert "AI responses" in AiResponsePanel.__doc__
+    assert "FileBrowserPanel" in FileBrowserPanel.__doc__
+    assert "GitPanel" in GitPanel.__doc__
+
+    source = Path("src/ecli/ui/panels.py").read_text(encoding="utf-8")
+    assert 'self.title: str = kwargs.get("title", "AI Response")' in source
+    assert 'title = " Git Control "' in source
+    assert "F10/q:Close F12:Focus Enter:Open" in source
+    assert "^C:Copy | Shift+arr:Select | F7:Close | F12:Focus" in source
+
+
+def test_file_browser_right_arrow_enters_directory(workspace: Path) -> None:
+    child_dir = workspace / "child"
+    child_dir.mkdir()
+    editor = FakeEditor(workspace)
+
+    panel = FileBrowserPanel(
+        editor.stdscr,
+        editor,
+        start_path=str(workspace),  # type: ignore[arg-type]
+    )
+    panel.idx = next(
+        index
+        for index, entry in enumerate(panel.entries)
+        if entry and entry.name == "child"
+    )
+
+    assert panel.handle_key(curses.KEY_RIGHT) is True
+    assert panel.cwd == child_dir.resolve()
+
+
+def test_file_browser_right_arrow_opens_selected_file(workspace: Path) -> None:
+    target = workspace / "target.txt"
+    target.write_text("content\n", encoding="utf-8")
+    editor = FakeEditor(workspace)
+
+    panel = FileBrowserPanel(
+        editor.stdscr,
+        editor,
+        start_path=str(workspace),  # type: ignore[arg-type]
+    )
+    panel.idx = next(
+        index
+        for index, entry in enumerate(panel.entries)
+        if entry and entry.name == "target.txt"
+    )
+
+    assert panel.handle_key(curses.KEY_RIGHT) is True
+    assert editor.opened_files == [str(target.resolve())]
+    assert editor.status_messages[-1] == "Opened file: target.txt"
+
+
+def test_test_workspaces_remain_under_logs(workspace: Path) -> None:
+    logs_root = (Path.cwd() / "logs").resolve(strict=False)
+
+    assert workspace.resolve(strict=False).is_relative_to(logs_root)


### PR DESCRIPTION
Closes #52

Added characterization tests for existing ECLI editor/TUI behavior before adding new service panels.

Scope:
- characterized existing keybinding table
- characterized current editor/TUI entrypoints
- characterized existing PanelManager behavior
- characterized existing panel labels/chrome strings
- characterized File Manager right-arrow behavior for directory entry and file opening
- confirmed TUI/editor modules import without launching an interactive terminal
- used fake curses windows and repository logs/ test workspaces only

Important inspection finding:
- current repository code binds Git menu to F9
- current repository code binds Diagnostics/Lint to F4
- F8 remains unassigned in the characterized action map
- this PR preserves existing runtime behavior and does not change keybindings

Not included:
- no SystemDoctor panel
- no CommandPlan panel
- no Services panel
- no ServiceRegistry editor/runtime wiring
- no CLI wiring
- no VMLab implementation
- no version bump
- no release artifacts
- no runtime behavior changes

Validation:
- python3 -m pytest tests/test_smoke.py -v
- python3 -m pytest tests/services -v
- python3 -m pytest tests/characterization -v
- python3 -m compileall src
- ruff check src tests
- ruff format --check src tests
- ./scripts/check-log-invariant.sh
- git diff --check
