### PR TITLE
feat: add right-side service panels and graceful AI config errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 license-files = ["LICENSE*"]
-authors = [
-    { name = "Siergej Sobolewski", email = "s.sobolewski@hotmail.com" },
-]
+authors = [{ name = "Siergej Sobolewski", email = "s.sobolewski@hotmail.com" }]
 keywords = [
     "editor",
     "terminal",

--- a/src/ecli/core/AsyncEngine.py
+++ b/src/ecli/core/AsyncEngine.py
@@ -43,7 +43,12 @@ import queue
 import threading
 from typing import Any, Optional, cast
 
-from ecli.integrations.AI import BaseAiClient, get_ai_client
+from ecli.integrations.AI import (
+    AiConfigurationError,
+    BaseAiClient,
+    ai_configuration_panel_message,
+    get_ai_client,
+)
 
 
 # Let's define an alias for the queue elements to avoid repetition.
@@ -222,6 +227,22 @@ class AsyncEngine:
 
             else:
                 logging.warning(f"AsyncEngine received unknown task type: {task_type}")
+
+        except AiConfigurationError as e:
+            logging.info("AI provider configuration incomplete: %s", e)
+            self.to_ui_queue.put(
+                {
+                    "type": "ai_configuration_error",
+                    "task_type": task_type,
+                    "provider": e.provider,
+                    "env_var": e.env_var,
+                    "title": "AI provider is not configured",
+                    "text": ai_configuration_panel_message(
+                        e.provider,
+                        env_var=e.env_var,
+                    ),
+                }
+            )
 
         except Exception as e:
             error_message = f"Error executing async task '{task_type}': {e}"

--- a/src/ecli/core/Ecli.py
+++ b/src/ecli/core/Ecli.py
@@ -84,6 +84,7 @@ from ecli.core.CodeCommenter import CodeCommenter
 from ecli.core.History import History
 from ecli.integrations.GitBridge import GitBridge
 from ecli.integrations.LinterBridge import LinterBridge
+from ecli.services.registry import ServiceRegistry
 from ecli.ui.TerminalAppMode import TerminalAppMode
 from ecli.ui.DrawScreen import DrawScreen
 from ecli.ui.KeyBinder import KeyBinder
@@ -432,6 +433,7 @@ class Ecli:
         self._git_cmd_q: queue.Queue[str] = queue.Queue()
         self._async_results_q: queue.Queue[dict[str, Any]] = queue.Queue()
         self.internal_clipboard: str = ""
+        self.service_registry: Optional[ServiceRegistry] = None
 
     # --- Component Initialization ---
     def _initialize_components(self) -> None:
@@ -773,6 +775,51 @@ class Ecli:
         # No need to return anything here, as the panel manager handles the redraw.
         # This action always changes the UI state (shows a panel or a message),
         # so a redraw is always required.
+        return True
+
+    def _get_service_registry(self) -> ServiceRegistry:
+        """Return the editor-owned service registry, creating it lazily."""
+        if self.service_registry is not None:
+            return self.service_registry
+
+        project_root = (
+            Path(self.filename).parent
+            if self.filename and os.path.exists(self.filename)
+            else Path.cwd()
+        )
+        self.service_registry = ServiceRegistry.create(project_root=project_root)
+        return self.service_registry
+
+    def toggle_system_doctor_panel(self) -> bool:
+        """Open the read-only System Doctor service panel."""
+        if not self.panel_manager:
+            self._set_status_message("System Doctor panel not available.")
+            return True
+        try:
+            registry = self._get_service_registry()
+            self.panel_manager.show_panel("system_doctor", registry=registry)
+        except Exception as exc:
+            self._set_status_message(f"System Doctor unavailable: {exc}")
+        return True
+
+    def show_command_plan_panel(self, plans: list[Any]) -> bool:
+        """Open a preview-only command plan panel."""
+        if not self.panel_manager:
+            self._set_status_message("Command Plan panel not available.")
+            return True
+        self.panel_manager.show_panel("command_plan", plans=plans)
+        return True
+
+    def show_services_panel(self) -> bool:
+        """Open the read-only services status panel."""
+        if not self.panel_manager:
+            self._set_status_message("Services panel not available.")
+            return True
+        try:
+            registry = self._get_service_registry()
+            self.panel_manager.show_panel("services_status", registry=registry)
+        except Exception as exc:
+            self._set_status_message(f"Services panel unavailable: {exc}")
         return True
 
     # --- Comment/Uncomment Block ---
@@ -7115,6 +7162,7 @@ class Ecli:
             "lint": "F4",
             "git_menu": "F9",
             "help": "F1",
+            "toggle_system_doctor_panel": "F8",
             "cancel_operation": "Esc",
             "tab": "Tab",
             "shift_tab": "Shift+Tab",
@@ -7131,6 +7179,7 @@ class Ecli:
             f"    {_kb('git_menu', defaults['git_menu']):<22}: Git menu",
             f"    {_kb('help', defaults['help']):<22}: This help screen",
             f"    {_kb('ai_assist', defaults['ai_assist']):<22}: AI Code Assistant",
+            f"    {_kb('toggle_system_doctor_panel', defaults['toggle_system_doctor_panel']):<22}: System Doctor",
             f"    {_kb('cancel_operation', defaults['cancel_operation']):<22}: Cancel / Close Panel",
             "    Insert Key            : Toggle Insert/Replace mode",
             "",
@@ -7615,6 +7664,21 @@ class Ecli:
                     if async_result.get("type") == "ai_reply":
                         reply_text = async_result.get("text", "AI response was empty.")
                         self.show_ai_panel("AI Assistant Reply", reply_text)
+
+                    elif async_result.get("type") == "ai_configuration_error":
+                        panel_title = async_result.get(
+                            "title",
+                            "AI provider is not configured",
+                        )
+                        panel_content = async_result.get(
+                            "text",
+                            "AI provider is not configured.",
+                        )
+                        provider = async_result.get("provider", "selected provider")
+                        self._set_status_message(
+                            f"AI provider is not configured: {provider}"
+                        )
+                        self.show_ai_panel(str(panel_title), str(panel_content))
 
                     elif async_result.get("type") == "task_error":
                         error_msg = async_result.get("error", "Unknown async error.")

--- a/src/ecli/integrations/AI.py
+++ b/src/ecli/integrations/AI.py
@@ -35,6 +35,46 @@ import aiohttp
 from ecli.utils.logging_config import logger
 
 
+class AiConfigurationError(ValueError):
+    """Expected AI provider configuration error suitable for user-facing UI."""
+
+    def __init__(
+        self,
+        provider: str,
+        message: str,
+        *,
+        env_var: str | None = None,
+    ) -> None:
+        """Initialize a structured AI configuration error."""
+        super().__init__(message)
+        self.provider = provider
+        self.env_var = env_var
+
+
+def ai_configuration_panel_message(
+    provider: str,
+    *,
+    env_var: str | None = None,
+) -> str:
+    """Return user-facing AI configuration guidance without traceback details."""
+    lines = [
+        "AI provider is not configured",
+        "",
+        f"Selected provider: {provider}",
+    ]
+    if env_var:
+        lines.append(f"Missing environment variable: {env_var}")
+    lines.extend(
+        [
+            "",
+            "AI features require a user-provided API key.",
+            "Add API keys to ~/.config/ecli/.env.",
+            "Provider selection is configured in config.toml.",
+        ]
+    )
+    return "\n".join(lines)
+
+
 # Get logger to ensure messages match the general logging system
 # ==================== BaseAiClient Class ====================
 class BaseAiClient:
@@ -851,11 +891,7 @@ def get_ai_client(provider: str, config: dict[str, Any]) -> BaseAiClient:
     """
     provider = provider.lower()
 
-    api_key_env_var = f"{provider.upper()}_API_KEY"
-    if provider == "huggingface":
-        api_key_env_var = "HUGGINGFACE_API_KEY"
-    elif provider == "grok":
-        api_key_env_var = "XAI_API_KEY"
+    api_key_env_var = _api_key_env_var(provider)
 
     api_key = os.environ.get(api_key_env_var) or config.get("ai", {}).get(
         "keys", {}
@@ -864,11 +900,19 @@ def get_ai_client(provider: str, config: dict[str, Any]) -> BaseAiClient:
     model = config.get("ai", {}).get("models", {}).get(provider)
 
     if not api_key:
-        raise ValueError(
-            f"API key for {provider} not found in config or environment variable {api_key_env_var}"
+        raise AiConfigurationError(
+            provider,
+            (
+                f"API key for {provider} not found in config or environment "
+                f"variable {api_key_env_var}"
+            ),
+            env_var=api_key_env_var,
         )
     if not model:
-        raise ValueError(f"Model for {provider} not found in config")
+        raise AiConfigurationError(
+            provider,
+            f"Model for {provider} not found in config",
+        )
 
     if provider == "openai":
         return OpenAiClient(model=model, api_key=api_key)
@@ -883,3 +927,11 @@ def get_ai_client(provider: str, config: dict[str, Any]) -> BaseAiClient:
     if provider == "grok":
         return GrokClient(model=model, api_key=api_key)
     raise ValueError(f"Unknown AI provider: {provider}")
+
+
+def _api_key_env_var(provider: str) -> str:
+    if provider == "huggingface":
+        return "HUGGINGFACE_API_KEY"
+    if provider == "grok":
+        return "XAI_API_KEY"
+    return f"{provider.upper()}_API_KEY"

--- a/src/ecli/ui/KeyBinder.py
+++ b/src/ecli/ui/KeyBinder.py
@@ -297,6 +297,7 @@ class KeyBinder:
             "quit": ["ctrl+q", 17],
             "goto_line": ["ctrl+g", 7],
             "toggle_widget_panel": ["f7", 271],
+            "toggle_system_doctor_panel": ["f8", 272],
             "git_menu": ["f9", 273],
             "help": ["f1", 265],
             "find": ["ctrl+f", 6],
@@ -715,6 +716,7 @@ class KeyBinder:
             "cancel_operation": self.editor.handle_escape,
             "toggle_file_browser": self.editor.toggle_file_browser,
             "toggle_focus": self.editor.toggle_focus,
+            "toggle_system_doctor_panel": self.editor.toggle_system_doctor_panel,
             # --- Git ---
             "git_menu": self.editor.show_git_panel,
             # --- AI ---

--- a/src/ecli/ui/PanelManager.py
+++ b/src/ecli/ui/PanelManager.py
@@ -25,7 +25,14 @@ import curses
 import logging
 from typing import TYPE_CHECKING, Any, Optional
 
-from .panels import AiResponsePanel, BasePanel, FileBrowserPanel
+from .panels import (
+    AiResponsePanel,
+    BasePanel,
+    CommandPlanPanel,
+    FileBrowserPanel,
+    ServicesPanel,
+    SystemDoctorPanel,
+)
 
 
 if TYPE_CHECKING:
@@ -76,7 +83,10 @@ class PanelManager:
         # All registered panels must adhere to the non-blocking BasePanel interface.
         self.registered_panels: dict[str, type[BasePanel]] = {
             "ai_response": AiResponsePanel,
+            "command_plan": CommandPlanPanel,
             "file_browser": FileBrowserPanel,
+            "services_status": ServicesPanel,
+            "system_doctor": SystemDoctorPanel,
         }
         logging.info(
             "PanelManager initialised with: %s", list(self.registered_panels.keys())

--- a/src/ecli/ui/panels.py
+++ b/src/ecli/ui/panels.py
@@ -56,6 +56,8 @@ import pyperclip
 from wcwidth import wcswidth
 
 from ecli.integrations.GitBridge import GitBridge
+from ecli.services.models.doctor import DoctorContext, DoctorFinding
+from ecli.services.models.plan import CommandPlan
 from ecli.utils.logging_config import logger
 from ecli.utils.utils import safe_run
 
@@ -1383,6 +1385,405 @@ class FileBrowserPanel(BasePanel):
             self._refresh_entries()
         except Exception as e:
             self.editor._set_status_message(f"Delete failed: {e}")
+
+
+# ==================== Phase 1 Service Panels ====================
+class _ReadOnlyRightPanel(BasePanel):
+    """Shared right-side panel chrome for read-only service views."""
+
+    title = " Service Panel "
+    close_key = getattr(curses, "KEY_F8", 272)
+
+    def __init__(
+        self, stdscr: CursesWindow, main_editor_instance: Ecli, **kwargs: Any
+    ) -> None:
+        super().__init__(stdscr, main_editor_instance, **kwargs)
+        self.width = int(self.term_width * 0.45)
+        self.height = self.term_height - 1
+        self.start_x = self.term_width - self.width
+        self.win = curses.newwin(self.height, self.width, 0, self.start_x)
+        self.win.keypad(True)
+        self.scroll = 0
+        self.registry = kwargs.get("registry")
+        self.attr_border = self.editor.colors.get("status", curses.A_BOLD)
+        self.attr_title = self.editor.colors.get("function", curses.A_BOLD)
+        self.attr_text = self.editor.colors.get("default", curses.A_NORMAL)
+        self.attr_dim = self.editor.colors.get("comment", curses.A_DIM)
+        self.attr_selected = curses.A_REVERSE | curses.A_BOLD
+        self.attr_warning = self.editor.colors.get("warning", curses.A_BOLD)
+        self.attr_error = self.editor.colors.get("error", curses.A_BOLD)
+
+    def resize(self) -> None:
+        """Handle terminal resize by recreating the backing panel window."""
+        super().resize()
+        self.width = int(self.term_width * 0.45)
+        self.height = self.term_height - 1
+        self.start_x = self.term_width - self.width
+        self.win = curses.newwin(self.height, self.width, 0, self.start_x)
+        self.win.keypad(True)
+
+    def open(self) -> None:
+        """Open the read-only panel and hide the editor cursor."""
+        super().open()
+        curses.curs_set(0)
+
+    def close(self) -> None:
+        """Close the panel and return focus to the editor."""
+        super().close()
+        curses.curs_set(1)
+        self.editor.focus = "editor"
+        if hasattr(self.editor, "_force_full_redraw"):
+            self.editor._force_full_redraw = True
+
+    def _draw_frame(self, footer: str) -> None:
+        is_focused = self.editor.focus == "panel"
+        border_attr = self.attr_border | (curses.A_BOLD if is_focused else 0)
+        try:
+            self.win.border()
+            self.win.addnstr(0, 2, self.title, max(1, self.width - 4), self.attr_title)
+            self.win.addnstr(
+                self.height - 1,
+                2,
+                footer,
+                max(1, self.width - 4),
+                self.attr_dim | border_attr,
+            )
+        except curses.error:
+            pass
+
+    def _draw_lines(self, lines: list[str], *, start_row: int = 1) -> None:
+        viewport_height = max(0, self.height - start_row - 2)
+        max_scroll = max(0, len(lines) - viewport_height)
+        self.scroll = min(max(0, self.scroll), max_scroll)
+        visible = lines[self.scroll : self.scroll + viewport_height]
+        for row_offset, line in enumerate(visible):
+            row = start_row + row_offset
+            attr = self._line_attr(line)
+            try:
+                self.win.addnstr(row, 1, line, max(1, self.width - 2), attr)
+            except curses.error:
+                pass
+
+    def _line_attr(self, line: str) -> int:
+        if " CRITICAL " in line or " ERROR " in line or " unavailable" in line:
+            return self.attr_error
+        if " WARNING " in line or "missing" in line:
+            return self.attr_warning
+        if line.startswith("  "):
+            return self.attr_dim
+        return self.attr_text
+
+    def _handle_common_key(self, key: Any) -> bool:
+        if key in (self.close_key, 27, ord("q")):
+            if hasattr(self.editor, "panel_manager") and self.editor.panel_manager:
+                self.editor.panel_manager.close_active_panel()
+            else:
+                self.close()
+            return True
+        if key == getattr(curses, "KEY_F12", 276):
+            if hasattr(self.editor, "toggle_focus"):
+                self.editor.toggle_focus()
+            return True
+        if key in (curses.KEY_UP, ord("k")):
+            self.scroll = max(0, self.scroll - 1)
+            return True
+        if key in (curses.KEY_DOWN, ord("j")):
+            self.scroll += 1
+            return True
+        if key == curses.KEY_PPAGE:
+            self.scroll = max(0, self.scroll - max(1, self.height - 4))
+            return True
+        if key == curses.KEY_NPAGE:
+            self.scroll += max(1, self.height - 4)
+            return True
+        return False
+
+    def _refresh_window(self) -> None:
+        try:
+            if hasattr(self.win, "noutrefresh"):
+                self.win.noutrefresh()
+            else:
+                self.win.refresh()
+        except curses.error:
+            pass
+
+    def _service_registry(self) -> Any:
+        if self.registry is not None:
+            return self.registry
+        registry = getattr(self.editor, "service_registry", None)
+        if registry is not None:
+            return registry
+        if hasattr(self.editor, "_get_service_registry"):
+            return self.editor._get_service_registry()
+        raise RuntimeError("Service registry is not available")
+
+
+class SystemDoctorPanel(_ReadOnlyRightPanel):
+    """Read-only right-side panel for structured SystemDoctor findings."""
+
+    title = " System Doctor "
+
+    def __init__(
+        self, stdscr: CursesWindow, main_editor_instance: Ecli, **kwargs: Any
+    ) -> None:
+        super().__init__(stdscr, main_editor_instance, **kwargs)
+        self.findings: list[DoctorFinding] = list(kwargs.get("findings") or [])
+        self.selected_idx = 0
+        self.loaded = bool(self.findings)
+        self.error_message: str | None = None
+
+    def open(self) -> None:
+        """Open and refresh read-only doctor findings."""
+        super().open()
+        if not self.loaded:
+            self.refresh_findings()
+        self.editor._set_status_message(
+            "System Doctor: r refresh, Enter/p preview plan, s services, F8/Esc close"
+        )
+
+    def refresh_findings(self) -> None:
+        """Run read-only SystemDoctor checks and store deterministic findings."""
+        try:
+            registry = self._service_registry()
+            context = self._doctor_context(registry)
+            self.findings = list(registry.system_doctor.detect_problems(context))
+            self.loaded = True
+            self.error_message = None
+            self.selected_idx = min(self.selected_idx, max(0, len(self.findings) - 1))
+        except Exception as exc:
+            self.findings = []
+            self.loaded = True
+            self.error_message = f"SystemDoctor unavailable: {exc}"
+
+    def _doctor_context(self, registry: Any) -> DoctorContext:
+        project_root = None
+        project_service = getattr(registry, "project_service", None)
+        if project_service is not None and hasattr(project_service, "root"):
+            project_root = project_service.root
+        elif getattr(self.editor, "filename", None):
+            project_root = Path(self.editor.filename).parent
+        return DoctorContext(project_root=project_root, dry_run=True)
+
+    def handle_key(self, key: Any) -> bool:
+        """Handle navigation plus read-only doctor panel actions."""
+        if self._handle_common_key(key):
+            return True
+        if key == ord("r"):
+            self.refresh_findings()
+            return True
+        if key == ord("s"):
+            self._open_services_panel()
+            return True
+        if key in (ord("p"), curses.KEY_ENTER, 10, 13, "\n"):
+            self._open_selected_plan()
+            return True
+        return False
+
+    def _open_services_panel(self) -> None:
+        if not hasattr(self.editor, "panel_manager") or not self.editor.panel_manager:
+            return
+        self.editor.panel_manager.show_panel(
+            "services_status",
+            registry=self._service_registry(),
+        )
+
+    def _open_selected_plan(self) -> None:
+        if not self.findings:
+            self.editor._set_status_message("System Doctor: no findings to preview.")
+            return
+        finding = self.findings[self.selected_idx]
+        if not finding.remediation_available:
+            self.editor._set_status_message(
+                f"System Doctor: no remediation preview for {finding.finding_id}."
+            )
+            return
+        registry = self._service_registry()
+        plan = registry.command_plan_service.create_plan_from_doctor_finding(
+            finding,
+            actor="system-doctor",
+        )
+        if plan is None:
+            self.editor._set_status_message(
+                f"System Doctor: no command plan for {finding.finding_id}."
+            )
+            return
+        self.editor.panel_manager.show_panel(
+            "command_plan",
+            plans=[plan],
+            registry=registry,
+        )
+
+    def draw(self) -> None:
+        """Render structured doctor findings."""
+        if not self.visible or self.win is None:
+            return
+        if self.height < 5 or self.width < 25:
+            return
+        self.win.erase()
+        self._draw_frame(" r:Refresh Enter/p:Plan s:Services F8/Esc/q:Close ")
+
+        lines = self._finding_lines()
+        viewport_height = max(0, self.height - 3)
+        top = max(0, self.selected_idx - viewport_height + 1)
+        for row_offset, line in enumerate(lines[top : top + viewport_height]):
+            row = row_offset + 1
+            attr = self._line_attr(line)
+            if top + row_offset == self.selected_idx and self.findings:
+                attr |= self.attr_selected
+            try:
+                self.win.addnstr(row, 1, line, max(1, self.width - 2), attr)
+            except curses.error:
+                pass
+        self._refresh_window()
+
+    def _finding_lines(self) -> list[str]:
+        if self.error_message is not None:
+            return [self.error_message]
+        if not self.findings:
+            return ["INFO config DOCTOR-OK SystemDoctor found no problems."]
+        return [
+            (
+                f"{finding.severity.value:<8} {finding.category:<15} "
+                f"{finding.finding_id} {finding.title} "
+                f"[remediation={'yes' if finding.remediation_available else 'no'}]"
+            )
+            for finding in self.findings
+        ]
+
+
+class CommandPlanPanel(_ReadOnlyRightPanel):
+    """Preview-only right-side panel for draft CommandPlan objects."""
+
+    title = " Command Plans "
+
+    def __init__(
+        self, stdscr: CursesWindow, main_editor_instance: Ecli, **kwargs: Any
+    ) -> None:
+        super().__init__(stdscr, main_editor_instance, **kwargs)
+        plans = list(kwargs.get("plans") or [])
+        plan = kwargs.get("plan")
+        if plan is not None:
+            plans.append(plan)
+        self.plans: list[CommandPlan] = plans
+        self.lines = self._build_lines()
+
+    def open(self) -> None:
+        """Open the preview-only command plan panel."""
+        super().open()
+        self.editor._set_status_message("Command Plans: preview only, F8/Esc/q close")
+
+    def handle_key(self, key: Any) -> bool:
+        """Handle scroll and close keys."""
+        return self._handle_common_key(key)
+
+    def draw(self) -> None:
+        """Render command plan previews."""
+        if not self.visible or self.win is None:
+            return
+        if self.height < 5 or self.width < 25:
+            return
+        self.win.erase()
+        self._draw_frame(" Preview only | arrows scroll | F8/Esc/q:Close ")
+        self._draw_lines(self.lines)
+        self._refresh_window()
+
+    def _build_lines(self) -> list[str]:
+        if not self.plans:
+            return ["No command plan previews are available."]
+
+        lines: list[str] = []
+        for plan in self.plans:
+            lines.extend(
+                [
+                    f"Plan ID: {plan.plan_id}",
+                    f"Title: {plan.title}",
+                    (
+                        f"Risk: {plan.risk.value}  Category: {plan.category.value}  "
+                        f"Source: {plan.source.value}"
+                    ),
+                    (
+                        f"Status: {plan.status.value}  "
+                        f"Confirmation: {plan.confirmation_required}"
+                    ),
+                    "Commands:",
+                ]
+            )
+            for step in plan.commands:
+                warnings = []
+                if step.requires_privilege:
+                    warnings.append("requires privilege")
+                if step.destructive:
+                    warnings.append("destructive")
+                warning_text = f" [{' / '.join(warnings)}]" if warnings else ""
+                lines.append(f"  - {step.display}{warning_text}")
+                lines.append(f"    argv: {shlex.join(step.argv)}")
+            try:
+                export_markdown = (
+                    self._service_registry()
+                    .command_plan_service.export_markdown(plan)
+                )
+                lines.extend(["", "Markdown preview:", *export_markdown.splitlines()])
+            except Exception:
+                lines.append("Markdown preview unavailable.")
+            lines.append("")
+        return lines
+
+
+class ServicesPanel(_ReadOnlyRightPanel):
+    """Read-only right-side service diagnostics/status panel."""
+
+    title = " Services "
+
+    SERVICE_NAMES = (
+        ("ConfigService", "config_service"),
+        ("ProjectService", "project_service"),
+        ("CommandPlanService", "command_plan_service"),
+        ("BuiltInPolicyEngine", "policy_engine"),
+        ("AuditLogService", "audit_log_service"),
+        ("PrivilegedActionService", "privileged_action_service"),
+        ("SystemDoctor", "system_doctor"),
+    )
+
+    def open(self) -> None:
+        """Open the service status panel."""
+        super().open()
+        self.editor._set_status_message("Services: read-only status, F8/Esc/q close")
+
+    def handle_key(self, key: Any) -> bool:
+        """Handle scroll and close keys."""
+        return self._handle_common_key(key)
+
+    def draw(self) -> None:
+        """Render service availability diagnostics."""
+        if not self.visible or self.win is None:
+            return
+        if self.height < 5 or self.width < 25:
+            return
+        self.win.erase()
+        self._draw_frame(" Read-only service status | F8/Esc/q:Close ")
+        self._draw_lines(self._service_lines())
+        self._refresh_window()
+
+    def _service_lines(self) -> list[str]:
+        try:
+            registry = self._service_registry()
+        except Exception as exc:
+            return [f"ServiceRegistry unavailable: {exc}"]
+
+        lines = ["Phase 1 service graph:"]
+        for label, attribute in self.SERVICE_NAMES:
+            service = getattr(registry, attribute, None)
+            if service is None:
+                lines.append(f"{label:<28} unavailable")
+            else:
+                lines.append(f"{label:<28} available ({service.__class__.__name__})")
+
+        config_result = getattr(registry, "config_result", None)
+        if config_result is not None:
+            diagnostics = getattr(config_result, "diagnostics", ())
+            lines.append("")
+            lines.append(f"Config diagnostics: {len(diagnostics)}")
+        return lines
 
 
 # ==================== GitPanel Class ====================

--- a/tests/characterization/test_existing_editor_entrypoints.py
+++ b/tests/characterization/test_existing_editor_entrypoints.py
@@ -49,6 +49,9 @@ def test_existing_editor_methods_for_help_and_panels_are_present() -> None:
         "toggle_widget_panel",
         "select_ai_provider_and_ask",
         "toggle_file_browser",
+        "toggle_system_doctor_panel",
+        "show_command_plan_panel",
+        "show_services_panel",
         "show_ai_panel",
         "toggle_focus",
     )

--- a/tests/characterization/test_existing_keybindings.py
+++ b/tests/characterization/test_existing_keybindings.py
@@ -178,6 +178,9 @@ class FakeEditor:
     def toggle_widget_panel(self) -> bool:
         return self._record("toggle_widget_panel")
 
+    def toggle_system_doctor_panel(self) -> bool:
+        return self._record("toggle_system_doctor_panel")
+
     def run_lint_async(self) -> bool:
         return self._record("run_lint_async")
 
@@ -209,7 +212,7 @@ def test_default_keybinding_definitions_preserve_known_help_and_panel_bindings()
     assert curses.KEY_F10 in binder.keybindings["toggle_file_browser"]
     assert curses.KEY_F9 in binder.keybindings["git_menu"]
     assert curses.KEY_F4 in binder.keybindings["lint"]
-    assert curses.KEY_F8 not in binder.action_map
+    assert curses.KEY_F8 in binder.keybindings["toggle_system_doctor_panel"]
 
 
 def test_action_map_keeps_existing_help_ai_file_manager_and_git_entrypoints() -> None:
@@ -219,6 +222,7 @@ def test_action_map_keeps_existing_help_ai_file_manager_and_git_entrypoints() ->
     assert method_name_for_key(binder, curses.KEY_F7) == "toggle_widget_panel"
     assert method_name_for_key(binder, curses.KEY_F10) == "toggle_file_browser"
     assert method_name_for_key(binder, curses.KEY_F9) == "show_git_panel"
+    assert method_name_for_key(binder, curses.KEY_F8) == "toggle_system_doctor_panel"
 
 
 def test_current_f4_behavior_remains_diagnostics_not_git_panel() -> None:
@@ -242,3 +246,5 @@ def test_help_text_keeps_existing_panel_and_tool_labels_discoverable() -> None:
     assert "File Manager" in rendered
     assert "F9" in rendered
     assert "Git menu" in rendered
+    assert "F8" in rendered
+    assert "System Doctor" in rendered

--- a/tests/characterization/test_existing_tui_panels.py
+++ b/tests/characterization/test_existing_tui_panels.py
@@ -23,7 +23,15 @@ from typing import Any, Iterator
 import pytest
 
 from ecli.ui.PanelManager import PanelManager
-from ecli.ui.panels import AiResponsePanel, BasePanel, FileBrowserPanel, GitPanel
+from ecli.ui.panels import (
+    AiResponsePanel,
+    BasePanel,
+    CommandPlanPanel,
+    FileBrowserPanel,
+    GitPanel,
+    ServicesPanel,
+    SystemDoctorPanel,
+)
 
 
 class FakeWindow:
@@ -117,6 +125,9 @@ def test_panel_manager_default_registry_preserves_existing_panel_names() -> None
 
     assert manager.registered_panels["ai_response"] is AiResponsePanel
     assert manager.registered_panels["file_browser"] is FileBrowserPanel
+    assert manager.registered_panels["system_doctor"] is SystemDoctorPanel
+    assert manager.registered_panels["command_plan"] is CommandPlanPanel
+    assert manager.registered_panels["services_status"] is ServicesPanel
     assert "git" not in manager.registered_panels
 
 

--- a/tests/ui/test_ai_configuration_errors.py
+++ b/tests/ui/test_ai_configuration_errors.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/ui/test_ai_configuration_errors.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for graceful AI Assistant configuration error handling."""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import shutil
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from ecli.core.AsyncEngine import AsyncEngine
+from ecli.core.Ecli import Ecli
+from ecli.integrations.AI import (
+    AiConfigurationError,
+    ai_configuration_panel_message,
+    get_ai_client,
+)
+
+
+class FakeEditor:
+    def __init__(self) -> None:
+        """Initialize the minimal queue-processing editor double."""
+        self.is_lightweight = False
+        self.status_message = "Ready"
+        self._shell_cmd_q: queue.Queue[str] = queue.Queue()
+        self._async_results_q: queue.Queue[dict[str, object]] = queue.Queue()
+        self.git = None
+        self.linter_bridge = None
+        self.async_engine = object()
+        self.lint_panel_active = False
+        self.lint_panel_message = ""
+        self.ai_panels: list[tuple[str, str]] = []
+
+    def _set_status_message(self, message: str) -> None:
+        self.status_message = message
+
+    def show_ai_panel(self, title: str, content: str) -> bool:
+        self.ai_panels.append((title, content))
+        return True
+
+
+@pytest.fixture
+def workspace(request: pytest.FixtureRequest) -> Iterator[Path]:
+    repo_logs = Path.cwd() / "logs" / "test-ai-configuration-errors"
+    test_root = repo_logs / request.node.name.replace("/", "_").replace(":", "_")
+    shutil.rmtree(test_root, ignore_errors=True)
+    test_root.mkdir(parents=True)
+    try:
+        yield test_root
+    finally:
+        shutil.rmtree(test_root, ignore_errors=True)
+
+
+def test_missing_ai_key_raises_typed_configuration_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(AiConfigurationError) as exc_info:
+        get_ai_client(
+            "openai",
+            {"ai": {"models": {"openai": "gpt-5-codex"}, "keys": {}}},
+        )
+
+    assert exc_info.value.provider == "openai"
+    assert exc_info.value.env_var == "OPENAI_API_KEY"
+    assert "Traceback" not in str(exc_info.value)
+
+
+def test_ai_configuration_panel_message_is_user_friendly() -> None:
+    message = ai_configuration_panel_message("openai", env_var="OPENAI_API_KEY")
+
+    assert "AI provider is not configured" in message
+    assert "Selected provider: openai" in message
+    assert "Missing environment variable: OPENAI_API_KEY" in message
+    assert "AI features require a user-provided API key" in message
+    assert "~/.config/ecli/.env" in message
+    assert "config.toml" in message
+    assert "Traceback" not in message
+    assert "ValueError" not in message
+
+
+def test_async_engine_converts_missing_ai_key_to_configuration_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    to_ui_queue: queue.Queue[dict[str, object]] = queue.Queue()
+    engine = AsyncEngine(
+        to_ui_queue,
+        config={},
+    )
+
+    asyncio.run(
+        engine.dispatch_task(
+            {
+                "type": "ai_chat",
+                "provider": "openai",
+                "prompt": "explain this",
+                "config": {"ai": {"models": {"openai": "gpt-5-codex"}, "keys": {}}},
+            }
+        )
+    )
+
+    result = to_ui_queue.get_nowait()
+    assert result["type"] == "ai_configuration_error"
+    assert result["provider"] == "openai"
+    assert result["env_var"] == "OPENAI_API_KEY"
+    assert result["title"] == "AI provider is not configured"
+    text = str(result["text"])
+    assert "~/.config/ecli/.env" in text
+    assert "config.toml" in text
+    assert "Traceback" not in text
+    assert "ValueError" not in text
+
+
+def test_editor_queue_renders_ai_configuration_panel_without_traceback() -> None:
+    editor = FakeEditor()
+    editor._async_results_q.put(
+        {
+            "type": "ai_configuration_error",
+            "provider": "openai",
+            "env_var": "OPENAI_API_KEY",
+            "title": "AI provider is not configured",
+            "text": ai_configuration_panel_message(
+                "openai",
+                env_var="OPENAI_API_KEY",
+            ),
+        }
+    )
+
+    changed = Ecli._process_all_queues(editor)  # type: ignore[arg-type]
+
+    assert changed is True
+    assert editor.status_message == "AI provider is not configured: openai"
+    assert editor.ai_panels
+    title, content = editor.ai_panels[-1]
+    assert title == "AI provider is not configured"
+    assert "Selected provider: openai" in content
+    assert "OPENAI_API_KEY" in content
+    assert "~/.config/ecli/.env" in content
+    assert "config.toml" in content
+    assert "Traceback" not in content
+    assert "ValueError" not in content
+
+
+def test_test_workspaces_remain_under_logs(workspace: Path) -> None:
+    logs_root = (Path.cwd() / "logs").resolve(strict=False)
+
+    assert workspace.resolve(strict=False).is_relative_to(logs_root)

--- a/tests/ui/test_service_panels.py
+++ b/tests/ui/test_service_panels.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/ui/test_service_panels.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for Phase 1 service right-side TUI panels."""
+
+from __future__ import annotations
+
+import curses
+import inspect
+import shutil
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from ecli.services.command_plan_service import CommandPlanService
+from ecli.services.models.doctor import DoctorFinding, DoctorSeverity
+from ecli.ui.panels import (
+    CommandPlanPanel,
+    ServicesPanel,
+    SystemDoctorPanel,
+    _ReadOnlyRightPanel,
+)
+
+
+class FakeWindow:
+    def __init__(self) -> None:
+        """Initialize a fake curses window."""
+        self.keypad_values: list[bool] = []
+        self.drawn_text: list[str] = []
+
+    def getmaxyx(self) -> tuple[int, int]:
+        return (32, 120)
+
+    def keypad(self, value: bool) -> None:
+        self.keypad_values.append(value)
+
+    def erase(self) -> None:
+        self.drawn_text.clear()
+
+    def border(self) -> None:
+        return None
+
+    def addnstr(self, _y: int, _x: int, text: str, _width: int, _attr: int = 0) -> None:
+        self.drawn_text.append(text)
+
+    def refresh(self) -> None:
+        return None
+
+    def noutrefresh(self) -> None:
+        return None
+
+
+class FakePanelManager:
+    def __init__(self) -> None:
+        """Initialize panel call recording."""
+        self.shown: list[tuple[str, dict[str, Any]]] = []
+        self.closed = False
+
+    def show_panel(self, name: str, **kwargs: Any) -> None:
+        self.shown.append((name, kwargs))
+
+    def close_active_panel(self) -> None:
+        self.closed = True
+
+
+class FakeDoctor:
+    def __init__(self, findings: list[DoctorFinding]) -> None:
+        """Initialize deterministic findings."""
+        self.findings = findings
+        self.contexts: list[Any] = []
+
+    def detect_problems(self, context: Any) -> list[DoctorFinding]:
+        self.contexts.append(context)
+        return list(self.findings)
+
+
+class FakeRegistry:
+    def __init__(self, findings: list[DoctorFinding]) -> None:
+        """Initialize a service-registry-shaped fake."""
+        self.config_service = object()
+        self.project_service = type(
+            "FakeProjectService",
+            (),
+            {"root": Path.cwd()},
+        )()
+        self.command_plan_service = CommandPlanService()
+        self.policy_engine = object()
+        self.audit_log_service = object()
+        self.privileged_action_service = object()
+        self.system_doctor = FakeDoctor(findings)
+        self.config_result = type("FakeConfigResult", (), {"diagnostics": []})()
+
+
+class FakeEditor:
+    def __init__(self, registry: FakeRegistry) -> None:
+        """Initialize a panel-compatible editor double."""
+        self.stdscr = FakeWindow()
+        self.focus = "panel"
+        self._force_full_redraw = False
+        self.colors = {
+            "status": curses.A_BOLD,
+            "function": curses.A_BOLD,
+            "default": curses.A_NORMAL,
+            "comment": curses.A_DIM,
+            "warning": curses.A_BOLD,
+            "error": curses.A_BOLD,
+        }
+        self.filename = None
+        self.service_registry = registry
+        self.panel_manager = FakePanelManager()
+        self.status_messages: list[str] = []
+
+    def _set_status_message(self, message: str) -> None:
+        self.status_messages.append(message)
+
+    def _get_service_registry(self) -> FakeRegistry:
+        return self.service_registry
+
+    def toggle_focus(self) -> None:
+        self.focus = "editor" if self.focus == "panel" else "panel"
+
+
+@pytest.fixture
+def workspace(request: pytest.FixtureRequest) -> Iterator[Path]:
+    repo_logs = Path.cwd() / "logs" / "test-ui-service-panels"
+    test_root = repo_logs / request.node.name.replace("/", "_").replace(":", "_")
+    shutil.rmtree(test_root, ignore_errors=True)
+    test_root.mkdir(parents=True)
+    try:
+        yield test_root
+    finally:
+        shutil.rmtree(test_root, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
+def fake_curses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("ecli.ui.panels.curses.newwin", lambda *args: FakeWindow())
+    monkeypatch.setattr("ecli.ui.panels.curses.curs_set", lambda value: None)
+
+
+def finding(remediation_available: bool = True) -> DoctorFinding:
+    return DoctorFinding(
+        finding_id="DOCTOR-CONFIG-001",
+        title="Repository logs directory is missing",
+        severity=DoctorSeverity.WARNING,
+        category="config",
+        description="Repository-level logs/ is absent.",
+        affected_resources=("logs",),
+        remediation_available=remediation_available,
+        remediation_plan_id="plan-20260101T000000Z-12345678",
+    )
+
+
+def rendered_text(window: FakeWindow) -> str:
+    return "\n".join(window.drawn_text)
+
+
+def test_system_doctor_panel_renders_structured_findings() -> None:
+    registry = FakeRegistry([finding()])
+    editor = FakeEditor(registry)
+    panel = SystemDoctorPanel(editor.stdscr, editor, registry=registry)
+
+    panel.open()
+    panel.draw()
+
+    text = rendered_text(panel.win)
+    assert "System Doctor" in text
+    assert "WARNING" in text
+    assert "config" in text
+    assert "DOCTOR-CONFIG-001" in text
+    assert "Repository logs directory is missing" in text
+    assert "remediation=yes" in text
+
+
+def test_system_doctor_panel_opens_command_plan_preview_for_finding() -> None:
+    registry = FakeRegistry([finding()])
+    editor = FakeEditor(registry)
+    panel = SystemDoctorPanel(editor.stdscr, editor, registry=registry)
+
+    panel.open()
+
+    assert panel.handle_key(ord("p")) is True
+    assert editor.panel_manager.shown
+    name, kwargs = editor.panel_manager.shown[-1]
+    assert name == "command_plan"
+    assert kwargs["plans"][0].plan_id == "plan-20260101T000000Z-12345678"
+    assert kwargs["plans"][0].status.value == "DRAFT"
+
+
+def test_system_doctor_panel_does_not_open_plan_for_unavailable_remediation() -> None:
+    registry = FakeRegistry([finding(remediation_available=False)])
+    editor = FakeEditor(registry)
+    panel = SystemDoctorPanel(editor.stdscr, editor, registry=registry)
+
+    panel.open()
+
+    assert panel.handle_key(ord("p")) is True
+    assert editor.panel_manager.shown == []
+    assert "no remediation preview" in editor.status_messages[-1]
+
+
+def test_system_doctor_panel_opens_services_status_view() -> None:
+    registry = FakeRegistry([finding()])
+    editor = FakeEditor(registry)
+    panel = SystemDoctorPanel(editor.stdscr, editor, registry=registry)
+
+    panel.open()
+
+    assert panel.handle_key(ord("s")) is True
+    assert editor.panel_manager.shown[-1][0] == "services_status"
+
+
+def test_command_plan_panel_renders_draft_plan_preview() -> None:
+    plan = CommandPlanService().create_plan_from_doctor_finding(finding())
+    assert plan is not None
+    registry = FakeRegistry([finding()])
+    editor = FakeEditor(registry)
+    panel = CommandPlanPanel(editor.stdscr, editor, registry=registry, plans=[plan])
+
+    panel.open()
+    panel.draw()
+
+    text = rendered_text(panel.win)
+    assert "Command Plans" in text
+    assert plan.plan_id in text
+    assert "Risk: LOW" in text
+    assert "Status: DRAFT" in text
+    assert "Confirmation: True" in text
+    assert "mkdir -p logs" in text
+    assert "Markdown preview:" in text
+
+
+def test_services_panel_renders_phase_one_service_status() -> None:
+    registry = FakeRegistry([finding()])
+    editor = FakeEditor(registry)
+    panel = ServicesPanel(editor.stdscr, editor, registry=registry)
+
+    panel.open()
+    panel.draw()
+
+    text = rendered_text(panel.win)
+    assert "Services" in text
+    assert "ConfigService" in text
+    assert "ProjectService" in text
+    assert "CommandPlanService" in text
+    assert "BuiltInPolicyEngine" in text
+    assert "AuditLogService" in text
+    assert "PrivilegedActionService" in text
+    assert "SystemDoctor" in text
+    assert "available" in text
+
+
+def test_new_service_panel_source_has_no_forbidden_runtime_operations() -> None:
+    source = "\n".join(
+        inspect.getsource(item)
+        for item in (
+            _ReadOnlyRightPanel,
+            SystemDoctorPanel,
+            CommandPlanPanel,
+            ServicesPanel,
+        )
+    )
+
+    forbidden_tokens = (
+        "subprocess",
+        "Popen",
+        "os.system",
+        ".run(",
+        "sudo",
+        "doas",
+        "pkexec",
+        "chmod",
+        "chown",
+        "usermod",
+        "modprobe",
+        "socket",
+        "requests",
+        "urllib",
+        "QEMU",
+    )
+    assert all(token not in source for token in forbidden_tokens)
+
+
+def test_test_workspaces_remain_under_logs(workspace: Path) -> None:
+    logs_root = (Path.cwd() / "logs").resolve(strict=False)
+
+    assert workspace.resolve(strict=False).is_relative_to(logs_root)


### PR DESCRIPTION
Closes #69

Added right-side TUI panels for Services, SystemDoctor, and CommandPlan workflows.

Scope:
- added SystemDoctorPanel
- added CommandPlanPanel
- added ServicesPanel
- registered new service panels in PanelManager
- added F8 keybinding for System Doctor
- added lazy editor-owned ServiceRegistry access
- added ECLI editor entrypoints for service panels
- updated Help screen to show F8 System Doctor
- preserved existing F1/F4/F7/F9/F10 behavior
- updated characterization tests for intentional F8 assignment
- added UI tests for service panels

AI Assistant UX fix:
- added AiConfigurationError for expected AI provider/key configuration failures
- missing API keys are now shown as friendly AI panel messages
- missing OPENAI_API_KEY no longer renders traceback or ValueError
- message tells user to configure keys in ~/.config/ecli/.env
- message explains provider selection belongs in config.toml
- unexpected async failures still use the existing generic error path

Manual visual verification completed:
- F1 Help opens and shows F8
- F4 Diagnostics/Lint remains mapped
- F7 AI Code Assistant opens
- missing OPENAI_API_KEY shows friendly configuration message without traceback
- F8 System Doctor opens
- System Doctor key s opens Services panel
- F9 Git panel still works
- F10 File Manager still works

Safety guarantees:
- no plan execution
- no privileged execution
- no real remediation
- no VMLab runtime behavior
- no subprocess execution
- no shell execution
- no network calls added
- no new dependencies
- no release bump

Validation:
- python3 -m pytest tests/test_smoke.py -v
- python3 -m pytest tests/services -v
- python3 -m pytest tests/characterization -v
- python3 -m pytest tests/ui -v
- python3 -m compileall src
- ruff check src tests
- ruff format --check src tests
- ./scripts/check-log-invariant.sh
- git diff --check
