### PR TITLE
feat: add minimal Phase 1 service CLI surface

### DIFF
--- a/src/ecli/__main__.py
+++ b/src/ecli/__main__.py
@@ -59,6 +59,20 @@ project_root = os.path.dirname(os.path.abspath(__file__))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
+# --- Step 2.5: Explicit read-only service CLI dispatch ---
+# Preserve the default editor path for `python -m ecli [file]`. Only explicit
+# Phase 1 service flags are handled here before curses/editor initialization.
+try:
+    from ecli.cli import is_service_cli, run_service_cli
+
+    if is_service_cli(sys.argv[1:]):
+        sys.exit(run_service_cli(sys.argv[1:]))
+except SystemExit:
+    raise
+except Exception as e:
+    print(f"ECLI service CLI error: {e}", file=sys.stderr)
+    sys.exit(1)
+
 # --- Step 3: Immediate Logging and Configuration Setup ---
 try:
     from ecli.utils.logging_config import setup_logging

--- a/src/ecli/cli.py
+++ b/src/ecli/cli.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: src/ecli/cli.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Minimal read-only CLI surface for Phase 1 services."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, TextIO
+
+from ecli.services.models.doctor import DoctorContext, DoctorFinding
+from ecli.services.models.plan import CommandPlan
+from ecli.services.registry import ServiceRegistry
+
+
+SERVICE_CLI_FLAGS = frozenset({"--services", "--doctor", "--plan-preview"})
+
+SERVICE_STATUS_NAMES: tuple[tuple[str, str], ...] = (
+    ("ConfigService", "config_service"),
+    ("ProjectService", "project_service"),
+    ("CommandPlanService", "command_plan_service"),
+    ("BuiltInPolicyEngine", "policy_engine"),
+    ("AuditLogService", "audit_log_service"),
+    ("PrivilegedActionService", "privileged_action_service"),
+    ("SystemDoctor", "system_doctor"),
+)
+
+
+def is_service_cli(argv: list[str]) -> bool:
+    """Return true when argv selects an explicit Phase 1 service CLI command."""
+    return any(argument in SERVICE_CLI_FLAGS for argument in argv)
+
+
+def run_service_cli(
+    argv: list[str],
+    *,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    """Run the minimal service CLI and return a process-style status code."""
+    out = _TextIOProxy(stdout, sys.stdout)
+    err = _TextIOProxy(stderr, sys.stderr)
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        return _run_service_command(args, out)
+    except ValueError as exc:
+        err.write(f"Error: {exc}\n")
+        return 2
+    except Exception as exc:
+        err.write(f"ECLI service CLI error: {exc}\n")
+        return 1
+
+    parser.print_help(file=err.file)
+    return 2
+
+
+def _run_service_command(args: argparse.Namespace, stdout: _TextIOProxy) -> int:
+    registry = _create_registry(args)
+    if args.services:
+        payload = _service_status_payload(registry)
+        _write_output(stdout, payload, _format_service_status(payload), args.as_json)
+        return 0
+    if args.doctor:
+        findings = _detect_findings(registry, args)
+        payload = {
+            "findings": [finding.as_dict() for finding in findings],
+            "count": len(findings),
+        }
+        _write_output(stdout, payload, _format_doctor_findings(findings), args.as_json)
+        return 0
+    if args.plan_preview:
+        findings = _detect_findings(registry, args)
+        plan = _first_preview_plan(registry, findings, args.finding_id)
+        return _write_plan_preview(stdout, registry, plan, args.as_json)
+    return 2
+
+
+def _write_plan_preview(
+    stdout: _TextIOProxy,
+    registry: ServiceRegistry,
+    plan: CommandPlan | None,
+    as_json: bool,
+) -> int:
+    if plan is None:
+        message = "No eligible SystemDoctor finding has a command plan preview."
+        if as_json:
+            stdout.write(_json_dumps({"plan": None, "message": message}) + "\n")
+        else:
+            stdout.write(message + "\n")
+        return 2
+    if as_json:
+        stdout.write(registry.command_plan_service.export_json(plan) + "\n")
+    else:
+        stdout.write(registry.command_plan_service.export_markdown(plan))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ecli",
+        description="Read-only Phase 1 service inspection commands.",
+    )
+    command_group = parser.add_mutually_exclusive_group(required=True)
+    command_group.add_argument(
+        "--services",
+        action="store_true",
+        help="Print ServiceRegistry service status.",
+    )
+    command_group.add_argument(
+        "--doctor",
+        action="store_true",
+        help="Run read-only SystemDoctor diagnostics.",
+    )
+    command_group.add_argument(
+        "--plan-preview",
+        action="store_true",
+        help="Print a draft CommandPlan preview from an eligible doctor finding.",
+    )
+    parser.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Print deterministic JSON.",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Project root or start path for discovery.",
+    )
+    parser.add_argument(
+        "--logs-root",
+        type=Path,
+        default=_repo_logs_root(),
+        help="Repository logs root used by read-only service diagnostics.",
+    )
+    parser.add_argument(
+        "--category",
+        action="append",
+        default=[],
+        help="SystemDoctor category to include. May be repeated.",
+    )
+    parser.add_argument(
+        "--finding-id",
+        help="Specific SystemDoctor finding ID to use for plan preview.",
+    )
+    return parser
+
+
+def _create_registry(args: argparse.Namespace) -> ServiceRegistry:
+    logs_root = Path(args.logs_root).resolve(strict=False)
+    _assert_under_repo_logs(logs_root)
+    return ServiceRegistry.create(
+        project_root=Path(args.project_root),
+        logs_root=logs_root,
+        env={},
+    )
+
+
+def _detect_findings(
+    registry: ServiceRegistry,
+    args: argparse.Namespace,
+) -> list[DoctorFinding]:
+    context = DoctorContext(
+        project_root=registry.project_service.root,
+        categories=tuple(args.category),
+        dry_run=True,
+    )
+    findings = registry.system_doctor.detect_problems(context)
+    return sorted(findings, key=lambda finding: finding.finding_id)
+
+
+def _first_preview_plan(
+    registry: ServiceRegistry,
+    findings: list[DoctorFinding],
+    finding_id: str | None,
+) -> CommandPlan | None:
+    for finding in findings:
+        if finding_id is not None and finding.finding_id != finding_id:
+            continue
+        if not finding.remediation_available:
+            continue
+        return registry.command_plan_service.create_plan_from_doctor_finding(
+            finding,
+            actor="ecli-cli",
+        )
+    return None
+
+
+def _service_status_payload(registry: ServiceRegistry) -> dict[str, Any]:
+    services = []
+    for label, attribute in SERVICE_STATUS_NAMES:
+        service = getattr(registry, attribute, None)
+        services.append(
+            {
+                "name": label,
+                "available": service is not None,
+                "implementation": None
+                if service is None
+                else service.__class__.__name__,
+            }
+        )
+    diagnostics = []
+    if registry.config_result is not None:
+        diagnostics = [
+            diagnostic.as_dict()
+            for diagnostic in getattr(registry.config_result, "diagnostics", ())
+        ]
+    return {
+        "services": services,
+        "config_diagnostics": diagnostics,
+        "project_root": str(registry.project_service.root),
+    }
+
+
+def _format_service_status(payload: dict[str, Any]) -> str:
+    lines = [
+        "ECLI Phase 1 service status",
+        f"Project root: {payload['project_root']}",
+        "",
+    ]
+    for service in payload["services"]:
+        status = "available" if service["available"] else "unavailable"
+        implementation = service["implementation"] or "none"
+        lines.append(f"{service['name']}: {status} ({implementation})")
+    diagnostics = payload["config_diagnostics"]
+    lines.extend(["", f"Config diagnostics: {len(diagnostics)}"])
+    return "\n".join(lines) + "\n"
+
+
+def _format_doctor_findings(findings: list[DoctorFinding]) -> str:
+    lines = ["SystemDoctor read-only findings"]
+    if not findings:
+        lines.append("No findings.")
+        return "\n".join(lines) + "\n"
+    for finding in findings:
+        remediation = "yes" if finding.remediation_available else "no"
+        lines.append(
+            f"{finding.finding_id}: {finding.severity.value} "
+            f"{finding.category} remediation={remediation} - {finding.title}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _write_output(
+    stdout: _TextIOProxy,
+    payload: dict[str, Any],
+    human_text: str,
+    as_json: bool,
+) -> None:
+    if as_json:
+        stdout.write(_json_dumps(payload) + "\n")
+    else:
+        stdout.write(human_text)
+
+
+def _json_dumps(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _repo_logs_root() -> Path:
+    return (_repo_root() / "logs").resolve(strict=False)
+
+
+def _assert_under_repo_logs(path: Path) -> None:
+    logs_root = _repo_logs_root()
+    if not path.resolve(strict=False).is_relative_to(logs_root):
+        raise ValueError("logs root must stay under repository-level logs/")
+
+
+class _TextIOProxy:
+    """Small wrapper around optional text streams."""
+
+    def __init__(self, file: TextIO | None, default: TextIO) -> None:
+        """Use the supplied stream or resolve the current standard stream lazily."""
+        self.file = default if file is None else file
+
+    def write(self, value: str) -> None:
+        """Write text to the wrapped stream."""
+        self.file.write(value)

--- a/tests/cli/test_phase1_service_cli.py
+++ b/tests/cli/test_phase1_service_cli.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/cli/test_phase1_service_cli.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for the minimal Phase 1 service CLI surface."""
+
+from __future__ import annotations
+
+import io
+import json
+import shutil
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from ecli.cli import is_service_cli, run_service_cli
+
+
+SERVICE_NAMES = (
+    "ConfigService",
+    "ProjectService",
+    "CommandPlanService",
+    "BuiltInPolicyEngine",
+    "AuditLogService",
+    "PrivilegedActionService",
+    "SystemDoctor",
+)
+
+
+@pytest.fixture
+def workspace(request: pytest.FixtureRequest) -> Iterator[Path]:
+    repo_logs = Path.cwd() / "logs" / "test-phase1-service-cli"
+    test_root = repo_logs / request.node.name.replace("/", "_").replace(":", "_")
+    shutil.rmtree(test_root, ignore_errors=True)
+    test_root.mkdir(parents=True)
+    (test_root / "pyproject.toml").write_text(
+        "[project]\nname = 'cli-test'\n",
+        encoding="utf-8",
+    )
+    try:
+        yield test_root
+    finally:
+        shutil.rmtree(test_root, ignore_errors=True)
+
+
+def snapshot_tree(root: Path) -> set[str]:
+    return {str(path.relative_to(root)) for path in root.rglob("*")}
+
+
+def run_cli(args: list[str]) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    status = run_service_cli(args, stdout=stdout, stderr=stderr)
+
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+def test_default_editor_launch_arguments_are_not_service_cli() -> None:
+    assert is_service_cli([]) is False
+    assert is_service_cli(["pyproject.toml"]) is False
+    assert is_service_cli(["logs/service"]) is False
+
+
+def test_service_status_command_reports_phase_one_services(workspace: Path) -> None:
+    status, output, error = run_cli(
+        [
+            "--services",
+            "--project-root",
+            str(workspace),
+            "--logs-root",
+            str(workspace / "logs-root"),
+        ]
+    )
+
+    assert status == 0
+    assert error == ""
+    assert "ECLI Phase 1 service status" in output
+    for service_name in SERVICE_NAMES:
+        assert service_name in output
+        assert "available" in output
+
+
+def test_service_status_command_supports_deterministic_json(workspace: Path) -> None:
+    status, output, error = run_cli(
+        [
+            "--services",
+            "--json",
+            "--project-root",
+            str(workspace),
+            "--logs-root",
+            str(workspace / "logs-root"),
+        ]
+    )
+
+    assert status == 0
+    assert error == ""
+    payload = json.loads(output)
+    assert [service["name"] for service in payload["services"]] == list(SERVICE_NAMES)
+    assert all(service["available"] for service in payload["services"])
+    assert payload["project_root"] == str(workspace.resolve(strict=False))
+
+
+def test_doctor_command_returns_structured_findings_without_mutation(
+    workspace: Path,
+) -> None:
+    project = workspace / "project"
+    project.mkdir()
+    missing_logs = workspace / "missing-logs"
+    before = snapshot_tree(workspace)
+
+    status, output, error = run_cli(
+        [
+            "--doctor",
+            "--project-root",
+            str(project),
+            "--logs-root",
+            str(missing_logs),
+            "--category",
+            "config",
+        ]
+    )
+
+    assert status == 0
+    assert error == ""
+    assert "SystemDoctor read-only findings" in output
+    assert "DOCTOR-CONFIG-001" in output
+    assert "remediation=yes" in output
+    assert not missing_logs.exists()
+    assert snapshot_tree(workspace) == before
+
+
+def test_plan_preview_command_returns_draft_preview_json(workspace: Path) -> None:
+    project = workspace / "project"
+    project.mkdir()
+
+    status, output, error = run_cli(
+        [
+            "--plan-preview",
+            "--json",
+            "--project-root",
+            str(project),
+            "--logs-root",
+            str(workspace / "missing-logs"),
+            "--category",
+            "config",
+        ]
+    )
+
+    assert status == 0
+    assert error == ""
+    payload = json.loads(output)
+    assert payload["status"] == "DRAFT"
+    assert payload["source"] == "DOCTOR"
+    assert payload["metadata"]["doctor_finding_id"] == "DOCTOR-CONFIG-001"
+    assert payload["commands"][0]["argv"][:2] == ["mkdir", "-p"]
+    assert "executed" not in payload
+
+
+def test_plan_preview_command_returns_human_preview_text(workspace: Path) -> None:
+    project = workspace / "project"
+    project.mkdir()
+
+    status, output, error = run_cli(
+        [
+            "--plan-preview",
+            "--project-root",
+            str(project),
+            "--logs-root",
+            str(workspace / "missing-logs"),
+            "--category",
+            "config",
+        ]
+    )
+
+    assert status == 0
+    assert error == ""
+    assert "# Command Plan: Doctor remediation preview" in output
+    assert "Status: `DRAFT`" in output
+    assert "Source: `DOCTOR`" in output
+
+
+def test_missing_ai_api_key_does_not_affect_service_cli(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace: Path,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    status, output, error = run_cli(
+        [
+            "--services",
+            "--project-root",
+            str(workspace),
+            "--logs-root",
+            str(workspace / "logs-root"),
+        ]
+    )
+
+    assert status == 0
+    assert error == ""
+    assert "Traceback" not in output
+    assert "API key" not in output
+
+
+def test_cli_source_adds_no_execution_privilege_or_network_usage() -> None:
+    source = Path("src/ecli/cli.py").read_text(encoding="utf-8")
+
+    forbidden_tokens = (
+        "subprocess",
+        "Popen",
+        "os.system",
+        ".run(",
+        "sudo",
+        "doas",
+        "pkexec",
+        "chmod",
+        "chown",
+        "usermod",
+        "modprobe",
+        "socket",
+        "requests",
+        "urllib",
+        "aiohttp",
+    )
+    assert all(token not in source for token in forbidden_tokens)
+
+
+def test_test_workspaces_remain_under_logs(workspace: Path) -> None:
+    logs_root = (Path.cwd() / "logs").resolve(strict=False)
+
+    assert workspace.resolve(strict=False).is_relative_to(logs_root)


### PR DESCRIPTION
Closes #51

Implemented minimal Phase 1 service CLI surface.

Scope:
- added explicit read-only service CLI dispatch before editor startup
- added stdlib-only service CLI module
- added --services command
- added --doctor command
- added --plan-preview command
- added deterministic --json output
- added --project-root option
- added --logs-root option
- added --category option
- added --finding-id option for plan preview
- preserved default editor launch behavior for:
  - python3 -m ecli
  - python3 -m ecli <file>
- added focused CLI tests

Behavior:
- --services prints ServiceRegistry service availability
- --doctor runs read-only SystemDoctor diagnostics
- --plan-preview creates draft/preview-only CommandPlan from eligible DoctorFinding
- missing AI API keys do not affect service CLI commands
- normal TUI/editor launch remains the default path

Safety guarantees:
- no plan execution
- no remediation execution
- no privileged execution
- no subprocess usage
- no Popen usage
- no os.system usage
- no shell execution
- no sudo/doas/pkexec invocation
- no package installation
- no VMLab runtime start
- no network calls
- no new dependencies

Not included:
- no release/version bump
- no package publishing
- no VMLab implementation
- no real remediation
- no plan apply flow

Validation:
- python3 -m pytest tests/test_smoke.py -v
- python3 -m pytest tests/services -v
- python3 -m pytest tests/characterization -v
- python3 -m pytest tests/ui -v
- python3 -m pytest tests/cli/test_phase1_service_cli.py -v
- python3 -m compileall src
- ruff check src tests
- ruff format --check src tests
- ./scripts/check-log-invariant.sh
- git diff --check

Manual smoke:
- PYTHONPATH=src python3 -m ecli --services --project-root logs --logs-root logs --json
- PYTHONPATH=src python3 -m ecli --doctor --project-root logs --logs-root logs --category config
- PYTHONPATH=src python3 -m ecli --plan-preview --project-root logs --logs-root logs --category config --json
- PYTHONPATH=src python3 -m ecli pyproject.toml
