### PR TITLE
release: prepare ECLI v0.2.0 Services Foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+## 0.2.0 - Services Foundation
+
+ECLI v0.2.0 prepares the Services Foundation release. The editor remains the
+default launch surface, and the new service capabilities are exposed through
+right-side TUI panels plus a minimal read-only CLI.
+
+### Added
+
+- Right-side System Doctor panel on `F8` for read-only diagnostic findings.
+- Right-side Services status view for the Phase 1 composition root.
+- Command Plan preview flow for eligible System Doctor findings.
+- Minimal service CLI:
+  - `python3 -m ecli --services`
+  - `python3 -m ecli --doctor`
+  - `python3 -m ecli --plan-preview`
+- Typed service foundation:
+  - `ConfigService`
+  - `ProjectService`
+  - `CommandPlanService`
+  - `BuiltInPolicyEngine`
+  - `AuditLogService`
+  - `PrivilegedActionService` refusal-only skeleton
+  - `SystemDoctor` read-only skeleton
+  - `ServiceRegistry` composition root
+- Friendly AI configuration error handling when a selected provider is missing
+  its user-provided API key.
+
+### Changed
+
+- Project package version is `0.2.0`.
+- PyPI-facing README now describes the terminal-first workbench model, current
+  panel keybindings, service CLI, and v0.2.0 safety boundaries.
+- AI provider selection and API-key storage guidance is documented explicitly:
+  provider selection belongs in `config.toml`; API keys belong in
+  `~/.config/ecli/.env`.
+
+### Safety Boundaries
+
+- SystemDoctor is read-only.
+- CommandPlan output is draft/preview-only.
+- PrivilegedActionService is refusal-only in this release.
+- Service panels do not execute remediation.
+- No VMLab runtime behavior is included.
+- No real privileged execution path is enabled.
+
+### Expected Release Artifacts
+
+- PyPI wheel and source distribution.
+- Linux `.deb`.
+- Linux `.rpm`.
+- Linux `.tar.gz`.
+- Windows portable `.exe`.
+- Windows setup `.exe`.
+- macOS universal2 `.dmg`.
+- FreeBSD `.pkg`.
+- CycloneDX SBOM.
+- SHA256 sidecars.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ See the LICENSE file in the project root for full license text.
 
 <h1 align="center"><b>ECLI</b></h1>
 <p align="center">
-  <b>The Next-Generation Terminal IDE</b><br/>
-  <i>Modern, AI-powered, extensible code editor for the terminal</i>
+  <b>Terminal-First Engineering Operations Workbench</b><br/>
+  <i>Panel-driven editor, diagnostics surface, and service foundation for controlled operational workflows</i>
 </p>
 
 <p align="center">
@@ -51,20 +51,31 @@ See the LICENSE file in the project root for full license text.
 
 ## 🚀 About ECLI
 
-**ECLI** (Editor CLI) is a next-generation terminal IDE that brings the power of modern development tools into your terminal environment. It's built for developers who value speed, flexibility, and the ability to work without leaving the terminal.
+**ECLI** (Editor CLI) is a terminal-first engineering operations workbench. It
+combines a curses-based editor with right-side workflow panels and a typed
+service foundation for configuration, project discovery, command-plan previews,
+policy checks, audit logging, privileged-action refusal paths, and read-only
+system diagnostics.
+
+The v0.2.0 Services Foundation release keeps the editor as the default product
+surface while making the new services visible through TUI panels and a minimal
+read-only CLI. It does not execute remediation, apply command plans, launch
+VMLab runtimes, or perform real privileged operations.
 
 ### ✨ Key Features
 
 
-* 🧠 **AI-Powered Assistant** - Integrated AI panel for code generation, documentation, and refactoring
-* 📂 **Modern File Manager** - Seamlessly navigate and manage projects with intuitive UI
-* 🌱 **Git Integration** - Stage, commit, push/pull directly in terminal
-* 🌈 **Syntax Highlighting** - Powered by Tree-sitter, supports 70+ programming languages
-* 📝 **LSP Integration** - Full Language Server Protocol support with autocomplete, diagnostics, go-to-definition
-* 🐍 **Built-in Linters** - Ruff (Python) by default + support for external linters across 70+ languages
-* ⚡ **Extensible Architecture** - Plugin and theme system for unlimited customization
-* 🎨 **Professional Themes** - Dark and light themes included
-* 🔄 **Cross-Platform** - Native support for Linux, macOS, FreeBSD, and Windows
+* 🧠 **AI Code Assistant** - F7 panel for code-generation and refactoring help when a user-provided API key is configured
+* 🩺 **System Doctor** - F8 read-only diagnostics panel with structured findings and preview-only remediation plans
+* 🧭 **Services Panel** - right-side visibility into the Phase 1 service composition root
+* 📋 **Command Plan Preview** - draft plans from eligible diagnostics, exportable as JSON or Markdown without execution
+* 📂 **File Manager** - F10 project navigation and file preview workflow
+* 🌱 **Git Panel** - F9 repository panel for existing Git workflows
+* 🔎 **Diagnostics/Lint** - F4 diagnostics and lint panel
+* ❓ **Help** - F1 help panel with current keybindings
+* 🌈 **Syntax Highlighting** - terminal highlighting for common source formats
+* 📝 **LSP Integration** - Language Server Protocol support where configured
+* 🔄 **Cross-Platform Packaging** - PyPI, Linux, FreeBSD, macOS, and Windows release artifacts
 
 ---
 
@@ -76,18 +87,18 @@ Download and install a pre-compiled package for your platform:
 
 ```bash
 # Debian/Ubuntu
-sudo apt install ./ecli_0.1.3_linux_x86_64.deb
+sudo apt install ./ecli_0.2.0_linux_x86_64.deb
 
 # Fedora/RHEL/Rocky
-sudo dnf install ./ecli_0.1.3_linux_x86_64.rpm
+sudo dnf install ./ecli_0.2.0_linux_x86_64.rpm
 
 # Windows (PowerShell)
-.\ecli_0.1.3_win_x86_64_setup.exe
-# Portable alternative: .\ecli_0.1.3_win_x86_64.exe
+.\ecli_0.2.0_win_x86_64_setup.exe
+# Portable alternative: .\ecli_0.2.0_win_x86_64.exe
 # See docs/install/windows.md for checksum verification and SmartScreen notes.
 
 # macOS
-open ecli_0.1.3_macos_universal2.dmg
+open ecli_0.2.0_macos_universal2.dmg
 # First launch is blocked by Gatekeeper; see docs/install/macos.md
 # for the one-time "Open Anyway" or xattr workaround.
 ```
@@ -162,10 +173,11 @@ brew install ncurses libyaml
 
 Download from [GitHub Releases](https://github.com/SSobol77/ecli/releases):
 
-- **Linux**: `.deb` (Debian/Ubuntu), `.rpm` (Fedora/RHEL), `.AppImage` (any Linux), `.tar.gz`
+- **Linux**: `.deb` (Debian/Ubuntu), `.rpm` (Fedora/RHEL), `.tar.gz`
 - **FreeBSD**: `.pkg`
 - **macOS**: `.dmg` ([install notes](https://github.com/SSobol77/ecli/blob/main/docs/install/macos.md))
 - **Windows**: `.exe` installer or portable executable ([install notes](https://github.com/SSobol77/ecli/blob/main/docs/install/windows.md))
+- **Release metadata**: CycloneDX SBOM and SHA256 sidecars for release artifacts
 
 **Option B: PyPI (Python Package Index)**
 
@@ -230,7 +242,7 @@ make help
 make sysinfo
 
 # Build for your platform
-make package-linux      # All Linux packages (deb, rpm, AppImage)
+make package-linux      # Linux package targets supported by the local toolchain
 make package-pypi       # Python wheel + source distribution
 make package-macos      # macOS DMG
 make package-windows    # Windows portable EXE + installer
@@ -250,18 +262,99 @@ make publish-all
 ecli [options] [file]
 ```
 
-### Basic Commands
+### Keyboard Shortcuts
+
+Master ECLI with these essential keyboard shortcuts. Press `F1` anytime inside
+the editor to open the help screen.
+
+#### Basic Editing
 
 | Shortcut | Action |
 |----------|--------|
-| `Ctrl+N` | New file |
+| `Backspace` | Delete character left / delete selection |
+| `Tab` | Smart indent / indent block |
+| `Shift+Tab` | Smart unindent |
+| `Ctrl+\` | Toggle comment (line/block) |
+| `Ctrl+C` | Copy |
+| `Ctrl+X` | Cut |
+| `Ctrl+V` | Paste |
+| `Ctrl+A` | Select all |
+| `Ctrl+Z` | Undo |
+| `Ctrl+Y` | Redo |
+
+#### Navigation & Search
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+G` | Go to line |
+| `Ctrl+F` | Find |
+| `F3` | Find next |
+| `F6` | Search & Replace with regex support |
+| `Arrow keys` / `Home` / `End` | Cursor movement |
+| `Page Up` / `Page Down` | Scroll by page |
+| `Shift` + `Arrow keys` | Extend selection |
+
+#### File Operations
+
+| Shortcut | Action |
+|----------|--------|
+| `F2` | New file |
 | `Ctrl+O` | Open file |
-| `Ctrl+S` | Save file |
-| `Ctrl+Q` | Quit |
-| `Ctrl+A` | AI assistant panel |
-| `Ctrl+G` | Git panel |
-| `Ctrl+F` | Search in file |
-| `F1` | Help |
+| `Ctrl+S` | Save |
+| `F5` | Save as... |
+| `Ctrl+Q` | Quit editor |
+
+#### Tools & Panels
+
+| Shortcut | Action |
+|----------|--------|
+| `F10` | File Explorer |
+| `F4` | Diagnostics / Linter panel |
+| `F9` | Git menu |
+| `F7` | AI Assistant panel |
+| `F8` | System Doctor |
+| `F1` | Show Keyboard Shortcuts |
+| `Esc` | Close current panel |
+| `Insert` | Toggle Insert / Overwrite mode |
+| `F12` | Switch focus between editor windows and panels |
+
+The right side of the editor hosts workflow panels. The v0.2.0 service panels
+are read-only or preview-only: System Doctor does not mutate host state, Command
+Plan previews do not execute, and the Services panel reports composition status.
+
+### Minimal Service CLI
+
+The default CLI path still launches the editor:
+
+```bash
+python3 -m ecli
+python3 -m ecli pyproject.toml
+```
+
+The explicit service flags provide read-only inspection without bypassing the
+TUI model:
+
+```bash
+python3 -m ecli --services
+python3 -m ecli --doctor
+python3 -m ecli --plan-preview
+```
+
+Use `--json` for deterministic JSON output where supported. These commands are
+inspection and preview surfaces only; they do not execute plans, run privileged
+commands, install packages, start VMLab, or apply remediation.
+
+### AI Configuration
+
+AI features require user-provided provider credentials. API keys belong in:
+
+```text
+~/.config/ecli/.env
+```
+
+Provider selection belongs in `config.toml`, not in `.env`. If a selected
+provider key is missing, the AI panel reports a normal configuration message
+instead of a Python traceback.
 
 For comprehensive keybindings and usage guide, see [Getting Started](https://github.com/SSobol77/ecli/blob/main/docs/contributor/development-setup.md).
 
@@ -298,14 +391,27 @@ Complete documentation is organized by audience:
 
 ## 🏗️ Architecture
 
-ECLI is built on a modern, extensible architecture:
+ECLI v0.2.0 keeps the existing editor/TUI behavior and introduces the Services
+Foundation as typed, testable service-layer infrastructure:
 
-- **Core Editor**: Python with async/await for responsive UI
-- **Terminal UI**: curses-based for full terminal control
-- **AI Integration**: Pluggable AI provider system (OpenAI, Anthropic, HuggingFace, Ollama)
-- **LSP Client**: Language Server Protocol for IDE-like features
-- **Git Integration**: Direct git repository management
-- **Plugin System**: Extensible architecture for custom features
+- **Core Editor**: curses-based terminal editor with async task integration
+- **Right-Side Panels**: Help, Diagnostics/Lint, AI Code Assistant, System Doctor, Git, File Manager, Services, and Command Plan previews
+- **ConfigService**: typed layered configuration loading
+- **ProjectService**: deterministic project discovery and path normalization
+- **CommandPlanService**: draft command-plan models and preview/export behavior
+- **BuiltInPolicyEngine**: deterministic built-in policy evaluation rules
+- **AuditLogService**: append-only JSONL audit records with mandatory redaction
+- **PrivilegedActionService**: refusal-only/dry-run-only skeleton for future elevated operations
+- **SystemDoctor**: read-only diagnostic skeleton with draft remediation-plan generation
+- **ServiceRegistry**: explicit composition root without global service-locator state
+
+Safety boundaries for v0.2.0:
+
+- SystemDoctor is read-only.
+- CommandPlan output is draft/preview-only.
+- PrivilegedActionService refuses real execution in this release.
+- Service panels are visible in the UI but do not execute remediation.
+- VMLab runtime behavior is not included in v0.2.0.
 
 For detailed architecture information, see [Architecture Overview](https://github.com/SSobol77/ecli/blob/main/docs/architecture/current-architecture.md).
 

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -14,7 +14,7 @@ See the LICENSE file in the project root for full license text.
 -->
 # Installing on macOS
 
-ECLI v0.1.0 ships a Universal2 DMG for macOS 12 and newer:
+ECLI ships a Universal2 DMG for macOS 12 and newer:
 
 ```text
 ecli_<version>_macos_universal2.dmg
@@ -46,7 +46,7 @@ DMG is used on Intel Macs and Apple Silicon Macs.
 
 ## First Launch and Gatekeeper
 
-ECLI v0.1.0 is ad-hoc signed but not notarized. On first launch, macOS
+Current ECLI macOS artifacts are ad-hoc signed but not notarized. On first launch, macOS
 Gatekeeper may block it with a message similar to:
 
 ```text
@@ -77,8 +77,9 @@ xattr -d com.apple.quarantine ~/bin/ecli
 
 ## Why Is the Binary Unsigned?
 
-ECLI v0.1.0 is an early release intended for early adopters and project
-visibility. Apple Developer Program enrollment is not yet available for this
-project, so v0.1.0 uses ad-hoc signing without notarization.
+ECLI is an early release intended for early adopters and project visibility.
+Apple Developer Program enrollment is not yet available for this project, so
+current artifacts use ad-hoc signing without notarization.
 
-Developer ID signing, notarization, and stapling are planned for v0.2.
+Developer ID signing, notarization, and stapling are planned for a later
+release.

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -27,7 +27,7 @@ version you intend to install.
 PowerShell checksum verification should be performed before first execution:
 
 ```powershell
-$version = "0.1.0"
+$version = "0.2.0"
 $file = "ecli_${version}_win_x86_64_setup.exe"
 $expected = (Get-Content "$file.sha256" -Raw).Trim().Split()[0]
 $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $file).Hash.ToLowerInvariant()
@@ -53,7 +53,7 @@ The sidecar format is compatible with coreutils:
 The installer is the recommended Windows path for normal workstations:
 
 ```powershell
-.\ecli_0.1.0_win_x86_64_setup.exe
+.\ecli_0.2.0_win_x86_64_setup.exe
 ```
 
 The NSIS installer writes ECLI under `C:\Program Files\Cartesian School\ECLI`,
@@ -71,7 +71,7 @@ The registered uninstall metadata includes `DisplayName`, `DisplayVersion`,
 Use the portable executable when you do not want a machine-level installation:
 
 ```powershell
-.\ecli_0.1.0_win_x86_64.exe
+.\ecli_0.2.0_win_x86_64.exe
 ```
 
 The portable artifact is a PyInstaller `--onefile` executable. It does not
@@ -80,12 +80,13 @@ runtime file access performed by ECLI.
 
 ## SmartScreen
 
-ECLI v0.1.0 Windows artifacts are unsigned. Windows SmartScreen may block first
+Current ECLI Windows artifacts are unsigned. Windows SmartScreen may block first
 launch or installation with a warning. To proceed after verifying the checksum:
 
 1. Select **More info**.
 2. Confirm the publisher is shown as unknown or unsigned.
 3. Select **Run anyway**.
 
-Code signing is planned for v0.2. Until signed artifacts are available, checksum
-verification against the release sidecar is the integrity check.
+Code signing is planned for a later release. Until signed artifacts are
+available, checksum verification against the release sidecar is the integrity
+check.

--- a/docs/planning/risk-register.md
+++ b/docs/planning/risk-register.md
@@ -23,20 +23,20 @@ See the LICENSE file in the project root for full license text.
 | Concurrency/event contract gaps | Medium | High | High | queue payload/runtime handling errors | typed payload contracts + gateway rules | Core + Integration maintainers | Open |
 | Contributor workflow drift | Medium | Medium | Medium | setup/build docs mismatch reports | command verification policy | Contributor maintainers | Open |
 | Extension safety boundary ambiguity | Medium | Medium | Medium | extension integration defects | extension guardrails + review checks | Extension maintainers | Open |
-| Static PyPI token exposure | Medium | High | High | secret scanning, release workflow audit, PyPI project event history | keep token scoped to `ecli-editor`; migrate to PyPI Trusted Publishers/OIDC in v0.2 | Release maintainers | New Phase 1 residual |
-| Unsigned Windows binary user friction | High | Medium | Medium | user install reports, SmartScreen prompts | document SmartScreen path for v0.1.0; add Azure Trusted Signing or EV certificate in v0.2 | Release maintainers | New Phase 1 residual |
-| macOS non-notarized first launch friction | High | Medium | Medium | user install reports, Gatekeeper prompts | document Gatekeeper workaround for v0.1.0; add Developer ID signing, hardened runtime, notarization, and stapling in v0.2 | Release maintainers | New Phase 1 residual |
+| Static PyPI token exposure | Medium | High | High | secret scanning, release workflow audit, PyPI project event history | keep token scoped to `ecli-editor`; migrate to PyPI Trusted Publishers/OIDC in a later release | Release maintainers | New Phase 1 residual |
+| Unsigned Windows binary user friction | High | Medium | Medium | user install reports, SmartScreen prompts | document SmartScreen path; add Azure Trusted Signing or EV certificate in a later release | Release maintainers | New Phase 1 residual |
+| macOS non-notarized first launch friction | High | Medium | Medium | user install reports, Gatekeeper prompts | document Gatekeeper workaround; add Developer ID signing, hardened runtime, notarization, and stapling in a later release | Release maintainers | New Phase 1 residual |
 | FreeBSD package polish deferred | Medium | Medium | Medium | FreeBSD release validation, package metadata audit | keep canonical Phase 0 FreeBSD package flow functional; schedule manifest polish and canonical naming audit in Workstream D | Release maintainers | Deferred |
 | License metadata drift | Low | Medium | Low | SPDX/header scan, package metadata review | PR #17 normalized Apache-2.0 headers and project-owned license metadata | Release maintainers | Mitigated in Phase 1 |
 
 ## Contingency Notes
 
 - Critical/High risks block release if tied to artifact contract, config parse safety, or core mutation invariants.
-- v0.1.0 accepts documented trust-friction risk for unsigned Windows artifacts
-  and ad-hoc signed macOS artifacts. These risks must be closed before claiming
-  production-grade first-launch trust.
+- Current releases accept documented trust-friction risk for unsigned Windows
+  artifacts and ad-hoc signed macOS artifacts. These risks must be closed before
+  claiming production-grade first-launch trust.
 - Static PyPI token exposure is acceptable only as a Phase 1 bridge. Treat OIDC
-  migration as a v0.2 release-readiness item, not a long-term architecture.
+  migration as a later release-readiness item, not a long-term architecture.
 
 ## Related Contract References
 

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -23,3 +23,4 @@ Authoritative files:
 - `release-process.md`
 - `release-checklist.md`
 - `artifact-verification.md`
+- `v0.2.0.md`

--- a/docs/release/release-process.md
+++ b/docs/release/release-process.md
@@ -93,8 +93,8 @@ The PyPI namespace guard remains mandatory before publish. It verifies that
 `pyproject.toml` declares `ecli-editor` and that the project exists on PyPI
 before the upload step can run.
 
-Trusted Publishers (OIDC) are deferred to v0.2. That migration will remove the
-static token requirement.
+Trusted Publishers (OIDC) are deferred to a later release. That migration will
+remove the static token requirement.
 
 ## SBOM
 

--- a/docs/release/v0.2.0.md
+++ b/docs/release/v0.2.0.md
@@ -1,0 +1,112 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+
+Project: Ecli
+File: docs/release/v0.2.0.md
+Website: https://www.ecli.io
+Repository: https://github.com/SSobol77/ecli
+PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+
+Copyright (c) 2026 Siergej Sobolewski
+
+Licensed under the Apache License, Version 2.0.
+See the LICENSE file in the project root for full license text.
+-->
+# ECLI v0.2.0 Release Notes
+
+## Release Theme
+
+ECLI v0.2.0 is the Services Foundation release. It keeps the existing
+terminal-editor workflow intact and adds user-visible service panels plus a
+minimal read-only CLI for inspecting the Phase 1 services.
+
+## User-Visible Panels
+
+| Key | Panel |
+|---|---|
+| `F1` | Help |
+| `F4` | Diagnostics/Lint |
+| `F7` | AI Code Assistant |
+| `F8` | System Doctor |
+| `F9` | Git panel |
+| `F10` | File Manager |
+
+The System Doctor, Services, and Command Plan surfaces are diagnostic and
+preview surfaces only in v0.2.0. They do not execute fixes, run privileged
+commands, install packages, start VMLab, or apply command plans.
+
+## Services Foundation
+
+The release includes these service-layer components:
+
+- `ConfigService`
+- `ProjectService`
+- `CommandPlanService`
+- `BuiltInPolicyEngine`
+- `AuditLogService`
+- `PrivilegedActionService` refusal-only skeleton
+- `SystemDoctor` read-only skeleton
+- `ServiceRegistry` composition root
+
+## Minimal Service CLI
+
+The default editor launch path is unchanged:
+
+```sh
+python3 -m ecli
+python3 -m ecli pyproject.toml
+```
+
+The explicit service flags are safe inspection surfaces:
+
+```sh
+python3 -m ecli --services
+python3 -m ecli --doctor
+python3 -m ecli --plan-preview
+```
+
+Use `--json` for deterministic JSON output where supported.
+
+## AI Configuration
+
+AI features require user-provided API keys. Provider selection belongs in
+`config.toml`; API keys belong in `~/.config/ecli/.env`.
+
+If the selected provider key is missing or invalid, the AI panel reports a
+normal configuration message instead of exposing a Python traceback.
+
+## Safety Boundaries
+
+- SystemDoctor is read-only.
+- CommandPlan preview is draft/preview-only.
+- PrivilegedActionService is refusal-only in this release.
+- Service panels are UI-visible but do not execute remediation.
+- No plan apply functionality is included.
+- No real privileged execution path is included.
+- No VMLab runtime behavior is included.
+
+## Expected Release Artifacts
+
+The tag-triggered release workflow is expected to produce:
+
+- PyPI wheel and source distribution.
+- Linux `.deb`.
+- Linux `.rpm`.
+- Linux `.tar.gz`.
+- Windows portable `.exe`.
+- Windows setup `.exe`.
+- macOS universal2 `.dmg`.
+- FreeBSD `.pkg`.
+- CycloneDX SBOM.
+- SHA256 sidecars.
+
+## Manual Smoke Commands
+
+Run these from a source checkout before tagging:
+
+```sh
+PYTHONPATH=src python3 -m ecli --services --project-root logs --logs-root logs --json
+PYTHONPATH=src python3 -m ecli --doctor --project-root logs --logs-root logs --category config
+PYTHONPATH=src python3 -m ecli --plan-preview --project-root logs --logs-root logs --category config --json
+PYTHONPATH=src python3 -m ecli pyproject.toml
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ecli-editor"
-version = "0.1.3"
-description = "ECLI — fast terminal code editor"
+version = "0.2.0"
+description = "ECLI — terminal-first engineering operations workbench"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "Apache-2.0"


### PR DESCRIPTION
Prepares ECLI v0.2.0 Services Foundation release.

Scope:
- bumps package version to 0.2.0
- updates README/PyPI-facing documentation before publication
- documents right-side TUI panel UX:
  - F1 Help
  - F4 Diagnostics/Lint
  - F7 AI Code Assistant
  - F8 System Doctor
  - F9 Git panel
  - F10 File Manager
- documents Phase 1 service foundation:
  - ConfigService
  - ProjectService
  - CommandPlanService
  - BuiltInPolicyEngine
  - AuditLogService
  - PrivilegedActionService refusal-only skeleton
  - SystemDoctor read-only skeleton
  - ServiceRegistry composition root
- documents minimal service CLI:
  - python3 -m ecli --services
  - python3 -m ecli --doctor
  - python3 -m ecli --plan-preview
- documents AI API key configuration:
  - API keys in ~/.config/ecli/.env
  - provider selection in config.toml
- prepares release notes for v0.2.0
- documents expected cross-platform release artifacts:
  - PyPI wheel/sdist
  - Linux .deb
  - Linux .rpm
  - Linux tar.gz
  - Windows portable .exe
  - Windows setup.exe
  - macOS universal2 .dmg
  - FreeBSD .pkg
  - SBOM
  - sha256 sidecars

Not included:
- no tag creation
- no PyPI publication
- no GitHub Release publication
- no VMLab runtime execution
- no real privileged execution
- no plan apply flow
- no real remediation

Validation:
- python3 -m pytest tests/test_smoke.py -v
- python3 -m pytest tests/services -v
- python3 -m pytest tests/characterization -v
- python3 -m pytest tests/ui -v
- python3 -m pytest tests/cli -v
- python3 -m compileall src
- ruff check src tests
- ruff format --check src tests
- ./scripts/check-log-invariant.sh
- git diff --check

Manual smoke:
- PYTHONPATH=src python3 -m ecli --services --project-root logs --logs-root logs --json
- PYTHONPATH=src python3 -m ecli --doctor --project-root logs --logs-root logs --category config
- PYTHONPATH=src python3 -m ecli --plan-preview --project-root logs --logs-root logs --category config --json
- PYTHONPATH=src python3 -m ecli pyproject.toml
