### PR TITLE
fix(release): stabilize v0.2.2 packaged runtime and TUI panels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,22 @@ name: CI
     branches: [main]
     paths:
       - ".github/workflows/ci.yml"
+      - "Makefile"
       - "main.py"
       - "pyproject.toml"
+      - "scripts/check_runtime_imports.py"
+      - "scripts/verify_runtime.sh"
       - "src/**"
       - "tests/**"
   pull_request:
     branches: [main]
     paths:
       - ".github/workflows/ci.yml"
+      - "Makefile"
       - "main.py"
       - "pyproject.toml"
+      - "scripts/check_runtime_imports.py"
+      - "scripts/verify_runtime.sh"
       - "src/**"
       - "tests/**"
 

--- a/.github/workflows/freebsd-pkg.yml
+++ b/.github/workflows/freebsd-pkg.yml
@@ -22,6 +22,8 @@ name: FreeBSD 14 .pkg
       - "src/**"
       - "packaging/**"
       - "scripts/build-and-package-freebsd.sh"
+      - "scripts/check_runtime_imports.py"
+      - "scripts/verify_runtime.sh"
       - "ecli.spec"
       - "pyproject.toml"
 
@@ -51,6 +53,7 @@ jobs:
           prepare: |
             set -eux
             env ASSUME_ALWAYS_YES=yes pkg update -f
+            env ASSUME_ALWAYS_YES=yes pkg install -y bash
           run: |
             set -eux
             sh ./scripts/build-and-package-freebsd.sh

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -21,6 +21,8 @@ name: macOS DMG
       - ".github/workflows/macos-dmg.yml"
       - "src/**"
       - "scripts/build-and-package-macos.sh"
+      - "scripts/check_runtime_imports.py"
+      - "scripts/verify_runtime.sh"
       - "packaging/pyinstaller/ecli.spec"
       - "ecli.spec"
       - "pyproject.toml"

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Verify artifact contract
         run: |
-          make package-macos-assert
+          make package-macos-assert MACOS_ASSERT_MODE=structural
           make show-macos-artifacts
 
       - name: Read version
@@ -60,30 +60,6 @@ jobs:
         run: |
           VER=$(awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ {print $2; exit}' pyproject.toml)
           echo "version=$VER" >> "$GITHUB_OUTPUT"
-
-      - name: Smoke test Universal2 binary inside DMG
-        run: |
-          set -euo pipefail
-          version="${{ steps.ver.outputs.version }}"
-          dmg="releases/${version}/ecli_${version}_macos_universal2.dmg"
-          mountpoint="$RUNNER_TEMP/ecli-dmg"
-          mkdir -p "$mountpoint"
-          hdiutil attach -readonly -nobrowse -mountpoint "$mountpoint" "$dmg"
-          trap 'hdiutil detach "$mountpoint"' EXIT
-          if [ -x "$mountpoint/ecli" ]; then
-            binary="$mountpoint/ecli"
-          elif [ -x "$mountpoint/ECLI.app/Contents/MacOS/ecli" ]; then
-            binary="$mountpoint/ECLI.app/Contents/MacOS/ecli"
-          else
-            echo "No ECLI binary found inside mounted DMG."
-            find "$mountpoint" -maxdepth 4 -print
-            exit 1
-          fi
-          info="$(lipo -info "$binary")"
-          echo "$info"
-          echo "$info" | grep -q x86_64
-          echo "$info" | grep -q arm64
-          codesign --verify --verbose "$binary"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macos-validate.yml
+++ b/.github/workflows/macos-validate.yml
@@ -58,28 +58,6 @@ jobs:
         run: make package-macos
 
       - name: Validate macOS contract
-        run: make validate-macos-contract
-
-      - name: Smoke test Universal2 binary inside DMG
         run: |
-          set -euo pipefail
-          version="$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
-          dmg="releases/${version}/ecli_${version}_macos_universal2.dmg"
-          mountpoint="$RUNNER_TEMP/ecli-dmg"
-          mkdir -p "$mountpoint"
-          hdiutil attach -readonly -nobrowse -mountpoint "$mountpoint" "$dmg"
-          trap 'hdiutil detach "$mountpoint"' EXIT
-          if [ -x "$mountpoint/ecli" ]; then
-            binary="$mountpoint/ecli"
-          elif [ -x "$mountpoint/ECLI.app/Contents/MacOS/ecli" ]; then
-            binary="$mountpoint/ECLI.app/Contents/MacOS/ecli"
-          else
-            echo "No ECLI binary found inside mounted DMG."
-            find "$mountpoint" -maxdepth 4 -print
-            exit 1
-          fi
-          info="$(lipo -info "$binary")"
-          echo "$info"
-          echo "$info" | grep -q x86_64
-          echo "$info" | grep -q arm64
-          codesign --verify --verbose "$binary"
+          make validate-macos-contract MACOS_ASSERT_MODE=structural
+          make show-macos-artifacts

--- a/.github/workflows/macos-validate.yml
+++ b/.github/workflows/macos-validate.yml
@@ -22,6 +22,8 @@ name: macOS Contract Validate
       - "Makefile"
       - "pyproject.toml"
       - "scripts/build-and-package-macos.sh"
+      - "scripts/check_runtime_imports.py"
+      - "scripts/verify_runtime.sh"
       - "packaging/pyinstaller/ecli.spec"
       - "src/**"
       - "packaging/**"

--- a/.github/workflows/pypi-validate.yml
+++ b/.github/workflows/pypi-validate.yml
@@ -80,7 +80,7 @@ jobs:
 
           wheel_name = project["name"].replace("-", "_")
           version = project["version"]
-          print(f"dist/{wheel_name}-{version}-py3-none-any.whl.sha256")
+          print(f"releases/{version}/{wheel_name}-{version}-py3-none-any.whl.sha256")
           PY
           )"
           cp "$wheel_sha" "$wheel_sha.bak"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,32 +221,8 @@ jobs:
 
       - name: Verify DMG
         run: |
-          make package-macos-assert
+          make package-macos-assert MACOS_ASSERT_MODE=structural
           make show-macos-artifacts
-
-      - name: Smoke test Universal2 binary inside DMG
-        run: |
-          set -euo pipefail
-          version="$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
-          dmg="releases/${version}/ecli_${version}_macos_universal2.dmg"
-          mountpoint="$RUNNER_TEMP/ecli-dmg"
-          mkdir -p "$mountpoint"
-          hdiutil attach -readonly -nobrowse -mountpoint "$mountpoint" "$dmg"
-          trap 'hdiutil detach "$mountpoint"' EXIT
-          if [ -x "$mountpoint/ecli" ]; then
-            binary="$mountpoint/ecli"
-          elif [ -x "$mountpoint/ECLI.app/Contents/MacOS/ecli" ]; then
-            binary="$mountpoint/ECLI.app/Contents/MacOS/ecli"
-          else
-            echo "No ECLI binary found inside mounted DMG."
-            find "$mountpoint" -maxdepth 4 -print
-            exit 1
-          fi
-          info="$(lipo -info "$binary")"
-          echo "$info"
-          echo "$info" | grep -q x86_64
-          echo "$info" | grep -q arm64
-          codesign --verify --verbose "$binary"
 
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,32 +37,37 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Guard production runtime imports
+        run: python3 scripts/check_runtime_imports.py
+
       - name: Build wheel and sdist
         run: |
           set -euo pipefail
           python3 -m pip install --upgrade build twine
-          python3 -m build
-          python3 -m twine check --strict dist/*.whl dist/*.tar.gz
           VERSION=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+          RELEASE_DIR="releases/${VERSION}"
+          mkdir -p "${RELEASE_DIR}"
+          python3 -m build --outdir "${RELEASE_DIR}"
+          python3 -m twine check --strict \
+            "${RELEASE_DIR}/ecli_editor-${VERSION}-py3-none-any.whl" \
+            "${RELEASE_DIR}/ecli_editor-${VERSION}.tar.gz"
           python3 -m pip install --user cyclonedx-bom
           python3 -m cyclonedx_py environment \
             --pyproject pyproject.toml \
             --sv 1.5 \
             --output-format json \
-            --output-file "dist/ecli-editor-${VERSION}.cdx.json" \
+            --output-file "${RELEASE_DIR}/ecli-editor-${VERSION}.cdx.json" \
             --validate
-          cd dist
-          sha256sum "ecli-editor-${VERSION}.cdx.json" > "ecli-editor-${VERSION}.cdx.json.sha256"
-          cd ..
-          ls -lh dist/
+          (cd "${RELEASE_DIR}" && sha256sum "ecli-editor-${VERSION}.cdx.json" > "ecli-editor-${VERSION}.cdx.json.sha256")
+          ls -lh "${RELEASE_DIR}/"
 
       - name: Upload Python distributions
         uses: actions/upload-artifact@v4
         with:
           name: python-dist
           path: |
-            dist/*.whl
-            dist/*.tar.gz
+            releases/**/*.whl
+            releases/**/*.tar.gz
           if-no-files-found: error
 
       - name: Upload Python SBOM
@@ -70,8 +75,8 @@ jobs:
         with:
           name: python-sbom
           path: |
-            dist/*.cdx.json
-            dist/*.cdx.json.sha256
+            releases/**/*.cdx.json
+            releases/**/*.cdx.json.sha256
           if-no-files-found: error
 
   build-linux:
@@ -85,6 +90,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install host package inspection tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends rpm cpio
 
       - name: Build Linux archive
         run: make package-tar-linux
@@ -157,7 +168,7 @@ jobs:
             # dependency) has no FreeBSD prebuilt wheel and must be
             # compiled from source. Other build essentials cover any
             # additional native deps that may need on-VM compilation.
-            env ASSUME_ALWAYS_YES=yes pkg install -y rust pkgconf
+            env ASSUME_ALWAYS_YES=yes pkg install -y bash rust pkgconf
             rustc --version
             cargo --version
           run: |

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -21,6 +21,8 @@ name: Windows Installer
       - ".github/workflows/windows-installer.yml"
       - "src/**"
       - "scripts/build-and-package-windows.ps1"
+      - "scripts/check_runtime_imports.py"
+      - "scripts/verify_runtime.sh"
       - "packaging/windows/nsis/**"
       - "packaging/pyinstaller/ecli.spec"
       - "pyproject.toml"
@@ -164,6 +166,17 @@ jobs:
           if (-not (Test-Path $uninstaller)) { throw "Missing uninstaller: $uninstaller" }
           if ($props.UninstallString -notmatch [regex]::Escape($uninstaller)) {
             throw "UninstallString does not reference $uninstaller"
+          }
+
+          $installedExe = Join-Path $props.InstallLocation "ecli.exe"
+          if (-not (Test-Path $installedExe)) { throw "Missing installed launcher: $installedExe" }
+          $help = & $installedExe --help
+          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace(($help -join "`n"))) {
+            throw "Installed ecli.exe --help failed"
+          }
+          $versionOutput = (& $installedExe --version) -join "`n"
+          if ($LASTEXITCODE -ne 0 -or $versionOutput.Trim() -ne "ecli $version") {
+            throw "Installed ecli.exe --version mismatch: '$versionOutput'"
           }
 
           $uninstall = Start-Process -FilePath $uninstaller -ArgumentList "/S" -Wait -PassThru

--- a/.github/workflows/windows-validate.yml
+++ b/.github/workflows/windows-validate.yml
@@ -22,6 +22,8 @@ name: Windows Contract Validate
       - "Makefile"
       - "pyproject.toml"
       - "scripts/build-and-package-windows.ps1"
+      - "scripts/check_runtime_imports.py"
+      - "scripts/verify_runtime.sh"
       - "packaging/windows/**"
       - "packaging/pyinstaller/ecli.spec"
       - "src/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 0.2.2 - Packaged Runtime Startup Fixes
+
+### Fixed
+
+- Fixed packaged/frozen runtime startup failure caused by a test-only
+  `unittest.mock` dependency leaking into production code.
+
+- Added visible stderr diagnostics for critical pre-curses startup failures.
+
+- Added cross-package runtime smoke validation for packaged ECLI launchers.
+
+- Fixed Git Panel status command getting stuck at
+  `Running: git status ...` without rendering command results.
+
+- Fixed Git Panel repository detection and working-directory handling.
+
+- Fixed Git Panel BUSY state reset after command completion, errors, timeout,
+  or cancellation.
+
+- Fixed Git Panel cancellation/output messages rendering outside the output
+  pane.
+
+- Fixed global Help shortcut being blocked by active panels.
+
+- Fixed AI Code Assistant shortcut crashing when invoked while File Manager is
+  active.
+
+- Made F7 AI Code Assistant close File Manager automatically and continue with
+  the normal editor AI flow.
+
+- Hardened editor selection handling so invalid panel/editor state cannot raise
+  `IndexError`.
+
+- Prevented selection warnings/log records from being printed into the curses
+  editor canvas.
+
+- Prevented input handler tracebacks from corrupting the curses screen.
+
+- Preserved global Help behavior across active panels.
+
+### Packaging
+
+- Hardened release builds with production import guards.
+
+- Ensured packaged `ecli --help` and `ecli --version` can run without curses
+  initialization.
+
+- Enforced artifact output under the current project version directory.
+
 ## 0.2.1 - Release Hardening and Packaging
 
 ECLI v0.2.1 is a release-hardening update for source editing correctness, Python package assets, Linux desktop integration, and Linux package coverage.

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,13 @@ define validate_if_present
 	fi
 endef
 
+define assert_current_release_file
+	@case "$(1)" in \
+		releases/$(PACKAGE_VERSION)/*) ;; \
+		*) echo "Artifact path is outside current release directory releases/$(PACKAGE_VERSION): $(1)"; exit 8 ;; \
+	esac
+endef
+
 .DEFAULT_GOAL := help
 
 # ---- FreeBSD .pkg (via vmactions/freebsd-vm) -------------------------------
@@ -198,16 +205,18 @@ distclean: clean
 # =============================================================================
 
 PYPI_VERSION    ?= $(PACKAGE_VERSION)
-PYPI_PKG_DIR    ?= dist
+PYPI_PKG_DIR    ?= $(RELEASE_DIR)
 PYPI_DIST_NAME   ?= ecli_editor
 PYPI_WHEEL_FILE ?= $(PYPI_PKG_DIR)/$(PYPI_DIST_NAME)-$(PYPI_VERSION)-py3-none-any.whl
 PYPI_SDIST_FILE ?= $(PYPI_PKG_DIR)/$(PYPI_DIST_NAME)-$(PYPI_VERSION).tar.gz
 
 .PHONY: package-pypi
-package-pypi: clean
+package-pypi: clean validate-runtime-imports
 	@echo "--> Building Python packages (wheel + sdist)..."
-	$(PYTHON) -m build
-	$(PYTHON) -m twine check --strict dist/*.whl dist/*.tar.gz
+	@mkdir -p "$(PYPI_PKG_DIR)"
+	@rm -f "$(PYPI_WHEEL_FILE)" "$(PYPI_WHEEL_FILE).sha256" "$(PYPI_SDIST_FILE)" "$(PYPI_SDIST_FILE).sha256"
+	$(PYTHON) -m build --outdir "$(PYPI_PKG_DIR)"
+	$(PYTHON) -m twine check --strict "$(PYPI_WHEEL_FILE)" "$(PYPI_SDIST_FILE)"
 	@for artifact in "$(PYPI_WHEEL_FILE)" "$(PYPI_SDIST_FILE)"; do \
 		dir="$$(dirname "$$artifact")"; \
 		base="$$(basename "$$artifact")"; \
@@ -225,6 +234,8 @@ package-pypi: clean
 .PHONY: package-pypi-assert
 package-pypi-assert:
 	@test -n "$(PYPI_VERSION)" || (echo "PYPI_VERSION is empty"; exit 1)
+	$(call assert_current_release_file,$(PYPI_WHEEL_FILE))
+	$(call assert_current_release_file,$(PYPI_SDIST_FILE))
 	$(call verify_sha256,$(PYPI_WHEEL_FILE))
 	$(call verify_sha256,$(PYPI_SDIST_FILE))
 	@echo "--> OK: $(PYPI_WHEEL_FILE)"
@@ -235,7 +246,7 @@ package-pypi-assert:
 .PHONY: show-python-artifacts
 show-python-artifacts:
 	@echo "Version: $(PYPI_VERSION)"
-	@ls -lh dist/ 2>/dev/null || echo "(no artifacts yet)"
+	@ls -lh "$(PYPI_PKG_DIR)"/*.whl "$(PYPI_PKG_DIR)"/*.tar.gz 2>/dev/null || echo "(no artifacts yet)"
 
 .PHONY: publish-pypi
 publish-pypi: package-pypi-assert
@@ -283,12 +294,12 @@ DEB_PKG_FILE    ?= $(DEB_PKG_DIR)/ecli_$(DEB_PKG_VERSION)_linux_$(LINUX_ARCH).de
 DEB_SHA_FILE    ?= $(DEB_PKG_FILE).sha256
 
 .PHONY: package-deb
-package-deb: clean
+package-deb: clean validate-runtime-imports
 	./scripts/build-and-package-deb.sh
 	$(MAKE) package-deb-assert
 
 .PHONY: package-deb-docker
-package-deb-docker: clean
+package-deb-docker: clean validate-runtime-imports
 	docker build -f docker/build-linux-deb.Dockerfile \
 		--build-arg PYTHON_VERSION=3.11 \
 		--build-arg DEBIAN_RELEASE=bullseye \
@@ -300,7 +311,9 @@ package-deb-docker: clean
 .PHONY: package-deb-assert
 package-deb-assert:
 	@test -n "$(DEB_PKG_VERSION)" || (echo "DEB_PKG_VERSION is empty (check pyproject.toml)"; exit 1)
+	$(call assert_current_release_file,$(DEB_PKG_FILE))
 	$(call verify_sha256,$(DEB_PKG_FILE))
+	@./scripts/verify_runtime.sh "$(DEB_PKG_FILE)"
 	@echo "--> OK: $(DEB_PKG_FILE)"
 	@echo "--> OK: $(DEB_SHA_FILE)"
 
@@ -361,12 +374,12 @@ RPM_PKG_FILE    ?= $(RPM_PKG_DIR)/ecli_$(RPM_PKG_VERSION)_linux_$(LINUX_ARCH).rp
 RPM_SHA_FILE    ?= $(RPM_PKG_FILE).sha256
 
 .PHONY: package-rpm
-package-rpm: clean
+package-rpm: clean validate-runtime-imports
 	./scripts/build-and-package-rpm.sh
 	$(MAKE) package-rpm-assert
 
 .PHONY: package-rpm-docker
-package-rpm-docker: clean
+package-rpm-docker: clean validate-runtime-imports
 	docker build -f docker/build-linux-rpm.Dockerfile -t ecli-rpm:alma9 .
 	docker run --rm -v "$$(pwd):/app" -w /app ecli-rpm:alma9
 	$(MAKE) package-rpm-assert
@@ -375,7 +388,9 @@ package-rpm-docker: clean
 .PHONY: package-rpm-assert
 package-rpm-assert:
 	@test -n "$(RPM_PKG_VERSION)" || (echo "RPM_PKG_VERSION is empty (check pyproject.toml)"; exit 1)
+	$(call assert_current_release_file,$(RPM_PKG_FILE))
 	$(call verify_sha256,$(RPM_PKG_FILE))
+	@./scripts/verify_runtime.sh "$(RPM_PKG_FILE)"
 	@echo "--> OK: $(RPM_PKG_FILE)"
 	@echo "--> OK: $(RPM_SHA_FILE)"
 
@@ -437,7 +452,7 @@ APPIMAGE_FILE    ?= $(APPIMAGE_PKG_DIR)/ecli_$(APPIMAGE_VERSION)_linux_$(LINUX_A
 APPIMAGE_SHA_FILE?= $(APPIMAGE_FILE).sha256
 
 .PHONY: package-appimage
-package-appimage: clean
+package-appimage: clean validate-runtime-imports
 	@command -v appimagetool >/dev/null 2>&1 || (echo "appimagetool not found. Install AppImageKit: https://github.com/AppImage/AppImageKit"; exit 1)
 	@echo "--> Building AppImage..."
 	bash ./scripts/package_appimage.sh "$(APPIMAGE_VERSION)" "$(LINUX_ARCH)"
@@ -450,7 +465,9 @@ package-appimage: clean
 .PHONY: package-appimage-assert
 package-appimage-assert:
 	@test -n "$(APPIMAGE_VERSION)" || (echo "APPIMAGE_VERSION is empty"; exit 1)
+	$(call assert_current_release_file,$(APPIMAGE_FILE))
 	$(call verify_sha256,$(APPIMAGE_FILE))
+	@./scripts/verify_runtime.sh "$(APPIMAGE_FILE)"
 	@echo "--> OK: $(APPIMAGE_FILE)"
 	@echo "--> OK: $(APPIMAGE_SHA_FILE)"
 
@@ -501,7 +518,7 @@ SNAP_FILE     ?= $(SNAP_PKG_DIR)/ecli_$(SNAP_VERSION)_linux_$(LINUX_ARCH).snap
 SNAP_SHA_FILE ?= $(SNAP_FILE).sha256
 
 .PHONY: package-snap
-package-snap: clean
+package-snap: clean validate-runtime-imports
 	@command -v snapcraft >/dev/null 2>&1 || (echo "snapcraft not found. Install: sudo snap install snapcraft --classic"; exit 1)
 	@test -f snapcraft.yaml || (echo "snapcraft.yaml not found in project root"; exit 1)
 	@echo "--> Building Snap..."
@@ -523,6 +540,7 @@ package-snap: clean
 
 .PHONY: package-snap-assert
 package-snap-assert:
+	$(call assert_current_release_file,$(SNAP_FILE))
 	$(call verify_sha256,$(SNAP_FILE))
 	@echo "--> OK: $(SNAP_FILE)"
 	@echo "--> OK: $(SNAP_SHA_FILE)"
@@ -554,22 +572,27 @@ TAR_LINUX_FILE?= $(TAR_PKG_DIR)/ecli_$(TAR_VERSION)_linux_$(LINUX_ARCH).tar.gz
 TAR_SHA_FILE  ?= $(TAR_LINUX_FILE).sha256
 
 .PHONY: package-tar-linux
-package-tar-linux: clean
-	@echo "--> Creating Linux tar.gz archive..."
+package-tar-linux: clean validate-runtime-imports
+	@echo "--> Building Linux binary tar.gz archive..."
 	@mkdir -p $(TAR_PKG_DIR)
-	@echo "ECLI v$(TAR_VERSION)" > RELEASE_NOTES.txt
-	@tar --exclude='.git' --exclude='.venv' --exclude='build' --exclude='dist' \
-		--exclude='releases' --exclude='__pycache__' --exclude='.pytest_cache' \
-		-czf "$(TAR_LINUX_FILE)" . \
-		--transform 's,^,ecli-$(TAR_VERSION)/,'
-	@rm -f RELEASE_NOTES.txt
+	@rm -f "$(TAR_LINUX_FILE)" "$(TAR_SHA_FILE)"
+	./scripts/build_pyinstaller_linux.sh
+	@rm -rf build/package-tar-linux
+	@mkdir -p build/package-tar-linux/ecli-$(TAR_VERSION)
+	@install -m 0755 dist/ecli build/package-tar-linux/ecli-$(TAR_VERSION)/ecli
+	@install -m 0644 README.md build/package-tar-linux/ecli-$(TAR_VERSION)/README.md
+	@install -m 0644 LICENSE build/package-tar-linux/ecli-$(TAR_VERSION)/LICENSE
+	@install -m 0644 CHANGELOG.md build/package-tar-linux/ecli-$(TAR_VERSION)/CHANGELOG.md
+	@tar -czf "$(TAR_LINUX_FILE)" -C build/package-tar-linux ecli-$(TAR_VERSION)
 	@cd $(TAR_PKG_DIR) && sha256sum $$(basename $(TAR_LINUX_FILE)) > $$(basename $(TAR_SHA_FILE))
 	$(MAKE) package-tar-linux-assert
 
 .PHONY: package-tar-linux-assert
 package-tar-linux-assert:
 	@test -n "$(TAR_VERSION)" || (echo "TAR_VERSION is empty"; exit 1)
+	$(call assert_current_release_file,$(TAR_LINUX_FILE))
 	$(call verify_sha256,$(TAR_LINUX_FILE))
+	@./scripts/verify_runtime.sh "$(TAR_LINUX_FILE)"
 	@echo "--> OK: $(TAR_LINUX_FILE)"
 	@echo "--> OK: $(TAR_SHA_FILE)"
 
@@ -620,7 +643,7 @@ package-freebsd-ci:
 # --- Local build on a real FreeBSD host/VM ------------------------------------
 # Runs the native packager script (PyInstaller -> stage -> pkg create).
 .PHONY: package-freebsd
-package-freebsd: clean
+package-freebsd: clean validate-runtime-imports
 	sh ./scripts/build-and-package-freebsd.sh
 	$(MAKE) package-freebsd-assert
 
@@ -628,7 +651,7 @@ package-freebsd: clean
 # Creates a clean 14.3 rootfs (base.txz), installs deps, runs the same build.
 # Requires root; keeps the host clean and returns artifacts into ./releases/.
 .PHONY: package-freebsd-chroot
-package-freebsd-chroot: clean
+package-freebsd-chroot: clean validate-runtime-imports
 	sudo tools/freebsd-chroot-build.sh
 	$(MAKE) package-freebsd-assert
 
@@ -636,7 +659,7 @@ package-freebsd-chroot: clean
 # Uses scripts/build_freebsd_port.sh to create a local port and `make package`.
 # Produces the same artifact names under releases/<version>/.
 .PHONY: package-freebsd-port
-package-freebsd-port: clean
+package-freebsd-port: clean validate-runtime-imports
 	sudo sh ./scripts/build_freebsd_port.sh
 	$(MAKE) package-freebsd-assert
 
@@ -644,7 +667,9 @@ package-freebsd-port: clean
 .PHONY: package-freebsd-assert
 package-freebsd-assert:
 	@test -n "$(FREEBSD_PKG_VERSION)" || (echo "FREEBSD_PKG_VERSION is empty (check pyproject.toml)"; exit 1)
+	$(call assert_current_release_file,$(FREEBSD_PKG_FILE))
 	$(call verify_sha256,$(FREEBSD_PKG_FILE))
+	@./scripts/verify_runtime.sh "$(FREEBSD_PKG_FILE)"
 	@echo "--> OK: $(FREEBSD_PKG_FILE)"
 	@echo "--> OK: $(FREEBSD_SHA_FILE)"
 
@@ -727,14 +752,16 @@ MACOS_PKG_FILE    ?= $(MACOS_PKG_DIR)/ecli_$(MACOS_PKG_VERSION)_macos_$(MACOS_AR
 MACOS_SHA_FILE    ?= $(MACOS_PKG_FILE).sha256
 
 .PHONY: package-macos
-package-macos: clean
+package-macos: clean validate-runtime-imports
 	./scripts/build-and-package-macos.sh
 	$(MAKE) package-macos-assert
 
 .PHONY: package-macos-assert
 package-macos-assert:
 	@test -n "$(MACOS_PKG_VERSION)" || (echo "MACOS_PKG_VERSION empty (pyproject.toml)"; exit 1)
+	$(call assert_current_release_file,$(MACOS_PKG_FILE))
 	$(call verify_sha256,$(MACOS_PKG_FILE))
+	@./scripts/verify_runtime.sh "$(MACOS_PKG_FILE)"
 	@echo "--> OK: $(MACOS_PKG_FILE)"
 	@echo "--> OK: $(MACOS_SHA_FILE)"
 
@@ -802,15 +829,19 @@ WIN_SHA_FILE    ?= $(WIN_PORTABLE_SHA_FILE)
 
 # Local Windows build (run in PowerShell on Windows host)
 .PHONY: package-windows
-package-windows: clean
+package-windows: clean validate-runtime-imports
 	pwsh -File ./scripts/build-and-package-windows.ps1
 	$(MAKE) package-windows-assert
 
 .PHONY: package-windows-assert
 package-windows-assert:
 	@test -n "$(WIN_PKG_VERSION)" || (echo "WIN_PKG_VERSION empty (pyproject.toml)"; exit 1)
+	$(call assert_current_release_file,$(WIN_PORTABLE_FILE))
+	$(call assert_current_release_file,$(WIN_INSTALLER_FILE))
 	$(call verify_sha256,$(WIN_PORTABLE_FILE))
 	$(call verify_sha256,$(WIN_INSTALLER_FILE))
+	@./scripts/verify_runtime.sh --mode structural "$(WIN_PORTABLE_FILE)"
+	@./scripts/verify_runtime.sh --mode structural "$(WIN_INSTALLER_FILE)"
 	@echo "--> OK: $(WIN_PORTABLE_FILE)"
 	@echo "--> OK: $(WIN_PORTABLE_SHA_FILE)"
 	@echo "--> OK: $(WIN_INSTALLER_FILE)"
@@ -931,10 +962,10 @@ publish-all:
 	else \
 		echo "SKIP: Windows artifact not found: $(WIN_PKG_FILE)"; \
 	fi
-	@if ls dist/*.whl dist/*.tar.gz >/dev/null 2>&1; then \
+	@if [ -f "$(PYPI_WHEEL_FILE)" ] && [ -f "$(PYPI_SDIST_FILE)" ]; then \
 		$(MAKE) publish-pypi; \
 	else \
-		echo "SKIP: PyPI artifacts not found under dist/"; \
+		echo "SKIP: PyPI artifacts not found under $(PYPI_PKG_DIR)"; \
 	fi
 	@echo ""
 	@echo "╔═══════════════════════════════════════════════════════════════════════╗"
@@ -950,17 +981,28 @@ publish-all:
 validate-version-consistency:
 	@$(PYTHON) -c 'import pathlib, sys, tomllib; root=pathlib.Path.cwd().resolve(); sys.path.insert(0, str(root / "src")); import ecli; pyproject=tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))["project"]; expected=pyproject["version"]; actual=ecli.__version__; imported=pathlib.Path(ecli.__file__).resolve(); source_root=root / "src" / "ecli"; print(f"pyproject={expected} ecli.__version__={actual}"); ok=(actual == expected and imported.is_relative_to(source_root)); sys.exit(0 if ok else 1)'
 
+.PHONY: validate-runtime-imports
+validate-runtime-imports:
+	@$(PYTHON) scripts/check_runtime_imports.py
+	@echo "--> OK: production runtime imports"
+
 .PHONY: validate-pypi-contract
 validate-pypi-contract:
 	@test -f "$(PYPI_WHEEL_FILE)" || (echo "Missing $(PYPI_WHEEL_FILE)"; exit 2)
 	@test -f "$(PYPI_SDIST_FILE)" || (echo "Missing $(PYPI_SDIST_FILE)"; exit 2)
 	@test -f "$(PYPI_WHEEL_FILE).sha256" || (echo "Missing $(PYPI_WHEEL_FILE).sha256"; exit 3)
 	@test -f "$(PYPI_SDIST_FILE).sha256" || (echo "Missing $(PYPI_SDIST_FILE).sha256"; exit 3)
+	$(call assert_current_release_file,$(PYPI_WHEEL_FILE))
+	$(call assert_current_release_file,$(PYPI_SDIST_FILE))
 	@$(PYTHON) -m twine --version >/dev/null 2>&1 || (echo "Missing tooling: twine"; exit 5)
 	@$(PYTHON) -m twine check --strict "$(PYPI_WHEEL_FILE)" "$(PYPI_SDIST_FILE)" || exit 1
 	$(call verify_sha256,$(PYPI_WHEEL_FILE))
 	$(call verify_sha256,$(PYPI_SDIST_FILE))
 	@echo "--> OK: PyPI contract"
+
+.PHONY: validate-tar-linux-contract
+validate-tar-linux-contract: package-tar-linux-assert
+	@echo "--> OK: Linux tar contract"
 
 .PHONY: validate-deb-contract
 validate-deb-contract: package-deb-assert
@@ -987,7 +1029,7 @@ validate-windows-contract: package-windows-assert
 	@echo "--> OK: Windows contract"
 
 .PHONY: validate-gate2
-validate-gate2: validate-version-consistency
+validate-gate2: validate-version-consistency validate-runtime-imports
 	@if [ -f "$(PYPI_WHEEL_FILE)" ] || [ -f "$(PYPI_WHEEL_FILE).sha256" ] || [ -f "$(PYPI_SDIST_FILE)" ] || [ -f "$(PYPI_SDIST_FILE).sha256" ]; then \
 		$(MAKE) validate-pypi-contract; \
 	else \
@@ -996,6 +1038,7 @@ validate-gate2: validate-version-consistency
 	$(call validate_if_present,$(DEB_PKG_FILE),validate-deb-contract,DEB)
 	$(call validate_if_present,$(RPM_PKG_FILE),validate-rpm-contract,RPM)
 	$(call validate_if_present,$(APPIMAGE_FILE),validate-appimage-contract,AppImage)
+	$(call validate_if_present,$(TAR_LINUX_FILE),validate-tar-linux-contract,Linux tar)
 	$(call validate_if_present,$(FREEBSD_PKG_FILE),validate-freebsd-contract,FreeBSD)
 	$(call validate_if_present,$(MACOS_PKG_FILE),validate-macos-contract,macOS)
 	$(call validate_if_present,$(WIN_PKG_FILE),validate-windows-contract,Windows)
@@ -1014,7 +1057,7 @@ show-artifacts:
 	@echo "╚═══════════════════════════════════════════════════════════════════════╝"
 	@echo ""
 	@echo "Python (PyPI):"
-	@ls -lh dist/*.whl dist/*.tar.gz 2>/dev/null || echo "  (not built)"
+	@ls -lh "$(PYPI_PKG_DIR)"/*.whl "$(PYPI_PKG_DIR)"/*.tar.gz 2>/dev/null || echo "  (not built)"
 	@echo ""
 	@echo "Linux (Debian/Ubuntu):"
 	@ls -lh $(RELEASE_DIR)/ecli_*_linux_*.deb* 2>/dev/null || echo "  (not built)"

--- a/Makefile
+++ b/Makefile
@@ -750,18 +750,29 @@ MACOS_PKG_VERSION ?= $(PACKAGE_VERSION)
 MACOS_PKG_DIR     ?= releases/$(MACOS_PKG_VERSION)
 MACOS_PKG_FILE    ?= $(MACOS_PKG_DIR)/ecli_$(MACOS_PKG_VERSION)_macos_$(MACOS_ARCH).dmg
 MACOS_SHA_FILE    ?= $(MACOS_PKG_FILE).sha256
+MACOS_ASSERT_MODE ?= native
 
 .PHONY: package-macos
 package-macos: clean validate-runtime-imports
 	./scripts/build-and-package-macos.sh
-	$(MAKE) package-macos-assert
+	$(MAKE) package-macos-assert MACOS_ASSERT_MODE=structural
 
 .PHONY: package-macos-assert
 package-macos-assert:
 	@test -n "$(MACOS_PKG_VERSION)" || (echo "MACOS_PKG_VERSION empty (pyproject.toml)"; exit 1)
 	$(call assert_current_release_file,$(MACOS_PKG_FILE))
 	$(call verify_sha256,$(MACOS_PKG_FILE))
+ifeq ($(MACOS_ASSERT_MODE),native)
 	@./scripts/verify_runtime.sh "$(MACOS_PKG_FILE)"
+	@echo "--> OK: macOS native runtime artifact contract"
+else ifeq ($(MACOS_ASSERT_MODE),structural)
+	@test -s "$(MACOS_PKG_FILE)" || (echo "Missing or empty $(MACOS_PKG_FILE)"; exit 2)
+	@test -s "$(MACOS_SHA_FILE)" || (echo "Missing or empty $(MACOS_SHA_FILE)"; exit 3)
+	@echo "--> OK: macOS structural artifact contract"
+	@echo "--> INFO: native DMG runtime smoke already completed during build script"
+else
+	@echo "Invalid MACOS_ASSERT_MODE=$(MACOS_ASSERT_MODE) (expected native or structural)"; exit 2
+endif
 	@echo "--> OK: $(MACOS_PKG_FILE)"
 	@echo "--> OK: $(MACOS_SHA_FILE)"
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See the LICENSE file in the project root for full license text.
 
 **ECLI** (Editor CLI) is a terminal-first engineering operations workbench. It combines a curses-based editor with right-side workflow panels and a typed service foundation for configuration, project discovery, command-plan previews,policy checks, audit logging, privileged-action refusal paths, and read-only system diagnostics.
 
-The v0.2.1 release keeps the Services Foundation editor surface intact and hardens release packaging, source-text preservation, and cross-platform install paths. It does not execute remediation, apply command plans, launch VMLab runtimes, or perform real privileged operations.
+The v0.2.2 release keeps the Services Foundation editor surface intact and hardens packaged/frozen runtime startup, release packaging, source-text preservation, and cross-platform install paths. It does not execute remediation, apply command plans, launch VMLab runtimes, or perform real privileged operations.
 
 ### ✨ Key Features
 
@@ -455,7 +455,7 @@ Master ECLI with these essential keyboard shortcuts. Press `F1` anytime inside t
 | `Insert` | Toggle Insert / Overwrite mode |
 | `F12` | Switch focus between editor windows and panels |
 
-The right side of the editor hosts workflow panels. The v0.2.1 service panels are read-only or preview-only: System Doctor does not mutate host state, Command Plan previews do not execute, and the Services panel reports composition status.
+The right side of the editor hosts workflow panels. The v0.2.2 service panels are read-only or preview-only: System Doctor does not mutate host state, Command Plan previews do not execute, and the Services panel reports composition status.
 
 ### Minimal Service CLI
 
@@ -536,7 +536,7 @@ Complete documentation is organized by audience:
 
 ## 🏗️ Architecture
 
-ECLI v0.2.1 keeps the existing editor/TUI behavior and introduces the Services Foundation as typed, testable service-layer infrastructure:
+ECLI v0.2.2 keeps the existing editor/TUI behavior and introduces the Services Foundation as typed, testable service-layer infrastructure:
 
 * **Core Editor**: curses-based terminal editor with async task integration
 
@@ -558,7 +558,7 @@ ECLI v0.2.1 keeps the existing editor/TUI behavior and introduces the Services F
 
 * **ServiceRegistry**: explicit composition root without global service-locator state
 
-**Safety boundaries for v0.2.1:**
+**Safety boundaries for v0.2.2:**
 
 * SystemDoctor is read-only.
 
@@ -568,7 +568,7 @@ ECLI v0.2.1 keeps the existing editor/TUI behavior and introduces the Services F
 
 * Service panels are visible in the UI but do not execute remediation.
 
-* VMLab runtime behavior is not included in v0.2.1.
+* VMLab runtime behavior is not included in v0.2.2.
 
 For detailed architecture information, see [Architecture Overview](https://github.com/SSobol77/ecli/blob/main/docs/architecture/current-architecture.md).
 

--- a/docs/architecture/command-plan-service.md
+++ b/docs/architecture/command-plan-service.md
@@ -906,7 +906,7 @@ Required schema:
   "source": "user",
   "details": {},
   "metadata": {
-    "ecli_version": "0.2.1",
+    "ecli_version": "0.2.2",
     "schema_revision": "audit-v1"
   }
 }

--- a/docs/contributor/development-setup.md
+++ b/docs/contributor/development-setup.md
@@ -31,6 +31,7 @@ See the LICENSE file in the project root for full license text.
 | `uv` | Recommended | deterministic dependency workflow | all platforms |
 | `pipx` | Optional | convenient tool installation | all platforms |
 | `ruff` / `pytest` toolchain | Role-dependent | local validation | maintainer-focused |
+| `twine` | Release-only | PyPI artifact validation in `make validate-gate2` | install via `.[release]`, `.[dev]`, or `requirements-dev.txt` |
 | `makensis` | Optional by role | Windows packaging | Windows packaging maintainers |
 | `hdiutil` | Optional by role | macOS DMG packaging | macOS only |
 | FreeBSD pkg toolchain | Optional by role | FreeBSD package build | FreeBSD environment only |

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -53,7 +53,7 @@ For source/development builds on Windows, install:
 PowerShell checksum verification should be performed before first execution:
 
 ```powershell
-$version = "0.2.1"
+$version = "0.2.2"
 $file = "ecli_${version}_win_x86_64_setup.exe"
 $expected = (Get-Content "$file.sha256" -Raw).Trim().Split()[0]
 $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $file).Hash.ToLowerInvariant()

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -23,5 +23,6 @@ Authoritative files:
 - `release-process.md`
 - `release-checklist.md`
 - `artifact-verification.md`
+- `v0.2.2.md`
 - `v0.2.1.md`
 - `v0.2.0.md`

--- a/docs/release/artifact-contract.md
+++ b/docs/release/artifact-contract.md
@@ -103,8 +103,8 @@ The artifact basename must not include a directory component.
 
 Release builds emit a CycloneDX SBOM alongside the Python distribution artifacts. SBOM filenames follow the PyPI distribution naming convention (hyphens, no platform/arch tokens) because they describe the Python distribution, not a native platform package:
 
-- `dist/ecli-editor-<version>.cdx.json`
-- `dist/ecli-editor-<version>.cdx.json.sha256`
+- `releases/<version>/ecli-editor-<version>.cdx.json`
+- `releases/<version>/ecli-editor-<version>.cdx.json.sha256`
 
 This is intentional inconsistency with native release artifacts (which use `ecli_<v>_<platform>_<arch>.<ext>` underscore convention). SBOMs apply to the Python wheel and sdist, both of which use PEP 427 / PEP 625 hyphen naming. The SBOM tracks the same convention.
 

--- a/docs/release/artifact-contract.md
+++ b/docs/release/artifact-contract.md
@@ -162,3 +162,8 @@ The migration makes artifact discovery deterministic for CI and release automati
 - release workflow must validate expected artifact names and checksums before publish.
 
 - missing contract artifact must fail the pipeline.
+
+- macOS DMG package builds must perform one native mounted-DMG runtime smoke
+  during `scripts/build-and-package-macos.sh`. Follow-up assertions in the same
+  build job may use structural/checksum-only validation to avoid redundant
+  immediate `hdiutil attach` calls against the same image.

--- a/docs/release/release-process.md
+++ b/docs/release/release-process.md
@@ -34,6 +34,19 @@ See the LICENSE file in the project root for full license text.
 - Missing required artifacts must block release.
 - Workflow references to non-existent files must be resolved as release blockers.
 
+## Release Tooling Prerequisites
+
+Install release tooling before running Gate 2 validation from a clean
+maintainer environment:
+
+```sh
+python3 -m pip install -e ".[release]"
+```
+
+The `validate-gate2` target requires `twine` for strict PyPI wheel/sdist
+metadata validation. `twine` is declared only in release/development tooling
+dependencies, not in ECLI runtime dependencies.
+
 ## PyPI Namespace Pre-Reservation
 
 The Python distribution name is `ecli-editor`; the import package and console
@@ -58,8 +71,10 @@ Before enabling a publish workflow for a new package name:
 
    ```sh
    python3 -m build
-   python3 -m twine check --strict dist/*
-   python3 -m twine upload dist/*
+   version=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+   python3 -m build --outdir "releases/${version}"
+   python3 -m twine check --strict "releases/${version}"/*.whl "releases/${version}"/ecli_editor-*.tar.gz
+   python3 -m twine upload "releases/${version}"/*.whl "releases/${version}"/ecli_editor-*.tar.gz
    ```
 
 4. Rotate or replace any token used for the bootstrap upload with a
@@ -101,8 +116,8 @@ remove the static token requirement.
 Release builds emit a CycloneDX SBOM for the Python distribution:
 
 ```text
-dist/ecli-editor-<version>.cdx.json
-dist/ecli-editor-<version>.cdx.json.sha256
+releases/<version>/ecli-editor-<version>.cdx.json
+releases/<version>/ecli-editor-<version>.cdx.json.sha256
 ```
 
 The SBOM is generated with the `cyclonedx-bom` Python distribution, invoked as

--- a/docs/release/v0.2.2.md
+++ b/docs/release/v0.2.2.md
@@ -1,0 +1,66 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+
+Project: Ecli
+File: docs/release/v0.2.2.md
+Website: https://www.ecli.io
+Repository: https://github.com/SSobol77/ecli
+PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+
+Copyright (c) 2026 Siergej Sobolewski
+
+Licensed under the Apache License, Version 2.0.
+See the LICENSE file in the project root for full license text.
+-->
+# ECLI v0.2.2 Release Notes
+
+ECLI v0.2.2 is a packaged-runtime startup hardening release. The fix is
+cross-platform: binary and package artifacts must not depend on test-only
+runtime imports and must validate packaged launcher startup before release.
+
+## Fixed
+
+- Fixed packaged/frozen runtime startup failure caused by a test-only
+  `unittest.mock` dependency leaking into production code.
+
+- Added visible stderr diagnostics for critical pre-curses startup failures.
+
+- Added cross-package runtime smoke validation for packaged ECLI launchers.
+
+- Fixed Git Panel status command getting stuck at
+  `Running: git status ...` without rendering command results.
+
+- Fixed Git Panel repository detection and working-directory handling.
+
+- Fixed Git Panel BUSY state reset after command completion, errors, timeout,
+  or cancellation.
+
+- Fixed Git Panel cancellation/output messages rendering outside the output
+  pane.
+
+- Fixed global Help shortcut being blocked by active panels.
+
+- Fixed AI Code Assistant shortcut crashing when invoked while File Manager is
+  active.
+
+- Made F7 AI Code Assistant close File Manager automatically and continue with
+  the normal editor AI flow.
+
+- Hardened editor selection handling so invalid panel/editor state cannot raise
+  `IndexError`.
+
+- Prevented selection warnings/log records from being printed into the curses
+  editor canvas.
+
+- Prevented input handler tracebacks from corrupting the curses screen.
+
+- Preserved global Help behavior across active panels.
+
+## Packaging
+
+- Hardened release builds with production import guards.
+
+- Ensured packaged `ecli --help` and `ecli --version` can run without curses
+  initialization.
+
+- Enforced artifact output under the current project version directory.

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
         in
         pkgs.callPackage ./packaging/nix/package.nix {
           src = self;
-          version = "0.2.1";
+          version = "0.2.2";
         };
     in
     {

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -7,7 +7,7 @@
 # PyPI: https://pypi.org/project/ecli-editor/0.0.1/
 
 pkgname=ecli-editor
-pkgver=0.2.1
+pkgver=0.2.2
 pkgrel=1
 pkgdesc="Terminal-first engineering operations workbench"
 arch=("x86_64" "aarch64")

--- a/packaging/linux/appimage/appimage-builder.yml
+++ b/packaging/linux/appimage/appimage-builder.yml
@@ -21,7 +21,7 @@ AppDir:
     id: io.ecli.app
     name: ECLI
     icon: ecli # without .png; the file resides in icons
-    version: "0.1.0" # inject the version via sed in CI
+    version: "0.2.2" # inject the version via sed in CI
     exec: usr/bin/ecli # path to the executable inside the AppImage
     exec_args: $@
   runtime:

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -9,7 +9,7 @@
 {
   pkgs,
   src ? ../..,
-  version ? "0.2.1",
+  version ? "0.2.2",
 }:
 
 let

--- a/packaging/pyinstaller/ecli.spec
+++ b/packaging/pyinstaller/ecli.spec
@@ -42,6 +42,7 @@ one_dir = os.environ.get("ECLI_PYINSTALLER_ONEDIR") == "1"
 build_macos_app = (
     sys.platform == "darwin" and os.environ.get("ECLI_BUILD_MACOS_APP") == "1"
 )
+strip_binaries = sys.platform != "win32"
 
 datas = [
     (str(config_file), "."),
@@ -106,7 +107,7 @@ if one_dir or build_macos_app:
         name="ecli",
         debug=False,
         bootloader_ignore_signals=False,
-        strip=True,
+        strip=strip_binaries,
         upx=True,
         console=True,
         disable_windowed_traceback=False,
@@ -120,7 +121,7 @@ if one_dir or build_macos_app:
         exe,
         a.binaries,
         a.datas,
-        strip=True,
+        strip=strip_binaries,
         upx=True,
         upx_exclude=[],
         name="ecli",
@@ -149,7 +150,7 @@ else:
         name="ecli",
         debug=False,
         bootloader_ignore_signals=False,
-        strip=True,
+        strip=strip_binaries,
         upx=True,
         upx_exclude=[],
         runtime_tmpdir=None,

--- a/packaging/pyinstaller/ecli.spec
+++ b/packaging/pyinstaller/ecli.spec
@@ -25,6 +25,7 @@ project_root = Path(os.environ.get("ECLI_REPO_ROOT", os.getcwd())).resolve()
 entry_point = project_root / "main.py"
 src_dir = project_root / "src"
 config_file = project_root / "config.toml"
+pyproject_file = project_root / "pyproject.toml"
 asset_icon = src_dir / "ecli" / "assets" / "ecli.png"
 windows_icon = project_root / "img" / "logo_m.ico"
 
@@ -32,6 +33,8 @@ if not entry_point.is_file():
     raise SystemExit(f"Missing PyInstaller entry point: {entry_point}")
 if not config_file.is_file():
     raise SystemExit(f"Missing PyInstaller data file: {config_file}")
+if not pyproject_file.is_file():
+    raise SystemExit(f"Missing PyInstaller metadata file: {pyproject_file}")
 if not asset_icon.is_file():
     raise SystemExit(f"Missing packaged icon asset: {asset_icon}")
 
@@ -40,7 +43,11 @@ build_macos_app = (
     sys.platform == "darwin" and os.environ.get("ECLI_BUILD_MACOS_APP") == "1"
 )
 
-datas = [(str(config_file), "."), (str(asset_icon), "ecli/assets")]
+datas = [
+    (str(config_file), "."),
+    (str(pyproject_file), "."),
+    (str(asset_icon), "ecli/assets"),
+]
 binaries = []
 exe_icon_kwargs = (
     {"icon": str(windows_icon)}

--- a/packaging/windows/nsis/ecli.nsi
+++ b/packaging/windows/nsis/ecli.nsi
@@ -1,9 +1,9 @@
 ; =============================================================================
 ; ECLI — Windows Installer (NSIS, Unicode, x64)
 ; Accepts defines:
-;   /DVERSION=0.1.0
-;   /DOUTFILE="releases\0.1.0\ecli_0.1.0_win_x86_64_setup.exe"
-;   /DINPUT_EXE="releases\0.1.0\ecli_0.1.0_win_x86_64.exe"
+;   /DVERSION=0.2.2
+;   /DOUTFILE="releases\0.2.2\ecli_0.2.2_win_x86_64_setup.exe"
+;   /DINPUT_EXE="releases\0.2.2\ecli_0.2.2_win_x86_64.exe"
 ; Defaults are provided for local runs.
 ; =============================================================================
 
@@ -15,7 +15,7 @@ SetCompressorDictSize 32
 !define APPNAME   "ECLI"
 !define COMPANY   "Cartesian School"
 !ifndef VERSION
-  !define VERSION "0.1.0"
+  !define VERSION "0.2.2"
 !endif
 !ifndef INPUT_EXE
   !define INPUT_EXE "build\windows\dist\ecli.exe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ecli-editor"
-version = "0.2.1"
+version = "0.2.2"
 description = "ECLI — terminal-first engineering operations workbench"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -84,7 +84,12 @@ dev = [
     "pytest-cov>=6.0.0",
     "coverage>=7.4.0",
     "build>=1.2",
-    "twine>=5.0",
+    "twine>=6.2.0",
+    "cyclonedx-bom>=4.0",
+]
+release = [
+    "build>=1.2",
+    "twine>=6.2.0",
     "cyclonedx-bom>=4.0",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -39,6 +39,8 @@ typing-extensions>=4.14.1
 wcwidth>=0.2.13
 yarl>=1.20.1
 -e .
+# Release tooling
+twine>=6.2.0
 # Test dependencies
 coverage>=7.10.0
 iniconfig>=2.1.0

--- a/scripts/build-and-package-arch.sh
+++ b/scripts/build-and-package-arch.sh
@@ -24,6 +24,7 @@ VERSION="$(awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ {print $2; exit}' pypr
   echo "ERROR: Cannot read version from pyproject.toml" >&2
   exit 1
 }
+python3 scripts/check_runtime_imports.py
 
 RAW_ARCH="$(uname -m 2>/dev/null || echo x86_64)"
 case "${RAW_ARCH}" in
@@ -65,6 +66,7 @@ cp -f "${raw_artifact}" "${NORMALIZED_ARTIFACT}"
 
 echo "==> Writing checksum"
 (cd "${RELEASES_DIR}" && sha256sum "$(basename "${NORMALIZED_ARTIFACT}")" > "$(basename "${NORMALIZED_ARTIFACT}").sha256")
+scripts/verify_runtime.sh "${NORMALIZED_ARTIFACT}"
 
 echo "Raw makepkg artifact: ${raw_artifact}"
 echo "DONE: ${NORMALIZED_ARTIFACT}"

--- a/scripts/build-and-package-deb.sh
+++ b/scripts/build-and-package-deb.sh
@@ -50,14 +50,18 @@ MAINTAINER="Siergej Sobolewski <s.sobolewski@hotmail.com>"
 HOMEPAGE="https://ecli.io"
 LICENSE="Apache-2.0"
 CATEGORY="editors"
+PYTHON_BIN="${PYTHON:-python3}"
 
-VERSION="$(python - <<'PY'
+VERSION="$("${PYTHON_BIN}" - <<'PY'
 import tomllib
 with open("pyproject.toml","rb") as f:
     print(tomllib.load(f)["project"]["version"])
 PY
 )"
 [ -n "${VERSION}" ] || { echo "Cannot read version from pyproject.toml"; exit 1; }
+
+echo "==> Checking production runtime imports"
+"${PYTHON_BIN}" scripts/check_runtime_imports.py
 
 ARCH_DEB="amd64"
 RAW_ARCH="$(uname -m 2>/dev/null || echo x86_64)"
@@ -72,6 +76,7 @@ STAGING_DIR="build/deb_staging"
 
 echo "==> Version: ${VERSION}"
 rm -rf build/ dist/
+rm -f "${FINAL_DEB_PATH}" "${FINAL_DEB_PATH}.sha256"
 
 echo "==> Building executable with PyInstaller"
 if [[ -f "packaging/pyinstaller/ecli.spec" ]]; then
@@ -83,6 +88,7 @@ else
     --onefile --clean --noconfirm --strip \
     --paths "src" \
     --add-data "config.toml:." \
+    --add-data "pyproject.toml:." \
     --hidden-import=ecli \
     --hidden-import=dotenv --collect-all=dotenv \
     --hidden-import=toml \
@@ -199,6 +205,7 @@ fpm -s dir -t deb \
 echo "==> Verify"
 dpkg-deb --info "${FINAL_DEB_PATH}" >/dev/null || true
 dpkg-deb --contents "${FINAL_DEB_PATH}" | head -20 || true
+scripts/verify_runtime.sh "${FINAL_DEB_PATH}"
 
 echo "==> Generating SHA-256 checksum"
 if command -v sha256sum >/dev/null 2>&1; then

--- a/scripts/build-and-package-freebsd.sh
+++ b/scripts/build-and-package-freebsd.sh
@@ -230,6 +230,7 @@ build_binary() {
       --onefile --clean --noconfirm --strip \
       --paths "src" \
       --add-data "config.toml:." \
+      --add-data "pyproject.toml:." \
       --hidden-import=ecli \
       --hidden-import=dotenv       --collect-all=dotenv \
       --hidden-import=toml \
@@ -400,11 +401,15 @@ install_python_dependencies
 VERSION="$(read_version)"
 print_step "Version detected: $VERSION"
 
+print_step "Checking production runtime imports..."
+python3.11 scripts/check_runtime_imports.py
+
 EXECUTABLE="$(build_binary)"
 print_step "Executable: $EXECUTABLE"
 
 STAGING_ROOT="$(stage_files "$EXECUTABLE" "$VERSION")"
 PKG_PATH="$(make_pkg "$STAGING_ROOT" "$VERSION")"
+./scripts/verify_runtime.sh "$PKG_PATH"
 
 print_header "DONE"
 print_step "Package:   $PKG_PATH"

--- a/scripts/build-and-package-macos.sh
+++ b/scripts/build-and-package-macos.sh
@@ -87,6 +87,9 @@ PY
 }
 ok "Version: ${VERSION}"
 
+log "Checking production runtime imports..."
+"$PYTHON_BIN" scripts/check_runtime_imports.py
+
 RELEASES_DIR="releases/${VERSION}"
 PKG_NAME_BASE="ecli_${VERSION}_macos_${MACOS_ARCH}"
 DMG_PATH="${RELEASES_DIR}/${PKG_NAME_BASE}.dmg"
@@ -236,4 +239,5 @@ log "Writing SHA256 sidecar..."
 
 ok "DMG: $DMG_PATH"
 ok "SHA: $SHA_PATH"
+./scripts/verify_runtime.sh "$DMG_PATH"
 log "Done."

--- a/scripts/build-and-package-rpm.sh
+++ b/scripts/build-and-package-rpm.sh
@@ -84,6 +84,9 @@ fi
 export VERSION
 echo "==> Version: ${VERSION}"
 
+echo "==> Checking production runtime imports"
+python3 scripts/check_runtime_imports.py
+
 # ------------------------------------------------------------------------------
 # Paths
 # ------------------------------------------------------------------------------
@@ -96,8 +99,14 @@ APPS_DIR="${STAGING_DIR}/usr/share/applications"
 ICON_DIR="${STAGING_DIR}/usr/share/icons/hicolor/256x256/apps"
 
 RELEASES_DIR="${RELEASES_DIR:-releases/${VERSION}}"
+if [[ "${RELEASES_DIR}" != "releases/${VERSION}" ]]; then
+  die "RELEASES_DIR must match current project version: releases/${VERSION}"
+fi
 mkdir -p "${RELEASES_DIR}"
 printf 'LINUX_ARCH := %s\n' "${NORMALIZED_ARCH}" > "${RELEASES_DIR}/.linux.env"
+rm -f \
+  "${RELEASES_DIR}/${PACKAGE_NAME}_${VERSION}_${RPM_PLATFORM_LABEL}_${NORMALIZED_ARCH}.rpm" \
+  "${RELEASES_DIR}/${PACKAGE_NAME}_${VERSION}_${RPM_PLATFORM_LABEL}_${NORMALIZED_ARCH}.rpm.sha256"
 
 # ------------------------------------------------------------------------------
 # Helpers
@@ -141,6 +150,7 @@ else
     --onefile --clean --noconfirm --strip \
     --paths "src" \
     --add-data "config.toml:." \
+    --add-data "pyproject.toml:." \
     --hidden-import=ecli \
     --hidden-import=dotenv --collect-all=dotenv \
     --hidden-import=toml \
@@ -277,6 +287,7 @@ echo "✅ DONE"
 echo "RPM (actual): ${ACTUAL_RPM}"
 echo "RPM (normalized): ${NORMALIZED_RPM}"
 [[ -f "${NORMALIZED_RPM}.sha256" ]] && echo "SHA256: ${NORMALIZED_RPM}.sha256"
+scripts/verify_runtime.sh "${NORMALIZED_RPM}"
 
 # Optional quick metadata check (does not fail the build)
 if command -v rpm >/dev/null 2>&1; then

--- a/scripts/build-and-package-slackware.sh
+++ b/scripts/build-and-package-slackware.sh
@@ -24,6 +24,7 @@ VERSION="$(awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ {print $2; exit}' pypr
   echo "ERROR: Cannot read version from pyproject.toml" >&2
   exit 1
 }
+python3 scripts/check_runtime_imports.py
 
 RAW_ARCH="$(uname -m 2>/dev/null || echo x86_64)"
 case "${RAW_ARCH}" in
@@ -98,5 +99,6 @@ rm -f "${FINAL_TXZ}" "${FINAL_TXZ}.sha256"
 
 echo "==> Writing checksum"
 (cd "${RELEASES_DIR}" && sha256sum "$(basename "${FINAL_TXZ}")" > "$(basename "${FINAL_TXZ}").sha256")
+scripts/verify_runtime.sh "${FINAL_TXZ}"
 
 echo "DONE: ${FINAL_TXZ}"

--- a/scripts/build-and-package-windows.ps1
+++ b/scripts/build-and-package-windows.ps1
@@ -84,6 +84,9 @@ if ([string]::IsNullOrWhiteSpace($version)) {
 }
 Write-Ok "Version: $version"
 
+Write-Info "Checking production runtime imports..."
+python scripts/check_runtime_imports.py
+
 $winArch = "x86_64"
 $releaseDir = Join-Path "releases" $version
 $portableName = "ecli_${version}_win_${winArch}.exe"
@@ -132,6 +135,31 @@ Write-Ok "Portable executable: $portablePath"
 
 Write-Info "Writing portable SHA256..."
 Write-Sha256Sidecar -ArtifactPath $portablePath
+
+Write-Info "Smoke-testing portable executable help/version..."
+$smokeHome = Join-Path $buildRoot "smoke-home"
+New-Item -ItemType Directory -Force -Path $smokeHome | Out-Null
+$oldUserProfile = $env:USERPROFILE
+$oldHome = $env:HOME
+try {
+  $env:USERPROFILE = $smokeHome
+  $env:HOME = $smokeHome
+  $helpOutput = & $portableFullPath --help
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace(($helpOutput -join "`n"))) {
+    Write-Err "Portable executable --help smoke failed."
+    exit 4
+  }
+  $versionOutput = (& $portableFullPath --version) -join "`n"
+  if ($LASTEXITCODE -ne 0 -or $versionOutput.Trim() -ne "ecli $version") {
+    Write-Err "Portable executable --version smoke failed: '$versionOutput'"
+    exit 4
+  }
+}
+finally {
+  $env:USERPROFILE = $oldUserProfile
+  $env:HOME = $oldHome
+}
+Write-Ok "Portable executable help/version smoke passed."
 
 $makensis = Resolve-MakeNsis
 if (-not $makensis) {

--- a/scripts/build_pyinstaller_linux.sh
+++ b/scripts/build_pyinstaller_linux.sh
@@ -26,6 +26,7 @@ SPEC_FILE="packaging/pyinstaller/ecli.spec"
 echo "==> Checking prerequisites"
 command -v python3 >/dev/null
 command -v pyinstaller >/dev/null
+python3 scripts/check_runtime_imports.py
 
 echo "==> Cleaning previous artifacts"
 rm -rf build/ dist/
@@ -35,6 +36,7 @@ PYI_ARGS=(--onefile --clean --noconfirm --strip)
 
 # Bundle optional configs if present
 [[ -f "config.toml" ]] && PYI_ARGS+=(--add-data "config.toml:.")
+[[ -f "pyproject.toml" ]] && PYI_ARGS+=(--add-data "pyproject.toml:.")
 [[ -d "config" ]] && PYI_ARGS+=(--add-data "config:config")
 
 if [[ -f "${SPEC_FILE}" ]]; then
@@ -46,8 +48,10 @@ fi
 # Sanity check
 if [[ -x "dist/${PACKAGE_NAME}/${PACKAGE_NAME}" ]]; then
   echo "==> OK: dist/${PACKAGE_NAME}/${PACKAGE_NAME}"
+  ./scripts/verify_runtime.sh --allow-nonrelease "dist/${PACKAGE_NAME}/${PACKAGE_NAME}"
 elif [[ -x "dist/${PACKAGE_NAME}" ]]; then
   echo "==> OK: dist/${PACKAGE_NAME}"
+  ./scripts/verify_runtime.sh --allow-nonrelease "dist/${PACKAGE_NAME}"
 else
   echo "Build output not found in dist/. Aborting." >&2
   exit 1

--- a/scripts/check_runtime_imports.py
+++ b/scripts/check_runtime_imports.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: scripts/check_runtime_imports.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Fail if production ECLI runtime source imports test-only modules."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+
+FORBIDDEN_IMPORT_ROOTS = frozenset({"mock", "pytest", "test", "tests", "unittest"})
+FORBIDDEN_IMPORT_PARTS = frozenset(
+    {"conftest", "mock", "pytest", "test_helpers", "testing", "unittest"}
+)
+SOURCE_ROOT = Path("src/ecli")
+
+
+def _forbidden_imports(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    findings: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_forbidden_module(alias.name):
+                    findings.append((node.lineno, f"import {alias.name}"))
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if _is_forbidden_module(module):
+                findings.append((node.lineno, f"from {module} import ..."))
+    return findings
+
+
+def _is_forbidden_module(module_name: str) -> bool:
+    parts = tuple(part for part in module_name.split(".") if part)
+    if not parts:
+        return False
+    if parts[0] in FORBIDDEN_IMPORT_ROOTS:
+        return True
+    return any(part in FORBIDDEN_IMPORT_PARTS for part in parts)
+
+
+def main() -> int:
+    """Validate production runtime import policy."""
+    violations: list[str] = []
+    for path in sorted(SOURCE_ROOT.rglob("*.py")):
+        for lineno, import_text in _forbidden_imports(path):
+            violations.append(
+                f"{path}:{lineno}: forbidden runtime import: {import_text}"
+            )
+
+    if violations:
+        print(
+            "Production runtime source must not import test-only modules.",
+            file=sys.stderr,
+        )
+        print("\n".join(violations), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package_appimage.sh
+++ b/scripts/package_appimage.sh
@@ -20,7 +20,17 @@ set -euo pipefail
 # 3) runs appimage-builder to create an .AppImage
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-VERSION="${1:-0.1.0}"
+PROJECT_VERSION="$(python3 - <<'PY'
+import tomllib
+with open("pyproject.toml", "rb") as f:
+    print(tomllib.load(f)["project"]["version"])
+PY
+)"
+VERSION="${1:-$PROJECT_VERSION}"
+if [[ "$VERSION" != "$PROJECT_VERSION" ]]; then
+  echo "Requested AppImage version ${VERSION} does not match pyproject.toml version ${PROJECT_VERSION}." >&2
+  exit 2
+fi
 RAW_ARCH="${2:-$(uname -m 2>/dev/null || echo x86_64)}"
 case "$RAW_ARCH" in
   amd64|x86_64) ARCH="x86_64" ;;
@@ -32,6 +42,7 @@ APPDIR="$PROJECT_ROOT/packaging/linux/appimage/AppDir"
 
 mkdir -p "$OUT_DIR"
 printf 'LINUX_ARCH := %s\n' "$ARCH" > "$OUT_DIR/.linux.env"
+python3 "$PROJECT_ROOT/scripts/check_runtime_imports.py"
 # 1) Build the PyInstaller binary (if it hasn't been built yet)
 bash "$PROJECT_ROOT/scripts/build_pyinstaller_linux.sh"
 
@@ -81,15 +92,27 @@ appimage-builder \
   --skip-test
 popd
 
+APPIMAGE_FILE="$OUT_DIR/ecli_${VERSION}_linux_${ARCH}.AppImage"
+found_appimage=0
+
 # The output file will be in PROJECT_ROOT by default. Rename and move it to
 # the canonical release directory.
-find "$PROJECT_ROOT" -maxdepth 1 -type f -name "*.AppImage" -print0 | while IFS= read -r -d '' f; do
-  NEW="$OUT_DIR/ecli_${VERSION}_linux_${ARCH}.AppImage"
-  mv "$f" "$NEW"
-  echo "Created AppImage: $NEW"
-done
+while IFS= read -r -d '' f; do
+  found_appimage=1
+  rm -f "$APPIMAGE_FILE" "$APPIMAGE_FILE.sha256"
+  mv "$f" "$APPIMAGE_FILE"
+  echo "Created AppImage: $APPIMAGE_FILE"
+done < <(find "$PROJECT_ROOT" -maxdepth 1 -type f -name "*.AppImage" -print0)
+
+if [[ "$found_appimage" -eq 0 || ! -f "$APPIMAGE_FILE" ]]; then
+  echo "AppImage build did not produce ${APPIMAGE_FILE}." >&2
+  exit 1
+fi
 
 # zsync (optional for AppImageUpdate)
 if command -v appimagetool >/dev/null 2>&1; then
-  (cd "$OUT_DIR" && appimagetool --sign -v "ecli_${VERSION}_linux_${ARCH}.AppImage" || true)
+  (cd "$OUT_DIR" && appimagetool --sign -v "$(basename "$APPIMAGE_FILE")" || true)
 fi
+
+(cd "$OUT_DIR" && sha256sum "$(basename "$APPIMAGE_FILE")" > "$(basename "$APPIMAGE_FILE").sha256")
+"$PROJECT_ROOT/scripts/verify_runtime.sh" "$APPIMAGE_FILE"

--- a/scripts/publish_pypi.sh
+++ b/scripts/publish_pypi.sh
@@ -21,9 +21,10 @@
 # Local maintainer publish from a clean workstation should be done
 # explicitly with the documented procedure:
 #
-#   python3 -m build
-#   python3 -m twine check --strict dist/*
-#   python3 -m twine upload dist/*
+#   version=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+#   python3 -m build --outdir "releases/${version}"
+#   python3 -m twine check --strict "releases/${version}"/*.whl "releases/${version}"/ecli_editor-*.tar.gz
+#   python3 -m twine upload "releases/${version}"/*.whl "releases/${version}"/ecli_editor-*.tar.gz
 #
 # See docs/release/release-process.md for the full procedure including
 # PyPI namespace pre-reservation and token rotation.

--- a/scripts/verify_runtime.sh
+++ b/scripts/verify_runtime.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
 # Project: Ecli
@@ -11,4 +12,332 @@
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for full license text.
 
-TODO: create this script
+# Cross-artifact launcher validation for packaged ECLI release outputs.
+#
+# Modes:
+#   --mode native      execute the staged launcher on this host
+#   --mode structural  verify package structure only; no execution claim
+#   --mode auto        execute when host/artifact ABI is compatible, otherwise
+#                      perform structural validation
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${PROJECT_ROOT}"
+
+MODE="auto"
+ARTIFACT=""
+ALLOW_NONRELEASE=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --mode)
+      MODE="${2:-}"
+      shift 2
+      ;;
+    --mode=*)
+      MODE="${1#--mode=}"
+      shift
+      ;;
+    --allow-nonrelease)
+      ALLOW_NONRELEASE=1
+      shift
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: scripts/verify_runtime.sh [--mode auto|native|structural] [--allow-nonrelease] ARTIFACT
+
+Validates packaged ECLI launchers. Native mode executes --help, --version, and
+a bounded pseudo-TTY startup. Structural mode verifies expected package payload
+paths when the artifact cannot run on the current host.
+EOF
+      exit 0
+      ;;
+    *)
+      ARTIFACT="$1"
+      shift
+      ;;
+  esac
+done
+
+case "$MODE" in
+  auto|native|structural) ;;
+  *) echo "Invalid mode: $MODE" >&2; exit 2 ;;
+esac
+
+VERSION="$(python3 - <<'PY'
+import tomllib
+with open("pyproject.toml", "rb") as f:
+    print(tomllib.load(f)["project"]["version"])
+PY
+)"
+EXPECTED_VERSION_OUTPUT="ecli ${VERSION}"
+
+if [ -z "$ARTIFACT" ]; then
+  raw_arch="$(uname -m 2>/dev/null || echo x86_64)"
+  case "$raw_arch" in
+    amd64|x86_64) arch="x86_64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *) arch="$raw_arch" ;;
+  esac
+  ARTIFACT="releases/${VERSION}/ecli_${VERSION}_linux_${arch}.deb"
+fi
+
+if [ ! -e "$ARTIFACT" ]; then
+  echo "Runtime artifact not found: $ARTIFACT" >&2
+  exit 3
+fi
+
+if [ "$ALLOW_NONRELEASE" -eq 0 ]; then
+  case "$ARTIFACT" in
+    releases/"$VERSION"/*|releases/"$VERSION") ;;
+    "$PROJECT_ROOT"/releases/"$VERSION"/*|"$PROJECT_ROOT"/releases/"$VERSION") ;;
+    *)
+      echo "Artifact is outside current project version directory releases/${VERSION}: $ARTIFACT" >&2
+      exit 4
+      ;;
+  esac
+fi
+
+tmpdir="$(mktemp -d)"
+mountpoint=""
+cleanup() {
+  if [ -n "$mountpoint" ] && command -v hdiutil >/dev/null 2>&1; then
+    hdiutil detach "$mountpoint" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+host_os="$(uname -s 2>/dev/null || echo unknown)"
+
+can_execute_artifact() {
+  case "$1" in
+    *.deb|*.rpm|*.AppImage|*.tar.gz|*.tgz|*.txz|*.pkg.tar.zst)
+      [ "$host_os" = "Linux" ]
+      ;;
+    *.pkg)
+      [ "$host_os" = "FreeBSD" ]
+      ;;
+    *.dmg)
+      [ "$host_os" = "Darwin" ]
+      ;;
+    *.exe)
+      case "$host_os" in MINGW*|MSYS*|CYGWIN*) return 0 ;; *) return 1 ;; esac
+      ;;
+    *)
+      [ -x "$1" ]
+      ;;
+  esac
+}
+
+extract_artifact() {
+  local artifact="$1"
+  local root="$tmpdir/root"
+  mkdir -p "$root"
+
+  if [ -d "$artifact" ]; then
+    printf '%s\n' "$artifact"
+    return 0
+  fi
+
+  case "$artifact" in
+    *.deb)
+      command -v dpkg-deb >/dev/null 2>&1 || {
+        echo "dpkg-deb is required to extract $artifact" >&2
+        return 1
+      }
+      dpkg-deb -x "$artifact" "$root"
+      ;;
+    *.rpm)
+      if command -v rpm2cpio >/dev/null 2>&1 && command -v cpio >/dev/null 2>&1; then
+        case "$artifact" in
+          /*) rpm_input="$artifact" ;;
+          *) rpm_input="$PROJECT_ROOT/$artifact" ;;
+        esac
+        (cd "$root" && rpm2cpio "$rpm_input" | cpio -idm --quiet)
+      elif command -v bsdtar >/dev/null 2>&1; then
+        bsdtar -xf "$artifact" -C "$root"
+      else
+        echo "rpm2cpio+cpio or bsdtar is required to extract $artifact" >&2
+        return 1
+      fi
+      ;;
+    *.pkg)
+      tar -xf "$artifact" -C "$root"
+      ;;
+    *.tar.gz|*.tgz)
+      tar -xzf "$artifact" -C "$root"
+      ;;
+    *.txz|*.pkg.tar.zst)
+      tar -xf "$artifact" -C "$root"
+      ;;
+    *.dmg)
+      if [ "$host_os" != "Darwin" ]; then
+        echo "DMG structural inspection requires macOS; CI must run native macOS smoke." >&2
+        return 2
+      fi
+      mountpoint="$tmpdir/dmg"
+      mkdir -p "$mountpoint"
+      hdiutil attach -readonly -nobrowse -mountpoint "$mountpoint" "$artifact" >/dev/null
+      printf '%s\n' "$mountpoint"
+      return 0
+      ;;
+    *.AppImage|*.exe)
+      install -m 0755 "$artifact" "$root/ecli"
+      ;;
+    *)
+      if [ -x "$artifact" ]; then
+        install -m 0755 "$artifact" "$root/ecli"
+      else
+        echo "Unsupported artifact type: $artifact" >&2
+        return 1
+      fi
+      ;;
+  esac
+
+  printf '%s\n' "$root"
+}
+
+find_launcher() {
+  local root="$1"
+  for candidate in \
+    "$root/usr/bin/ecli" \
+    "$root/usr/local/bin/ecli" \
+    "$root/ecli" \
+    "$root/ECLI.app/Contents/MacOS/ecli"; do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  find "$root" -maxdepth 5 -type f \( -name ecli -o -name ecli.exe \) -perm -111 -print | head -n 1
+}
+
+scan_logs() {
+  local home="$1"
+  local log_file="$home/.config/ecli/logs/editor.log"
+  [ -f "$log_file" ] || return 0
+  if grep -E "ModuleNotFoundError|No module named 'unittest'|CRITICAL - ecli - Failed to import a critical application component" "$log_file" >/dev/null; then
+    echo "Runtime smoke created forbidden startup log entries:" >&2
+    cat "$log_file" >&2
+    return 1
+  fi
+}
+
+run_command() {
+  local home="$1"
+  shift
+  HOME="$home" TERM="${TERM:-xterm-256color}" "$@"
+}
+
+run_native_smoke() {
+  local binary="$1"
+  local home="$tmpdir/home"
+  local out="$tmpdir/stdout"
+  local err="$tmpdir/stderr"
+  mkdir -p "$home"
+
+  run_command "$home" "$binary" --help >"$out" 2>"$err"
+  [ -s "$out" ] || {
+    echo "Runtime smoke --help produced no stdout." >&2
+    cat "$err" >&2 || true
+    return 1
+  }
+
+  run_command "$home" "$binary" --version >"$out" 2>"$err"
+  version_output="$(tr -d '\r' <"$out" | sed -n '1p')"
+  if [ "$version_output" != "$EXPECTED_VERSION_OUTPUT" ]; then
+    echo "Unexpected --version output: '$version_output' (expected '$EXPECTED_VERSION_OUTPUT')" >&2
+    cat "$err" >&2 || true
+    return 1
+  fi
+
+  if command -v timeout >/dev/null 2>&1 && command -v script >/dev/null 2>&1; then
+    set +e
+    timeout 3s script -q -c "HOME='$home' TERM='${TERM:-xterm-256color}' '$binary'" /dev/null \
+      >"$tmpdir/tty.stdout" 2>"$tmpdir/tty.stderr"
+    tty_rc=$?
+    set -e
+    case "$tty_rc" in
+      0|124) ;;
+      *)
+        echo "Bare ECLI pseudo-TTY startup exited unexpectedly with status $tty_rc" >&2
+        cat "$tmpdir/tty.stderr" >&2 || true
+        return 1
+        ;;
+    esac
+  else
+    echo "WARNING: timeout or script unavailable; skipping bounded pseudo-TTY startup." >&2
+  fi
+
+  scan_logs "$home"
+}
+
+run_structural_check() {
+  local artifact="$1"
+  local root="$2"
+
+  case "$artifact" in
+    *.rpm)
+      if command -v rpm >/dev/null 2>&1; then
+        rpm -qpl "$artifact" | grep -E '(^|/)usr/bin/ecli$' >/dev/null
+      else
+        [ -n "$(find_launcher "$root")" ]
+      fi
+      ;;
+    *.pkg)
+      tar -tf "$artifact" | grep -E '(^|/)usr/local/bin/ecli$' >/dev/null
+      ;;
+    *.dmg)
+      if [ "$host_os" = "Darwin" ]; then
+        [ -n "$(find_launcher "$root")" ]
+      else
+        [ -s "$artifact" ]
+      fi
+      ;;
+    *.exe)
+      [ -s "$artifact" ]
+      ;;
+    *)
+      [ -n "$(find_launcher "$root")" ]
+      ;;
+  esac
+}
+
+report_structural_pass() {
+  echo "--> OK: structural package contract passed for $1 (runtime execution was not performed)"
+}
+
+root=""
+extract_rc=0
+root="$(extract_artifact "$ARTIFACT")" || extract_rc=$?
+
+if [ "$extract_rc" -ne 0 ]; then
+  if [ "$MODE" = "native" ]; then
+    exit "$extract_rc"
+  fi
+  run_structural_check "$ARTIFACT" "$tmpdir/root"
+  report_structural_pass "$ARTIFACT"
+  exit 0
+fi
+
+binary="$(find_launcher "$root")"
+
+if [ "$MODE" = "structural" ]; then
+  run_structural_check "$ARTIFACT" "$root"
+  report_structural_pass "$ARTIFACT"
+  exit 0
+fi
+
+if [ "$MODE" = "native" ] || can_execute_artifact "$ARTIFACT"; then
+  if [ -z "$binary" ] || [ ! -x "$binary" ]; then
+    echo "Runtime launcher is missing or not executable under $root" >&2
+    exit 5
+  fi
+  run_native_smoke "$binary"
+  echo "--> OK: native runtime smoke passed for $ARTIFACT"
+else
+  run_structural_check "$ARTIFACT" "$root"
+  report_structural_pass "$ARTIFACT"
+fi

--- a/scripts/verify_runtime.sh
+++ b/scripts/verify_runtime.sh
@@ -101,14 +101,137 @@ fi
 
 tmpdir="$(mktemp -d)"
 mountpoint=""
+dmg_device=""
+
+private_var_path() {
+  case "$1" in
+    /var/*) printf '/private%s\n' "$1" ;;
+    *) printf '%s\n' "$1" ;;
+  esac
+}
+
+is_mountpoint_mounted() {
+  local path="$1"
+  local private_path
+  private_path="$(private_var_path "$path")"
+  mount | awk -v mp="$path" -v private_mp="$private_path" '
+    $3 == mp || $3 == private_mp { found = 1 }
+    END { exit found ? 0 : 1 }
+  '
+}
+
+is_dmg_device_attached() {
+  [ -n "$dmg_device" ] || return 1
+  hdiutil info 2>/dev/null | grep -F "$dmg_device" >/dev/null 2>&1
+}
+
+wait_for_mountpoint() {
+  local path="$1"
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if is_mountpoint_mounted "$path"; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+wait_for_detach() {
+  local path="$1"
+  local attempt
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    if ! is_mountpoint_mounted "$path" && ! is_dmg_device_attached; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+detach_dmg() {
+  local target
+  local attempt
+  local output
+  local rc
+
+  set +e
+  if [ -z "$mountpoint" ]; then
+    set -e
+    return 0
+  fi
+  if ! is_mountpoint_mounted "$mountpoint" && ! is_dmg_device_attached; then
+    dmg_device=""
+    set -e
+    return 0
+  fi
+
+  target="${dmg_device:-$mountpoint}"
+  for attempt in 1 2 3; do
+    output="$(hdiutil detach "$target" 2>&1)"
+    rc=$?
+    if [ "$rc" -eq 0 ] && wait_for_detach "$mountpoint"; then
+      dmg_device=""
+      set -e
+      return 0
+    fi
+    echo "WARNING: hdiutil detach retry ${attempt}/3 failed or did not settle for ${target}." >&2
+    [ -z "$output" ] || printf '%s\n' "$output" >&2
+    sleep 1
+  done
+
+  output="$(hdiutil detach -force "$target" 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "WARNING: hdiutil detach -force failed for ${target}." >&2
+    [ -z "$output" ] || printf '%s\n' "$output" >&2
+  fi
+  if ! wait_for_detach "$mountpoint"; then
+    echo "WARNING: DMG mount/device did not fully detach before cleanup: ${mountpoint}" >&2
+  fi
+  dmg_device=""
+  set -e
+}
+
+attach_dmg() {
+  local artifact="$1"
+  local output_file="$tmpdir/hdiutil-attach.out"
+  local attempt
+  local rc
+
+  for attempt in 1 2 3 4 5; do
+    : >"$output_file"
+    set +e
+    hdiutil attach -readonly -nobrowse -mountpoint "$mountpoint" "$artifact" >"$output_file" 2>&1
+    rc=$?
+    set -e
+
+    if [ "$rc" -eq 0 ]; then
+      dmg_device="$(awk '/^\/dev\/disk/ { print $1; exit }' "$output_file")"
+      if wait_for_mountpoint "$mountpoint"; then
+        return 0
+      fi
+      echo "WARNING: hdiutil attach succeeded but mountpoint did not settle: ${mountpoint}" >&2
+      detach_dmg
+    else
+      echo "WARNING: hdiutil attach failed for ${artifact} (attempt ${attempt}/5, rc=${rc})." >&2
+      sed 's/^/hdiutil: /' "$output_file" >&2
+    fi
+
+    if [ "$attempt" -lt 5 ]; then
+      sleep 2
+    fi
+  done
+
+  echo "ERR: failed to attach DMG: ${artifact}" >&2
+  sed 's/^/hdiutil: /' "$output_file" >&2
+  return 6
+}
+
 cleanup() {
   set +e
   if [ -n "$mountpoint" ] && command -v hdiutil >/dev/null 2>&1; then
-    for _attempt in 1 2 3; do
-      hdiutil detach "$mountpoint" >/dev/null 2>&1 && break
-      sleep 1
-    done
-    hdiutil detach -force "$mountpoint" >/dev/null 2>&1 || true
+    detach_dmg
   fi
   rm -rf "$tmpdir" >/dev/null 2>&1 || true
   return 0
@@ -185,7 +308,7 @@ extract_artifact() {
       fi
       mountpoint="$tmpdir/dmg"
       mkdir -p "$mountpoint"
-      hdiutil attach -readonly -nobrowse -mountpoint "$mountpoint" "$artifact" >/dev/null
+      attach_dmg "$artifact" || return $?
       printf '%s\n' "$mountpoint"
       return 0
       ;;
@@ -320,7 +443,7 @@ extract_rc=0
 root="$(extract_artifact "$ARTIFACT")" || extract_rc=$?
 
 if [ "$extract_rc" -ne 0 ]; then
-  if [ "$MODE" = "native" ]; then
+  if [ "$MODE" = "native" ] || { [ "$host_os" = "Darwin" ] && [ "${ARTIFACT##*.}" = "dmg" ]; }; then
     exit "$extract_rc"
   fi
   run_structural_check "$ARTIFACT" "$tmpdir/root"

--- a/scripts/verify_runtime.sh
+++ b/scripts/verify_runtime.sh
@@ -102,10 +102,16 @@ fi
 tmpdir="$(mktemp -d)"
 mountpoint=""
 cleanup() {
+  set +e
   if [ -n "$mountpoint" ] && command -v hdiutil >/dev/null 2>&1; then
-    hdiutil detach "$mountpoint" >/dev/null 2>&1 || true
+    for _attempt in 1 2 3; do
+      hdiutil detach "$mountpoint" >/dev/null 2>&1 && break
+      sleep 1
+    done
+    hdiutil detach -force "$mountpoint" >/dev/null 2>&1 || true
   fi
-  rm -rf "$tmpdir"
+  rm -rf "$tmpdir" >/dev/null 2>&1 || true
+  return 0
 }
 trap cleanup EXIT
 

--- a/src/ecli/__init__.py
+++ b/src/ecli/__init__.py
@@ -13,6 +13,7 @@
 
 """ECLI — terminal-based text editor."""
 
+import sys
 import tomllib
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -49,8 +50,20 @@ def _installed_package_version(
         return None
 
 
+def _bundled_version() -> str | None:
+    bundle_root = getattr(sys, "_MEIPASS", None)
+    if not bundle_root:
+        return None
+    return _read_pyproject_version(Path(str(bundle_root)) / "pyproject.toml")
+
+
 def _resolve_version() -> str:
-    return _source_tree_version() or _installed_package_version() or "0.0.0+local"
+    return (
+        _source_tree_version()
+        or _bundled_version()
+        or _installed_package_version()
+        or "0.0.0+local"
+    )
 
 
 __version__ = _resolve_version()

--- a/src/ecli/__main__.py
+++ b/src/ecli/__main__.py
@@ -33,25 +33,11 @@ import logging
 import os
 import signal
 import sys
+import traceback
 from pathlib import Path
 from typing import Any, Optional
 
-from dotenv import load_dotenv
-
-# --- Step 1: Load Environment Variables from the User's Config Directory ---
-# Load ~/.config/ecli/.env early, before any other imports use environment.
-try:
-    user_config_dir = Path.home() / ".config" / "ecli"
-    dotenv_path = user_config_dir / ".env"
-    if dotenv_path.exists():
-        load_dotenv(dotenv_path=dotenv_path)
-except (RuntimeError, PermissionError, OSError) as e:
-    print(f"Warning: Could not load .env file: {e}", file=sys.stderr)
-except Exception as e:
-    print(
-        f"Warning: Unexpected error loading .env, continuing with defaults: {e}",
-        file=sys.stderr,
-    )
+from ecli import __version__
 
 # --- Step 2: Set up the Python Path ---
 # Ensure the 'ecli' package is importable for both source and bundled runs.
@@ -59,10 +45,66 @@ project_root = os.path.dirname(os.path.abspath(__file__))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
+
+def _default_log_path() -> Path:
+    return Path.home() / ".config" / "ecli" / "logs" / "editor.log"
+
+
+def _write_unconfigured_startup_traceback(message: str, exc: BaseException) -> None:
+    """Best-effort traceback logging before configured logging is available."""
+    try:
+        log_path = _default_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as log_file:
+            log_file.write(f"CRITICAL - ecli - {message}: {exc}\n")
+            log_file.writelines(
+                traceback.format_exception(type(exc), exc, exc.__traceback__)
+            )
+    except Exception:
+        return
+
+
+def _print_startup_failure(message: str, exc: BaseException) -> None:
+    print(f"ECLI startup failure: {message}: {exc}", file=sys.stderr)
+    print(f"Full traceback logged to: {_default_log_path()}", file=sys.stderr)
+
+
+def _exit_startup_failure(message: str, exc: BaseException) -> None:
+    logger.critical("%s: %s", message, exc, exc_info=True)
+    _print_startup_failure(message, exc)
+    sys.exit(1)
+
+
+def _print_help() -> None:
+    print(
+        "Usage: ecli [OPTIONS] [FILE]\n"
+        "\n"
+        "ECLI terminal-first engineering operations workbench.\n"
+        "\n"
+        "Options:\n"
+        "  -h, --help       Show this help and exit.\n"
+        "  --version        Show version and exit.\n"
+        "  --services       Print ServiceRegistry service status.\n"
+        "  --doctor         Run read-only SystemDoctor diagnostics.\n"
+        "  --plan-preview   Print a draft CommandPlan preview.\n"
+    )
+
+
+def _print_version() -> None:
+    print(f"ecli {__version__}")
+
+
 # --- Step 2.5: Explicit read-only service CLI dispatch ---
 # Preserve the default editor path for `python -m ecli [file]`. Only explicit
 # Phase 1 service flags are handled here before curses/editor initialization.
 try:
+    if sys.argv[1:] in (["--help"], ["-h"]):
+        _print_help()
+        sys.exit(0)
+    if sys.argv[1:] == ["--version"]:
+        _print_version()
+        sys.exit(0)
+
     from ecli.cli import is_service_cli, run_service_cli
 
     if is_service_cli(sys.argv[1:]):
@@ -73,6 +115,25 @@ except Exception as e:
     print(f"ECLI service CLI error: {e}", file=sys.stderr)
     sys.exit(1)
 
+# --- Step 1: Load Environment Variables from the User's Config Directory ---
+# Load ~/.config/ecli/.env before runtime imports use environment.
+try:
+    from dotenv import load_dotenv
+
+    user_config_dir = Path.home() / ".config" / "ecli"
+    dotenv_path = user_config_dir / ".env"
+    if dotenv_path.exists():
+        load_dotenv(dotenv_path=dotenv_path)
+except ImportError as e:
+    print(f"Warning: Could not load dotenv support: {e}", file=sys.stderr)
+except (RuntimeError, PermissionError, OSError) as e:
+    print(f"Warning: Could not load .env file: {e}", file=sys.stderr)
+except Exception as e:
+    print(
+        f"Warning: Unexpected error loading .env, continuing with defaults: {e}",
+        file=sys.stderr,
+    )
+
 # --- Step 3: Immediate Logging and Configuration Setup ---
 try:
     from ecli.utils.logging_config import setup_logging
@@ -82,24 +143,20 @@ try:
     setup_logging(config)
     logger = logging.getLogger("ecli")
 except Exception as e:
-    # Logging is not ready; print to stderr and exit.
-    print(
-        f"FATAL: Could not initialize configuration or logging system: {e}",
-        file=sys.stderr,
-    )
-    import traceback
-
-    traceback.print_exc()
+    message = "Could not initialize configuration or logging system"
+    _write_unconfigured_startup_traceback(message, e)
+    _print_startup_failure(message, e)
+    traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)
     sys.exit(1)
 
 # --- Step 4: Import the Core Application ---
 try:
     from ecli.core.Ecli import Ecli
-except ImportError as e:
-    logger.critical(
-        "Failed to import a critical application component: %s", e, exc_info=True
+except Exception as e:
+    _exit_startup_failure(
+        "Failed to import a critical application component",
+        e,
     )
-    sys.exit(1)
 
 
 def _resolve_cli_path(argv: list[str]) -> Optional[Path]:
@@ -288,8 +345,9 @@ def start() -> None:
         curses.wrapper(main_app_runner, config, file_to_open)
 
         logger.info("ECLI editor shut down gracefully.")
-    except Exception:
+    except Exception as e:
         logger.critical("Unhandled exception at the top level.", exc_info=True)
+        _print_startup_failure("Unhandled exception at the top level", e)
         sys.exit(1)
     finally:
         # Disable application modes after curses finishes:

--- a/src/ecli/core/Ecli.py
+++ b/src/ecli/core/Ecli.py
@@ -65,7 +65,6 @@ from typing import (
     cast,
     overload,
 )
-from unittest.mock import Mock
 
 import pyperclip
 
@@ -89,7 +88,7 @@ from ecli.ui.DrawScreen import DrawScreen
 from ecli.ui.KeyBinder import KeyBinder
 from ecli.ui.PanelManager import PanelManager
 from ecli.ui.panels import FileBrowserPanel, GitPanel
-from ecli.utils.logging_config import logger
+from ecli.utils.logging_config import logger, log_record_to_file_handlers
 from ecli.utils.text_buffer import (
     detect_and_decode_text,
     split_text_preserving_content,
@@ -100,6 +99,63 @@ from ecli.utils.utils import hex_to_xterm
 # --- CONDITIONAL IMPORT FOR UNIX SYSTEMS ---
 if sys.platform != "win32":
     import termios
+
+
+class _LightweightGitBridge:
+    """No-op Git bridge used by lightweight editor instances."""
+
+    info: tuple[str, str, str] = ("", "", "")
+
+    def update_git_info(self) -> None:
+        return None
+
+    def reset_state(self) -> None:
+        return None
+
+    def process_queues(self) -> bool:
+        return False
+
+
+class _LightweightLinterBridge:
+    """No-op linter bridge used by lightweight editor instances."""
+
+    def shutdown(self) -> None:
+        return None
+
+    def reload_devops_module(self) -> bool:
+        return False
+
+    def run_linter(self, _code: str) -> list[Any]:
+        return []
+
+    def process_lsp_queue(self) -> bool:
+        return False
+
+
+class _LightweightPanelManager:
+    """No-op panel manager used by lightweight editor instances."""
+
+    def __init__(self) -> None:
+        self.registered_panels: dict[str, Any] = {}
+        self.active_panel: Any = None
+
+    def is_panel_active(self) -> bool:
+        return False
+
+    def show_panel_instance(self, _panel: Any) -> None:
+        return None
+
+    def show_panel(self, _panel_name: str, **_kwargs: Any) -> None:
+        return None
+
+    def close_active_panel(self) -> None:
+        self.active_panel = None
+
+    def handle_key(self, _key_input: Any) -> bool:
+        return False
+
+    def draw_active_panel(self) -> None:
+        return None
 
 
 ## ==================== Ecli Class ====================
@@ -475,10 +531,9 @@ class Ecli:
             if self.panel_manager:
                 self.panel_manager.registered_panels["git"] = GitPanel
         else:
-            # Use Mocks for lightweight mode to avoid AttributeError
-            self.git = Mock()
-            self.linter_bridge = Mock()
-            self.panel_manager = Mock()
+            self.git = _LightweightGitBridge()
+            self.linter_bridge = _LightweightLinterBridge()
+            self.panel_manager = _LightweightPanelManager()
 
         # KeyBinder is initialized last as it may depend on other components
         self.keybinder: KeyBinder = KeyBinder(self)
@@ -556,15 +611,20 @@ class Ecli:
         self._cli_intended_path = intended
 
         # 1) If editor already has a dedicated API, use it.
-        for meth_name in ("preload_cli_document", "open_or_create"):
-            if hasattr(self, meth_name) and getattr(self, meth_name) is not self.preload_cli_document:
+        for meth_name in ("open_or_create",):
+            if hasattr(self, meth_name):
                 try:
                     getattr(self, meth_name)(intended)  # type: ignore[misc]
                     # also mirror filename state for downstream save logic
                     self._set_current_path(intended)
                     return
-                except Exception:
-                    logger.debug("%s(%s) failed, will try fallbacks", meth_name, intended, exc_info=True)
+                except Exception as exc:
+                    logger.debug(
+                        "%s(%s) failed, will try fallbacks: %s",
+                        meth_name,
+                        intended,
+                        exc,
+                    )
 
         # 2) If file exists, use open_file; else create empty buffer with that name.
         if os.path.exists(intended):
@@ -760,10 +820,39 @@ class Ecli:
         return self.cursor_y, self.cursor_y
 
     # --- Panel toggles ---
+    def _is_active_panel_type(self, panel_type_name: str) -> bool:
+        """Return True when the named panel class is currently visible."""
+        panel_manager = getattr(self, "panel_manager", None)
+        if not panel_manager or not panel_manager.is_panel_active():
+            return False
+        active_panel = getattr(panel_manager, "active_panel", None)
+        return active_panel.__class__.__name__ == panel_type_name
+
+    def _is_file_browser_active(self) -> bool:
+        """Return True when the File Manager panel is currently active."""
+        return self._is_active_panel_type("FileBrowserPanel")
+
+    def _close_file_browser_for_ai(self) -> None:
+        """Close the File Manager before running the editor-scoped AI flow."""
+        panel_manager = getattr(self, "panel_manager", None)
+        if panel_manager and self._is_file_browser_active():
+            panel_manager.close_active_panel()
+            self.focus = "editor"
+
     def toggle_widget_panel(self) -> bool:
         """Keeps original AI widget behaviour (bound to F7).
         Shows widget selection menu and launches the selected one.
         """
+        if self._is_file_browser_active():
+            self._close_file_browser_for_ai()
+
+        if self.panel_manager and self.panel_manager.is_panel_active():
+            self._set_status_message(
+                "AI Code Assistant is available from the editor. Close active panel first."
+            )
+            self._force_full_redraw = True
+            return True
+
         # This function now simply calls select_ai_provider_and_ask,
         # which in turn will call the non-blocking panel.
         logging.debug("toggle_widget_panel -> AI panel request.")
@@ -1025,6 +1114,39 @@ class Ecli:
         start_coords, end_coords = norm_range
         start_row, start_col = start_coords
         end_row, end_col = end_coords
+
+        if not self.text:
+            log_record_to_file_handlers(
+                logging.WARNING,
+                "get_selected_text: empty text buffer",
+                logger_name="ecli.selection",
+            )
+            return ""
+
+        if not all(
+            isinstance(value, int)
+            for value in (start_row, start_col, end_row, end_col)
+        ):
+            log_record_to_file_handlers(
+                logging.WARNING,
+                "get_selected_text: non-integer selection coordinates",
+                logger_name="ecli.selection",
+            )
+            return ""
+
+        if not (0 <= start_row < len(self.text)) or not (0 <= end_row < len(self.text)):
+            log_record_to_file_handlers(
+                logging.WARNING,
+                "get_selected_text: selection rows out of bounds (%s..%s), text lines=%s",
+                start_row,
+                end_row,
+                len(self.text),
+                logger_name="ecli.selection",
+            )
+            return ""
+
+        start_col = max(0, min(start_col, len(self.text[start_row])))
+        end_col = max(0, min(end_col, len(self.text[end_row])))
 
         if start_row == end_row:
             # Single-line selection
@@ -7588,6 +7710,16 @@ class Ecli:
         if self.git:
             any_state_changed_by_queues |= self.git.process_queues()
 
+        panel_manager = getattr(self, "panel_manager", None)
+        if (
+            panel_manager
+            and panel_manager.is_panel_active()
+            and hasattr(panel_manager.active_panel, "process_queues")
+        ):
+            any_state_changed_by_queues |= bool(
+                panel_manager.active_panel.process_queues()
+            )
+
         # 3. Delegate Linter/LSP queue processing.
         if self.linter_bridge:
             any_state_changed_by_queues |= self.linter_bridge.process_lsp_queue()
@@ -7806,11 +7938,11 @@ class Ecli:
     def _handle_input_dispatch(self, key_input: Any) -> bool:
         """Dispatches a key press to the correct handler (panel or editor).
 
-        This method determines the current focus of the application.
-        - If the focus is on a panel (`self.focus == 'panel'`) and a panel is
-          active, the key press is passed to the `PanelManager` for handling.
-        - Otherwise, the key press is handled by the main editor's input handler
-          (`self.handle_input`, which is an alias for `self.keybinder.handle_input`).
+        Routing order:
+        1. Global Help shortcut.
+        2. Global AI Code Assistant shortcut.
+        3. Focused active panel.
+        4. Main editor keybinder.
 
         Args:
             key_input: The key event received from curses.
@@ -7819,6 +7951,12 @@ class Ecli:
             bool: The result from the called handler, indicating whether the key
                   press caused a state change (True) or not (False).
         """
+        if self.keybinder.is_key_for_action(key_input, "help"):
+            return self.handle_input(key_input)
+
+        if self.keybinder.is_key_for_action(key_input, "toggle_widget_panel"):
+            return self.handle_input(key_input)
+
         if (
             self.focus == "panel"
             and self.panel_manager

--- a/src/ecli/integrations/GitBridge.py
+++ b/src/ecli/integrations/GitBridge.py
@@ -23,9 +23,12 @@ the necessary configuration and state management for Git operations.
 """
 
 import functools
-import os
 import queue
+import shutil
+import subprocess
 import threading
+from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from ecli.utils.utils import safe_run
@@ -33,6 +36,19 @@ from ecli.utils.utils import safe_run
 
 if TYPE_CHECKING:
     from ecli.core.Ecli import Ecli
+
+
+@dataclass(frozen=True)
+class GitCommandResult:
+    """Structured result contract for Git command execution."""
+
+    command_label: str
+    cwd: str
+    returncode: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+    error: str = ""
 
 
 # ================= GitBridge Class ==============================
@@ -45,6 +61,8 @@ class GitBridge:
         self.editor: Ecli = editor
         self.config: dict = editor.config
         self.info: tuple[str, str, str] = ("", "", "0")
+        self.repo_root: Optional[str] = None
+        self.repo_state: str = "unavailable"
         self.last_filename_context: Optional[str] = None
         self.info_q: queue.Queue[tuple[str, str, str]] = editor._git_q
         self.cmd_q: queue.Queue[str] = editor._git_cmd_q
@@ -53,7 +71,7 @@ class GitBridge:
         """Synchronously fetches essential Git information."""
         return self._get_repo_info_sync(file_path_context)
 
-    def update_git_info(self) -> None:
+    def update_git_info(self, force: bool = False) -> None:
         """Initiates a non-blocking, asynchronous update of the Git information."""
         if not self.config.get("git", {}).get("enabled", True):
             if self.info != ("", "", "0"):
@@ -62,9 +80,10 @@ class GitBridge:
 
         current_file_context = self.editor.filename
         with self.editor._state_lock:
-            if current_file_context == self.last_filename_context:
+            if not force and current_file_context == self.last_filename_context:
                 return
             self.last_filename_context = current_file_context
+            self.repo_state = "loading"
 
         thread = threading.Thread(
             target=self._fetch_git_info_async,
@@ -113,33 +132,149 @@ class GitBridge:
     def reset_state(self):
         """Resets the cached Git state."""
         self.info = ("", "", "0")
+        self.repo_root = None
+        self.repo_state = "unavailable"
         self.last_filename_context = None
+
+    def resolve_repo_root(
+        self, file_path_context: Optional[str] = None
+    ) -> Optional[str]:
+        """Resolve the Git repository root for an active file or current directory."""
+        if shutil.which("git") is None:
+            self.repo_root = None
+            self.repo_state = "unavailable"
+            return None
+
+        candidates: list[Path] = []
+        if file_path_context:
+            path = Path(file_path_context).expanduser()
+            if not path.is_absolute():
+                path = Path.cwd() / path
+            path = path.resolve(strict=False)
+            candidates.append(path if path.is_dir() else path.parent)
+        candidates.append(Path.cwd())
+
+        seen: set[str] = set()
+        for candidate in candidates:
+            key = str(candidate)
+            if key in seen:
+                continue
+            seen.add(key)
+            result = safe_run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=str(candidate),
+                timeout=3,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                self.repo_root = result.stdout.strip()
+                return self.repo_root
+
+        self.repo_root = None
+        self.repo_state = "not repo"
+        return None
+
+    def run_git_command(
+        self,
+        cmd_list: list[str],
+        *,
+        file_path_context: Optional[str] = None,
+        timeout: float = 15.0,
+    ) -> GitCommandResult:
+        """Run a Git command in the resolved repository root."""
+        command_label = " ".join(cmd_list)
+        repo_root = self.resolve_repo_root(file_path_context)
+        if repo_root is None:
+            return GitCommandResult(
+                command_label=command_label,
+                cwd=str(Path.cwd()),
+                returncode=128,
+                stdout="",
+                stderr="Not a Git repository.",
+                error="not_repo" if self.repo_state == "not repo" else self.repo_state,
+            )
+
+        try:
+            result = subprocess.run(
+                cmd_list,
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                check=False,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout,
+            )
+            return GitCommandResult(
+                command_label=command_label,
+                cwd=repo_root,
+                returncode=result.returncode,
+                stdout=result.stdout or "",
+                stderr=result.stderr or "",
+            )
+        except subprocess.TimeoutExpired as exc:
+            return GitCommandResult(
+                command_label=command_label,
+                cwd=repo_root,
+                returncode=-15,
+                stdout=exc.stdout or "",
+                stderr=exc.stderr or "",
+                timed_out=True,
+                error=f"Command timed out after {timeout:g}s.",
+            )
+        except OSError as exc:
+            return GitCommandResult(
+                command_label=command_label,
+                cwd=repo_root,
+                returncode=127,
+                stdout="",
+                stderr=str(exc),
+                error=str(exc),
+            )
 
     def _get_repo_info_sync(
         self, file_path_context: Optional[str]
     ) -> tuple[str, str, str]:
-        # (Your original, unchanged code for this method goes here)
-        repo_dir = os.getcwd()
-        if file_path_context and os.path.isfile(file_path_context):
-            repo_dir = os.path.dirname(os.path.abspath(file_path_context))
-        if not os.path.isdir(os.path.join(repo_dir, ".git")):
-            return "", "", "0"
+        repo_dir = self.resolve_repo_root(file_path_context)
+        if repo_dir is None:
+            return "", "not configured", "0"
+
         run_git = functools.partial(safe_run, cwd=repo_dir, timeout=3)
         branch, user, commits = "", "", "0"
         res_branch = run_git(["git", "branch", "--show-current"])
         if res_branch.returncode == 0 and res_branch.stdout.strip():
             branch = res_branch.stdout.strip()
         else:
-            res_ref = run_git(["git", "symbolic-ref", "--short", "HEAD"])
+            res_ref = run_git(["git", "rev-parse", "--abbrev-ref", "HEAD"])
             if res_ref.returncode == 0 and res_ref.stdout.strip():
                 branch = res_ref.stdout.strip()
             else:
-                branch = "detached"
-        if run_git(["git", "status", "--porcelain"]).stdout.strip():
+                res_symbolic = run_git(["git", "symbolic-ref", "--short", "HEAD"])
+                if res_symbolic.returncode == 0 and res_symbolic.stdout.strip():
+                    branch = res_symbolic.stdout.strip()
+                else:
+                    branch = "detached"
+        if branch == "HEAD":
+            branch = "detached"
+
+        status_result = run_git(["git", "status", "--porcelain"])
+        if status_result.returncode == 0 and status_result.stdout.strip():
+            self.repo_state = "dirty"
             branch += "*"
+        elif status_result.returncode == 0:
+            self.repo_state = "clean"
+        else:
+            self.repo_state = "unavailable"
+
         res_user = run_git(["git", "config", "user.name"])
-        if res_user.returncode == 0:
+        if res_user.returncode == 0 and res_user.stdout.strip():
             user = res_user.stdout.strip()
+        else:
+            res_email = run_git(["git", "config", "user.email"])
+            user = (
+                res_email.stdout.strip()
+                if res_email.returncode == 0 and res_email.stdout.strip()
+                else "not configured"
+            )
         res_commits = run_git(["git", "rev-list", "--count", "HEAD"])
         if res_commits.returncode == 0 and res_commits.stdout.strip().isdigit():
             commits = res_commits.stdout.strip()
@@ -155,34 +290,31 @@ class GitBridge:
 
     def _run_git_command_async(self, cmd_list: list[str], command_name: str) -> None:
         """Executes a Git command in a thread and puts the result in the queue."""
-        # (Your original, unchanged code for this method goes here)
-        msg = ""
-        try:
-            repo_dir = os.getcwd()
-            if self.editor.filename and os.path.isfile(self.editor.filename):
-                repo_dir = os.path.dirname(os.path.abspath(self.editor.filename))
-            res = safe_run(cmd_list, cwd=repo_dir)
-            if res.returncode == 0:
-                msg = f"Git {command_name}: Successful."
-                if command_name in ["commit", "pull", "push"]:
-                    self.cmd_q.put("request_git_info_update")
-                if res.stdout.strip():
-                    msg += f" Output: {res.stdout.strip().splitlines()[0][:90]}..."
-            else:
-                msg = f"Git {command_name} error: {res.stderr.strip().splitlines()[0][:100]}..."
-        except Exception as e:
-            msg = f"Git {command_name} system error: {e}"
+        res = self.run_git_command(cmd_list, file_path_context=self.editor.filename)
+        if res.returncode == 0:
+            msg = f"Git {command_name}: Successful."
+            if command_name in ["commit", "pull", "push"]:
+                self.cmd_q.put("request_git_info_update")
+            if res.stdout.strip():
+                msg += f" Output: {res.stdout.strip().splitlines()[0][:90]}..."
+        else:
+            detail = (res.stderr or res.error or "unknown error").strip()
+            msg = f"Git {command_name} error: {detail.splitlines()[0][:100]}..."
         self.cmd_q.put(msg)
 
     def _handle_git_info(self, git_data: tuple[str, str, str]) -> None:
         """Processes fetched Git data and updates the editor's status message."""
         with self.editor._state_lock:
-            if git_data == self.info:
+            if git_data == self.info and self.repo_state != "loading":
                 return
             self.info = git_data
         branch, user, commits = git_data
         if not branch:
+            if self.repo_state == "loading":
+                self.repo_state = "not repo"
             self.editor._set_status_message("Not a Git repository.")
             return
-        status = f"Git: {branch} by {user} ({commits} commits)"
+        state = "dirty" if "*" in branch else "clean"
+        self.repo_state = state
+        status = f"Git: {state} - {branch.rstrip('*')} by {user} ({commits} commits)"
         self.editor._set_status_message(status)

--- a/src/ecli/ui/DrawScreen.py
+++ b/src/ecli/ui/DrawScreen.py
@@ -986,13 +986,20 @@ class DrawScreen:
                 "enabled", True
             ):
                 branch, user, commits = self.editor.git.info
-                if branch:
+                git_state = getattr(self.editor.git, "repo_state", "unavailable")
+                if git_state in {"clean", "dirty"} and branch:
                     dirty = "*" in branch
                     branch = branch.rstrip("*")
-                    git_txt = f" Git: {user}, {branch}, {commits or '0'}"
+                    git_txt = f" Git: {'dirty' if dirty else 'clean'}"
                     git_attr = c_dirty if dirty else c_git
+                elif git_state == "loading":
+                    git_txt = " Git: loading"
+                elif git_state == "not repo":
+                    git_txt = " Git: not repo"
+                elif git_state == "unavailable":
+                    git_txt = " Git: unavailable"
                 else:
-                    git_txt = " Git: None"
+                    git_txt = " Git: loading"
             right_w = self.editor.get_string_width(git_txt)
 
             # -- middle = status message --------------------------------

--- a/src/ecli/ui/KeyBinder.py
+++ b/src/ecli/ui/KeyBinder.py
@@ -49,6 +49,8 @@ import re
 from typing import TYPE_CHECKING, Any, Callable, Optional
 from wcwidth import wcswidth
 
+from ecli.utils.logging_config import log_exception_to_file_handlers
+
 if TYPE_CHECKING:
     from ecli.core.Ecli import Ecli
 
@@ -238,13 +240,19 @@ class KeyBinder:
                 return action_caused_visual_change
 
             except Exception as e_handler:
-                logging.exception(
-                    "Input handler critical error. This should be investigated."
+                log_exception_to_file_handlers(
+                    "Input handler critical error. This should be investigated.",
+                    e_handler,
+                    logger_name="ecli.input",
                 )
-                self.editor._set_status_message(
-                    f"Input handler error: {str(e_handler)[:50]}"
-                )
+                self.editor._set_status_message("Input handler error. See logs.")
+                if hasattr(self.editor, "_force_full_redraw"):
+                    self.editor._force_full_redraw = True
                 return True
+
+    def is_key_for_action(self, key: str | int, action_name: str) -> bool:
+        """Return True if key is bound to the named editor action."""
+        return key in self.keybindings.get(action_name, [])
 
     def _load_keybindings(self) -> dict[str, list[int | str]]:
         """Loads and returns the keybindings configuration for the editor.

--- a/src/ecli/ui/PanelManager.py
+++ b/src/ecli/ui/PanelManager.py
@@ -25,6 +25,8 @@ import curses
 import logging
 from typing import TYPE_CHECKING, Any, Optional
 
+from ecli.utils.logging_config import log_exception_to_file_handlers
+
 from .panels import (
     AiResponsePanel,
     BasePanel,
@@ -183,8 +185,15 @@ class PanelManager:
             try:
                 # The panel itself decides if it can handle the key.
                 return self.active_panel.handle_key(key)
-            except Exception:
-                logging.exception("Panel key-handler crashed")
+            except Exception as exc:
+                log_exception_to_file_handlers(
+                    "Panel key-handler crashed",
+                    exc,
+                    logger_name="ecli.input",
+                )
+                self.editor._set_status_message("Input handler error. See logs.")
+                self.editor._force_full_redraw = True
+                return True
         return False
 
     def draw_active_panel(self) -> None:

--- a/src/ecli/ui/panels.py
+++ b/src/ecli/ui/panels.py
@@ -44,9 +44,9 @@ from __future__ import annotations
 import curses
 import logging
 import os
+import queue
 import shlex
 import shutil
-import subprocess
 import textwrap
 import threading
 from pathlib import Path
@@ -55,11 +55,10 @@ from typing import TYPE_CHECKING, Any, Optional
 import pyperclip
 from wcwidth import wcswidth
 
-from ecli.integrations.GitBridge import GitBridge
+from ecli.integrations.GitBridge import GitBridge, GitCommandResult
 from ecli.services.models.doctor import DoctorContext, DoctorFinding
 from ecli.services.models.plan import CommandPlan
 from ecli.utils.logging_config import logger
-from ecli.utils.utils import safe_run
 
 
 if TYPE_CHECKING:
@@ -1719,8 +1718,7 @@ class CommandPlanPanel(_ReadOnlyRightPanel):
                 lines.append(f"    argv: {shlex.join(step.argv)}")
             try:
                 export_markdown = (
-                    self._service_registry()
-                    .command_plan_service.export_markdown(plan)
+                    self._service_registry().command_plan_service.export_markdown(plan)
                 )
                 lines.extend(["", "Markdown preview:", *export_markdown.splitlines()])
             except Exception:
@@ -1884,6 +1882,9 @@ class GitPanel(BasePanel):
             )
         self.git_bridge: GitBridge = main_editor_instance.git
         self.output_lines: list[str] = ["Select a command from the menu to run."]
+        self.command_results: queue.Queue[tuple[int, GitCommandResult]] = queue.Queue()
+        self.current_command_label: str = ""
+        self._command_generation = 0
         self.menu_items = [
             "Status",
             "Diff",
@@ -1962,62 +1963,130 @@ class GitPanel(BasePanel):
         self, cmd_list: list[str], show_running: bool = True
     ) -> None:
         """Runs a command in a separate thread (for long, non-interactive operations)."""
+        if self.is_busy:
+            return
+
+        self.is_busy = True
+        self._command_generation += 1
+        command_generation = self._command_generation
+        self.current_command_label = " ".join(cmd_list)
+        if show_running:
+            self._set_output_lines([f"Running: {self.current_command_label}..."])
+        self._update_status_help()
 
         def worker() -> None:
-            self.is_busy = True
             try:
-                # If the check passed, change the directory
-                if show_running:
-                    self.output_lines = [f"Running: {' '.join(cmd_list)}..."]
                 result = self._run_git_command(cmd_list)
-                # Update output based on result
-                if result.returncode == 0:
-                    output = result.stdout.strip()
-                    self.output_lines = output.splitlines() or [
-                        "Command successful (no output)"
-                    ]
-                else:  # Error occurred
-                    self.output_lines = [f"ERROR (code {result.returncode}):"] + (
-                        result.stderr.strip().splitlines() or ["(no error message)"]
-                    )
-                self.git_bridge.update_git_info()
-            finally:  # Ensure busy state is reset
-                self.is_busy = False
+            except Exception as exc:
+                result = GitCommandResult(
+                    command_label=" ".join(cmd_list),
+                    cwd=str(Path.cwd()),
+                    returncode=127,
+                    stdout="",
+                    stderr=str(exc),
+                    error=str(exc),
+                )
+            self.command_results.put((command_generation, result))
 
         threading.Thread(target=worker, daemon=True).start()
 
     def _run_command_sync(self, cmd_list: list[str]) -> None:
         """Executes a command synchronously and immediately updates output_lines."""
+        if self.is_busy:
+            return
+
         self.is_busy = True
-        # Remove unnecessary redrawing, the prompt will handle it
+        self._command_generation += 1
+        self.current_command_label = " ".join(cmd_list)
         try:
             result = self._run_git_command(cmd_list)
-            # Update output based on result
-            if result.returncode == 0:
-                output = result.stdout.strip()
-                self.output_lines = output.splitlines() or [
-                    "Command successful (no output)."
-                ]
-                self.editor._set_status_message(
-                    f"Git {cmd_list[1]} successful."
-                )  # Notify about success
-            else:  # Error occurred
-                err_summary = (
-                    result.stderr.strip().splitlines()[0]
-                    if result.stderr.strip()
-                    else "(no error message)"
-                )
-                self.output_lines = [
-                    f"ERROR (code {result.returncode}):"
-                ] + result.stderr.strip().splitlines()
-                self.editor._set_status_message(
-                    f"Git {cmd_list[1]} failed: {err_summary[:50]}..."
-                )  # Notify about error
-
-            # Update overall information in any case
-            self.git_bridge.update_git_info()
-        finally:  # Ensure busy state is reset
+            self._render_command_result(result)
+            if result.error != "not_repo":
+                self.git_bridge.update_git_info(force=True)
+        finally:
             self.is_busy = False
+            self._update_status_help()
+            self.editor._force_full_redraw = True
+
+    def process_queues(self) -> bool:
+        """Render completed Git command results on the UI thread."""
+        changed = False
+        try:
+            while True:
+                command_generation, result = self.command_results.get_nowait()
+                if command_generation != self._command_generation:
+                    changed = True
+                    continue
+                self._render_command_result(result)
+                self.is_busy = False
+                if result.error != "not_repo":
+                    self.git_bridge.update_git_info(force=True)
+                self._update_status_help()
+                changed = True
+        except queue.Empty:
+            pass
+
+        if changed:
+            self.editor._force_full_redraw = True
+        return changed
+
+    def _set_output_lines(self, lines: list[str]) -> None:
+        self.output_lines = lines or [""]
+        self.scroll_offset = 0
+        self.editor._force_full_redraw = True
+
+    def _cancel_current_operation(self) -> None:
+        self._command_generation += 1
+        self.is_busy = False
+        self.current_command_label = ""
+        self._set_output_lines(["Operation cancelled."])
+        self._update_status_help()
+
+    def _empty_success_message(self, result: GitCommandResult) -> str:
+        if result.command_label.startswith("git status"):
+            return "Clean working tree."
+        return "Command successful (no output)."
+
+    def _render_command_result(self, result: GitCommandResult) -> None:
+        if result.error == "not_repo":
+            self._set_output_lines(["Not a Git repository."])
+            return
+
+        if result.timed_out:
+            lines = [
+                f"Command timed out: {result.command_label}",
+                f"CWD: {result.cwd}",
+            ]
+            if result.error:
+                lines.append(result.error)
+            self._set_output_lines(lines)
+            return
+
+        stdout = result.stdout.strip()
+        stderr = result.stderr.strip()
+        if result.returncode == 0:
+            if stdout:
+                self._set_output_lines(stdout.splitlines())
+            elif stderr:
+                self._set_output_lines(stderr.splitlines())
+            else:
+                self._set_output_lines([self._empty_success_message(result)])
+            return
+
+        lines = [
+            f"Command failed: {result.command_label}",
+            f"CWD: {result.cwd}",
+            f"Return code: {result.returncode}",
+        ]
+        if stderr:
+            lines.append("stderr:")
+            lines.extend(stderr.splitlines())
+        if stdout:
+            lines.append("stdout:")
+            lines.extend(stdout.splitlines())
+        if result.error and not stderr:
+            lines.append(result.error)
+        self._set_output_lines(lines)
 
     def _start_auto_update(self) -> None:
         """Starts the auto-update thread for git information."""
@@ -2045,12 +2114,7 @@ class GitPanel(BasePanel):
     def _update_git_info_background(self) -> None:
         """Updates the git information (file status, branch info) in the background."""
         try:
-            # Update only the main branch information
-            self.git_bridge.update_git_info()
-
-            # If the git status is on screen, update it
-            if not self.is_log_view and self.menu_items[self.selected_idx] == "Status":
-                self._handle_status(run_async=False)
+            self.git_bridge.update_git_info(force=True)
         except Exception as e:
             logger.error(f"GitPanel: Background update failed: {e}")
 
@@ -2319,7 +2383,7 @@ class GitPanel(BasePanel):
         logger.info("GitPanel: Opening panel.")
         curses.curs_set(0)
         if self.editor.git:
-            self.editor.git.update_git_info()
+            self.editor.git.update_git_info(force=True)
             self._handle_status()
             self._update_status_help()
 
@@ -2332,15 +2396,24 @@ class GitPanel(BasePanel):
 
     def _get_repo_dir(self) -> str:
         """Determines the repository directory based on the active file."""
-        if self.editor.filename and os.path.isfile(self.editor.filename):
-            return str(Path(self.editor.filename).parent)
+        repo_root = self.git_bridge.resolve_repo_root(self.editor.filename)
+        if repo_root is not None:
+            return repo_root
+        if self.editor.filename:
+            path = Path(self.editor.filename).expanduser()
+            if not path.is_absolute():
+                path = Path.cwd() / path
+            return str(path if path.is_dir() else path.parent)
         return os.getcwd()
 
-    def _run_git_command(self, cmd_list: list[str]) -> subprocess.CompletedProcess[str]:
+    def _run_git_command(self, cmd_list: list[str]) -> GitCommandResult:
         """Executes a Git command in the correct repository context."""
         logger.debug(f"GitPanel: Running command: {cmd_list}")
-        repo_dir = self._get_repo_dir()
-        return safe_run(cmd_list, cwd=repo_dir)
+        return self.git_bridge.run_git_command(
+            cmd_list,
+            file_path_context=self.editor.filename,
+            timeout=15.0,
+        )
 
     def _navigate_menu(self, direction: int) -> None:
         """Navigate through the menu items, skipping separators.
@@ -2406,7 +2479,12 @@ class GitPanel(BasePanel):
             allowing it to be processed by other handlers if necessary.
         """
         # Basic validity checks
-        if not self.visible or self.is_busy:
+        if not self.visible:
+            return False
+        if self.is_busy:
+            if key in (27, ord("q")):
+                self._cancel_current_operation()
+                return True
             return False
 
         # Handle log navigation first as it's a special case
@@ -2513,36 +2591,6 @@ class GitPanel(BasePanel):
         """Get the git command name from the command list."""
         return cmd_list[1] if len(cmd_list) > 1 else cmd_list[0]
 
-    def _handle_successful_command(self, result: Any, cmd_list: list[str]) -> None:
-        """Handle successful command execution output."""
-        output = result.stdout.strip()
-        self.output_lines = (
-            output.splitlines() if output else ["Command successful (no output)."]
-        )
-
-        cmd_name = self._get_command_name(cmd_list)
-        self.editor._set_status_message(f"Git {cmd_name} successful.")
-
-    def _handle_command_error(self, result: Any, cmd_list: list[str]) -> None:
-        """Handle command execution error output."""
-        error_lines = [f"ERROR (code {result.returncode}):"]
-        if result.stderr.strip():
-            error_lines.extend(result.stderr.strip().splitlines())
-        else:
-            error_lines.append("(no error message)")
-
-        self.output_lines = error_lines
-
-        cmd_name = self._get_command_name(cmd_list)
-        error_summary = (
-            result.stderr.strip().split("\n")[0]
-            if result.stderr.strip()
-            else "unknown error"
-        )
-        self.editor._set_status_message(
-            f"Git {cmd_name} failed: {error_summary[:50]}..."
-        )
-
     def _run_command_and_display_output(
         self, cmd_list: list[str], show_running: bool = True
     ) -> None:
@@ -2557,26 +2605,21 @@ class GitPanel(BasePanel):
             logger.debug(f"GitPanel: Running command: {cmd_list}")
 
             if show_running:
-                self.output_lines = [f"Running: {' '.join(cmd_list)}..."]
-                self.scroll_offset = 0
+                self._set_output_lines([f"Running: {' '.join(cmd_list)}..."])
                 self.draw()
                 self.win.refresh()
 
             result = self._run_git_command(cmd_list)
-
-            if result.returncode == 0:
-                self._handle_successful_command(result, cmd_list)
-            else:
-                self._handle_command_error(result, cmd_list)
+            self._render_command_result(result)
 
             # Refresh git info and reset scroll
-            self.editor.git.update_git_info()
+            if result.error != "not_repo":
+                self.editor.git.update_git_info(force=True)
             self.scroll_offset = 0
 
         except Exception as e:
             logger.error(f"GitPanel: Command execution failed: {e}")
-            self.output_lines = [f"Command execution failed: {str(e)}"]
-            self.editor._set_status_message("Git command execution failed.")
+            self._set_output_lines([f"Command execution failed: {str(e)}"])
         finally:
             self.is_busy = False
             self._update_status_help()
@@ -2602,6 +2645,19 @@ class GitPanel(BasePanel):
     def _draw_info_section(self) -> None:
         """Draws the repository info section."""
         branch, user, commits = self.git_bridge.info
+        repo_state = getattr(self.git_bridge, "repo_state", "unavailable")
+        if repo_state in {"not repo", "unavailable"} and not branch:
+            status_text = (
+                "● Not a Git repository"
+                if repo_state == "not repo"
+                else "● Git unavailable"
+            )
+            self.win.addnstr(1, 2, status_text, self.width - 4, self.attr_dim)
+            info_str = "Branch: - | User: - | Commits: 0"
+            self.win.addnstr(2, 2, info_str, self.width - 4, self.attr_branch)
+            self.win.hline(3, 1, curses.ACS_HLINE, self.width - 2, self.attr_border)
+            return
+
         clean_branch = branch.strip("*")
         has_changes = "*" in branch
 
@@ -2706,10 +2762,11 @@ class GitPanel(BasePanel):
     # --- Action Handlers ---
     def _handle_status(self, run_async=True) -> None:
         # Status can be called both synchronously (in the background) and asynchronously (by pressing 'r')
+        command = ["git", "status", "--short", "--branch"]
         if run_async:
-            self._run_command_async(["git", "status", "-s"])
+            self._run_command_async(command)
         else:
-            self._run_command_sync(["git", "status", "-s"])
+            self._run_command_sync(command)
 
     def _handle_diff(self) -> None:
         """Runs `git diff` and displays the output."""
@@ -2758,7 +2815,7 @@ class GitPanel(BasePanel):
             "Branch: <new_name> | del <name> | (empty to cancel)"
         )
         if not user_input:
-            self.output_lines.append("\nOperation cancelled.")
+            self._set_output_lines(["Operation cancelled."])
             return
 
         parts = user_input.strip().split()
@@ -2869,7 +2926,7 @@ class GitPanel(BasePanel):
             "Remote: add <name> <url> | remove <name> | (empty to cancel)"
         )
         if not action:
-            self.output_lines.append("\nOperation cancelled.")
+            self._set_output_lines(["Operation cancelled."])
             return
 
         try:

--- a/src/ecli/utils/logging_config.py
+++ b/src/ecli/utils/logging_config.py
@@ -20,12 +20,12 @@ application-wide logging handlers and log levels based on a supplied configurati
 
 Features:
     - Rotating file logging for general application events (editor.log).
-    - Optional console logging to stderr with configurable log level.
+    - Runtime logging is file-backed; curses sessions do not attach console handlers.
     - Optional separate error log file (error.log) for ERROR and CRITICAL events.
     - Optional key event tracing (keytrace.log) enabled via the MOOPS2_KEYTRACE environment variable.
     - Automatic creation of log directories, with fallback to the system temp directory on failure.
     - Safe reconfiguration: clears existing handlers to avoid duplicate logs when called multiple times.
-    - Never raises exceptions; all errors are reported to stderr and logging continues with best-effort.
+    - Never raises exceptions; setup-time failures use explicit stderr fallback before curses takes ownership.
 
 Usage:
     Import the module and call `setup_logging()` early in your application's startup sequence,
@@ -49,6 +49,7 @@ import logging.handlers
 import os
 import sys
 import tempfile
+from types import TracebackType
 from typing import Any, Optional
 
 
@@ -59,12 +60,65 @@ logger = logging.getLogger("ecli")  # main application logger
 KEY_LOGGER = logging.getLogger("ecli.keyevents")  # raw key-press trace
 
 
+def log_exception_to_file_handlers(
+    message: str,
+    exc: BaseException,
+    *,
+    logger_name: str = "ecli",
+) -> None:
+    """Log an exception through file-backed handlers without writing to stderr."""
+    root_logger = logging.getLogger()
+    exc_info: tuple[type[BaseException], BaseException, TracebackType | None] = (
+        type(exc),
+        exc,
+        exc.__traceback__,
+    )
+    record = root_logger.makeRecord(
+        logger_name,
+        logging.ERROR,
+        __file__,
+        0,
+        message,
+        (),
+        exc_info,
+        None,
+    )
+
+    for handler in root_logger.handlers:
+        if isinstance(handler, logging.FileHandler) and record.levelno >= handler.level:
+            handler.handle(record)
+
+
+def log_record_to_file_handlers(
+    level: int,
+    message: str,
+    *args: Any,
+    logger_name: str = "ecli",
+) -> None:
+    """Log a non-exception record through file-backed handlers only."""
+    root_logger = logging.getLogger()
+    record = root_logger.makeRecord(
+        logger_name,
+        level,
+        __file__,
+        0,
+        message,
+        args,
+        None,
+        None,
+    )
+
+    for handler in root_logger.handlers:
+        if isinstance(handler, logging.FileHandler) and record.levelno >= handler.level:
+            handler.handle(record)
+
+
 # --- Enhanced Logging Setup Function ---
 def setup_logging(config: Optional[dict[str, Any]] = None) -> None:
     """Configures application-wide logging handlers and log levels.
 
     This function sets up a flexible logging system with support for file logging,
-    console logging, error-only file logging, and optional key event tracing.
+    error-only file logging, and optional key event tracing.
     It clears existing root logger handlers to avoid duplicate logs and applies
     settings from the provided configuration dictionary.
 
@@ -73,8 +127,8 @@ def setup_logging(config: Optional[dict[str, Any]] = None) -> None:
 
     1. File handler – rotating editor.log capturing everything from
        the configured `file_level` (default DEBUG) upward.
-    2. Console handler – optional `stderr` output whose threshold is
-       `console_level` (default WARNING).
+    2. Console handler – intentionally disabled for runtime logging so log
+       records cannot corrupt the curses screen.
     3. Error-file handler – optional rotating error.log that stores
        only ERROR and CRITICAL events.
     4. Key-event handler – optional rotating keytrace.log enabled
@@ -92,10 +146,10 @@ def setup_logging(config: Optional[dict[str, Any]] = None) -> None:
 
             - ``file_level`` (str): Log-level for editor.log
               (DEBUG, INFO, …).  Default: ``"DEBUG"``.
-            - ``console_level`` (str): Log-level for console output.
-              Default: ``"WARNING"``.
-            - ``log_to_console`` (bool): Disable/enable console handler.
-              Default: ``True``.
+            - ``console_level`` (str): Retained for configuration
+              compatibility; runtime console logging is disabled.
+            - ``log_to_console`` (bool): Retained for configuration
+              compatibility; runtime console logging is disabled.
             - ``separate_error_log`` (bool): Whether to create error.log.
               Default: ``False``.
 
@@ -107,9 +161,9 @@ def setup_logging(config: Optional[dict[str, Any]] = None) -> None:
           propagate and attaches/clears its handlers independently.
 
     Notes:
-        The function never raises; all I/O or permission errors are
-        reported to stderr and the logging subsystem continues with a
-        best-effort configuration.
+        The function never raises; setup-time I/O or permission errors use
+        explicit stderr fallback before curses starts, and the logging subsystem
+        continues with a best-effort configuration.
 
     Example:
         >>> config = {
@@ -158,8 +212,9 @@ def setup_logging(config: Optional[dict[str, Any]] = None) -> None:
             file=sys.stderr,
         )
 
-    # Console Handler
-    log_to_console_enabled = logging_config.get("log_to_console", True)
+    # Console logging is unsafe once curses owns the terminal. Startup failures
+    # that must be visible use explicit stderr printing in __main__.py instead.
+    log_to_console_enabled = False
     console_handler = None
     if log_to_console_enabled:
         console_level_str = logging_config.get("console_level", "WARNING").upper()
@@ -206,6 +261,11 @@ def setup_logging(config: Optional[dict[str, Any]] = None) -> None:
         root_logger.addHandler(console_handler)
     if error_file_handler:
         root_logger.addHandler(error_file_handler)
+    if not root_logger.handlers:
+        # Prevent logging.lastResort from writing warnings/errors to stderr if
+        # file logging could not be initialized. Setup-time stderr diagnostics
+        # above are intentional; runtime logging records must stay off curses.
+        root_logger.addHandler(logging.NullHandler())
 
     root_logger.setLevel(
         log_file_level

--- a/tests/packaging/test_runtime_import_contract.py
+++ b/tests/packaging/test_runtime_import_contract.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/packaging/test_runtime_import_contract.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Runtime import guards for PyInstaller-packaged Linux artifacts."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import site
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IMPORT_GUARD_PATH = REPO_ROOT / "scripts" / "check_runtime_imports.py"
+
+spec = importlib.util.spec_from_file_location(
+    "check_runtime_imports", IMPORT_GUARD_PATH
+)
+assert spec is not None
+check_runtime_imports = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(check_runtime_imports)
+
+
+@pytest.fixture()
+def isolated_runtime_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    source_root = tmp_path / "src" / "ecli"
+    source_root.mkdir(parents=True)
+    monkeypatch.setattr(check_runtime_imports, "SOURCE_ROOT", source_root)
+    return source_root
+
+
+def _write_runtime_module(source_root: Path, source: str) -> None:
+    (source_root / "module.py").write_text(source, encoding="utf-8")
+
+
+def _guard_result(source_root: Path, source: str) -> int:
+    _write_runtime_module(source_root, source)
+    return check_runtime_imports.main()
+
+
+def _python_env(tmp_path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    python_paths = [str(REPO_ROOT / "src")]
+    existing_pythonpath = env.get("PYTHONPATH")
+    if existing_pythonpath:
+        python_paths.append(existing_pythonpath)
+    user_site = site.getusersitepackages()
+    if user_site:
+        python_paths.append(user_site)
+    env["HOME"] = str(tmp_path / "home")
+    env["PYTHONPATH"] = os.pathsep.join(python_paths)
+    return env
+
+
+def test_runtime_modules_import_when_unittest_is_unavailable(tmp_path: Path) -> None:
+    script = """
+import importlib
+import importlib.abc
+import sys
+
+for name in tuple(sys.modules):
+    if name == "unittest" or name.startswith("unittest."):
+        del sys.modules[name]
+
+class BlockUnittest(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "unittest" or fullname.startswith("unittest."):
+            raise ModuleNotFoundError("No module named 'unittest'")
+        return None
+
+sys.meta_path.insert(0, BlockUnittest())
+
+for module_name in (
+    "ecli.__main__",
+    "ecli.core.Ecli",
+    "ecli.ui.KeyBinder",
+    "ecli.ui.PanelManager",
+    "ecli.ui.DrawScreen",
+):
+    importlib.import_module(module_name)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=_python_env(tmp_path),
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_production_source_does_not_import_test_only_modules() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/check_runtime_imports.py"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "import unittest\n",
+        "from unittest.mock import Mock\n",
+        "import pytest\n",
+    ),
+)
+def test_production_test_only_imports_fail(
+    isolated_runtime_source: Path,
+    source: str,
+) -> None:
+    assert _guard_result(isolated_runtime_source, source) == 1
+
+
+def test_test_files_may_import_test_only_modules(
+    isolated_runtime_source: Path,
+    tmp_path: Path,
+) -> None:
+    _write_runtime_module(isolated_runtime_source, "VALUE = 1\n")
+    test_root = tmp_path / "tests"
+    test_root.mkdir()
+    (test_root / "test_allowed_imports.py").write_text(
+        "import unittest\nimport pytest\n",
+        encoding="utf-8",
+    )
+
+    assert check_runtime_imports.main() == 0
+
+
+def test_comments_and_strings_do_not_trigger_import_guard(
+    isolated_runtime_source: Path,
+) -> None:
+    source = """
+# import unittest
+TEXT = "from unittest.mock import Mock"
+LATEST = "latest contest"
+"""
+    assert _guard_result(isolated_runtime_source, source) == 0
+
+
+def test_global_help_and_version_do_not_start_curses_or_log_critical(
+    tmp_path: Path,
+) -> None:
+    env = _python_env(tmp_path)
+    for argument in ("--help", "--version"):
+        result = subprocess.run(
+            [sys.executable, "-m", "ecli", argument],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=20,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip()
+
+    log_path = Path(env["HOME"]) / ".config" / "ecli" / "logs" / "editor.log"
+    if log_path.exists():
+        assert "CRITICAL" not in log_path.read_text(encoding="utf-8")
+
+
+def test_runtime_validator_enforces_current_release_directory() -> None:
+    script = (REPO_ROOT / "scripts" / "verify_runtime.sh").read_text(encoding="utf-8")
+
+    assert "releases/${VERSION}" in script
+    assert "Artifact is outside current project version directory" in script
+
+
+def test_runtime_validator_checks_exact_version_and_startup_logs() -> None:
+    script = (REPO_ROOT / "scripts" / "verify_runtime.sh").read_text(encoding="utf-8")
+
+    assert 'EXPECTED_VERSION_OUTPUT="ecli ${VERSION}"' in script
+    assert "ModuleNotFoundError" in script
+    assert "No module named 'unittest'" in script
+    assert "Failed to import a critical application component" in script

--- a/tests/test_version_resolution.py
+++ b/tests/test_version_resolution.py
@@ -103,9 +103,24 @@ def test_resolve_version_falls_back_to_installed_package_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(ecli, "_source_tree_version", lambda: None)
+    monkeypatch.setattr(ecli, "_bundled_version", lambda: None)
     monkeypatch.setattr(ecli, "_installed_package_version", lambda: "1.2.3")
 
     assert ecli._resolve_version() == "1.2.3"
+
+
+def test_resolve_version_uses_pyinstaller_bundle_metadata(
+    version_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (version_workspace / "pyproject.toml").write_text(
+        '[project]\nversion = "7.6.5"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ecli, "_source_tree_version", lambda: None)
+    monkeypatch.setattr(ecli.sys, "_MEIPASS", str(version_workspace), raising=False)
+
+    assert ecli._resolve_version() == "7.6.5"
 
 
 def test_installed_package_version_returns_none_when_metadata_is_missing(
@@ -123,6 +138,7 @@ def test_resolve_version_falls_back_to_local_when_metadata_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(ecli, "_source_tree_version", lambda: None)
+    monkeypatch.setattr(ecli, "_bundled_version", lambda: None)
     monkeypatch.setattr(ecli, "_installed_package_version", lambda: None)
 
     assert ecli._resolve_version() == "0.0.0+local"

--- a/tests/ui/test_git_panel.py
+++ b/tests/ui/test_git_panel.py
@@ -1,0 +1,458 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/ui/test_git_panel.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Git panel command execution and repository-state tests."""
+
+from __future__ import annotations
+
+import curses
+import queue
+import shutil
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ecli.integrations.GitBridge import GitBridge, GitCommandResult
+from ecli.ui.panels import GitPanel
+
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+
+
+class FakeWindow:
+    def __init__(self) -> None:
+        """Initialize a fake curses window."""
+        self.keypad_values: list[bool] = []
+        self.drawn: list[str] = []
+
+    def getmaxyx(self) -> tuple[int, int]:
+        return (30, 120)
+
+    def keypad(self, value: bool) -> None:
+        self.keypad_values.append(value)
+
+    def erase(self) -> None:
+        return None
+
+    def border(self) -> None:
+        return None
+
+    def attron(self, attr: int) -> None:
+        return None
+
+    def attroff(self, attr: int) -> None:
+        return None
+
+    def addstr(self, *_args: Any) -> None:
+        return None
+
+    def addnstr(self, *_args: Any) -> None:
+        if len(_args) >= 3:
+            self.drawn.append(str(_args[2]))
+
+    def hline(self, *_args: Any) -> None:
+        return None
+
+    def vline(self, *_args: Any) -> None:
+        return None
+
+    def noutrefresh(self) -> None:
+        return None
+
+    def refresh(self) -> None:
+        return None
+
+
+class FakePanelManager:
+    active_panel: Any = None
+
+    def close_active_panel(self) -> None:
+        return None
+
+
+class FakeEditor:
+    def __init__(self, filename: Path | None = None) -> None:
+        """Initialize a Git panel compatible editor double."""
+        self.stdscr = FakeWindow()
+        self.focus = "panel"
+        self._force_full_redraw = False
+        self.colors = {
+            "status": curses.A_BOLD,
+            "keyword": curses.A_BOLD,
+            "default": curses.A_NORMAL,
+            "comment": curses.A_DIM,
+            "function": curses.A_BOLD,
+            "error": curses.A_BOLD,
+            "git_dirty": curses.A_BOLD,
+            "git_added": curses.A_NORMAL,
+            "git_deleted": curses.A_NORMAL,
+            "number": curses.A_NORMAL,
+        }
+        self.config: dict[str, Any] = {"git": {"enabled": True}}
+        self.status_messages: list[str] = []
+        self.filename = str(filename) if filename is not None else None
+        self._state_lock = threading.RLock()
+        self._git_q: queue.Queue[tuple[str, str, str]] = queue.Queue()
+        self._git_cmd_q: queue.Queue[str] = queue.Queue()
+        self.panel_manager = FakePanelManager()
+        self.git = GitBridge(self)  # type: ignore[arg-type]
+
+    def _set_status_message(self, message: str) -> None:
+        self.status_messages.append(message)
+
+    def prompt(self, *_args: Any, **_kwargs: Any) -> str:
+        return ""
+
+    def toggle_focus(self) -> None:
+        self.focus = "editor" if self.focus == "panel" else "panel"
+
+
+@pytest.fixture(autouse=True)
+def fake_curses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("ecli.ui.panels.curses.newwin", lambda *args: FakeWindow())
+    monkeypatch.setattr("ecli.ui.panels.curses.curs_set", lambda value: None)
+    monkeypatch.setattr("ecli.ui.panels.curses.init_pair", lambda *args: None)
+    monkeypatch.setattr("ecli.ui.panels.curses.color_pair", lambda pair: pair)
+
+
+def git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+def init_repo(path: Path, *, commit: bool = True) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    git(path, "init")
+    git(path, "config", "user.name", "ECLI Tests")
+    git(path, "config", "user.email", "ecli-tests@example.invalid")
+    tracked = path / "tracked.txt"
+    tracked.write_text("hello\n", encoding="utf-8")
+    if commit:
+        git(path, "add", "tracked.txt")
+        git(path, "commit", "-m", "initial")
+    return tracked
+
+
+def make_panel(filename: Path | None = None) -> tuple[FakeEditor, GitPanel]:
+    editor = FakeEditor(filename)
+    panel = GitPanel(editor.stdscr, editor)  # type: ignore[arg-type]
+    editor.panel_manager.active_panel = panel
+    panel.visible = True
+    return editor, panel
+
+
+def wait_for_panel(panel: GitPanel, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        panel.process_queues()
+        if not panel.is_busy:
+            return
+        time.sleep(0.02)
+    pytest.fail(f"Git panel remained busy with output: {panel.output_lines!r}")
+
+
+def test_status_command_returns_output_and_clears_busy(tmp_path: Path) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    (tracked.parent / "new.txt").write_text("new\n", encoding="utf-8")
+    _editor, panel = make_panel(tracked)
+
+    panel._handle_status()
+    assert panel.output_lines == ["Running: git status --short --branch..."]
+    wait_for_panel(panel)
+
+    output = "\n".join(panel.output_lines)
+    assert "Running:" not in output
+    assert "##" in output
+    assert "new.txt" in output
+    assert panel.is_busy is False
+
+
+def test_status_command_clean_repo_does_not_stay_running(tmp_path: Path) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    _editor, panel = make_panel(tracked)
+
+    panel._handle_status()
+    wait_for_panel(panel)
+
+    output = "\n".join(panel.output_lines)
+    assert "Running:" not in output
+    assert output == "Clean working tree." or "##" in output
+    assert panel.is_busy is False
+
+
+def test_status_command_non_git_directory_reports_not_repo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "not-repo" / "file.txt"
+    target.parent.mkdir()
+    target.write_text("hello\n", encoding="utf-8")
+    monkeypatch.chdir(target.parent)
+    _editor, panel = make_panel(target)
+
+    panel._handle_status()
+    wait_for_panel(panel)
+
+    assert panel.output_lines == ["Not a Git repository."]
+    assert panel.is_busy is False
+    assert panel.git_bridge.repo_state == "not repo"
+
+
+def test_failing_cwd_renders_error_and_clears_busy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    _editor, panel = make_panel(tracked)
+    missing = tmp_path / "missing"
+    monkeypatch.setattr(
+        panel.git_bridge, "resolve_repo_root", lambda _ctx=None: str(missing)
+    )
+
+    panel._run_command_sync(["git", "status", "--short", "--branch"])
+
+    output = "\n".join(panel.output_lines)
+    assert "Command failed: git status --short --branch" in output
+    assert "Return code: 127" in output
+    assert panel.is_busy is False
+
+
+def test_timeout_renders_message_and_clears_busy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    _editor, panel = make_panel(tracked)
+
+    def timed_out(*_args: Any, **_kwargs: Any) -> GitCommandResult:
+        return GitCommandResult(
+            command_label="git status --short --branch",
+            cwd=str(tracked.parent),
+            returncode=-15,
+            stdout="",
+            stderr="",
+            timed_out=True,
+            error="Command timed out after 15s.",
+        )
+
+    monkeypatch.setattr(panel.git_bridge, "run_git_command", timed_out)
+    panel._run_command_sync(["git", "status", "--short", "--branch"])
+
+    output = "\n".join(panel.output_lines)
+    assert "Command timed out: git status --short --branch" in output
+    assert panel.is_busy is False
+
+
+def test_async_worker_only_enqueues_result_until_ui_thread_consumes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    editor, panel = make_panel(tracked)
+
+    def completed(*_args: Any, **_kwargs: Any) -> GitCommandResult:
+        return GitCommandResult(
+            command_label="git status --short --branch",
+            cwd=str(tracked.parent),
+            returncode=0,
+            stdout="## main\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(panel, "_run_git_command", completed)
+
+    panel._handle_status()
+    editor._force_full_redraw = False
+
+    deadline = time.monotonic() + 5.0
+    while panel.command_results.empty() and time.monotonic() < deadline:
+        time.sleep(0.02)
+
+    assert not panel.command_results.empty()
+    assert panel.output_lines == ["Running: git status --short --branch..."]
+    assert panel.is_busy is True
+    assert editor._force_full_redraw is False
+
+    assert panel.process_queues() is True
+    assert panel.output_lines == ["## main"]
+    assert panel.is_busy is False
+    assert editor._force_full_redraw is True
+
+
+def test_stale_worker_result_after_cancel_is_ignored(tmp_path: Path) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    _editor, panel = make_panel(tracked)
+    stale_generation = panel._command_generation + 1
+    panel._command_generation = stale_generation
+    panel.is_busy = True
+    panel.output_lines = ["Running: git status --short --branch..."]
+
+    assert panel.handle_key(27) is True
+    assert panel.output_lines == ["Operation cancelled."]
+
+    panel.command_results.put(
+        (
+            stale_generation,
+            GitCommandResult(
+                command_label="git status --short --branch",
+                cwd=str(tracked.parent),
+                returncode=0,
+                stdout="## stale\n",
+                stderr="",
+            ),
+        )
+    )
+
+    assert panel.process_queues() is True
+    assert panel.output_lines == ["Operation cancelled."]
+    assert panel.is_busy is False
+
+
+def test_nonzero_exit_renders_stderr_and_clears_busy(tmp_path: Path) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    _editor, panel = make_panel(tracked)
+
+    panel._run_command_sync(["git", "rev-parse", "--verify", "missing-ref"])
+
+    output = "\n".join(panel.output_lines)
+    assert "Command failed: git rev-parse --verify missing-ref" in output
+    assert "Return code: 128" in output
+    assert "stderr:" in output
+    assert panel.is_busy is False
+
+
+def test_operation_cancelled_is_panel_local(tmp_path: Path) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    editor, panel = make_panel(tracked)
+    editor.status_messages.clear()
+    panel.is_busy = True
+
+    assert panel.handle_key(27) is True
+
+    assert panel.output_lines == ["Operation cancelled."]
+    assert panel.is_busy is False
+    assert editor.status_messages
+    assert all(message != "Operation cancelled." for message in editor.status_messages)
+
+
+def test_header_fields_are_populated_for_repo(tmp_path: Path) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    editor, _panel = make_panel(tracked)
+
+    branch, user, commits = editor.git.get_info(str(tracked))
+
+    assert branch.strip("*")
+    assert user == "ECLI Tests"
+    assert commits == "1"
+    assert editor.git.repo_state in {"clean", "dirty"}
+
+
+def test_empty_repo_has_zero_commits_and_no_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(tmp_path / "no-global-gitconfig"))
+    repo = tmp_path / "empty"
+    repo.mkdir()
+    git(repo, "init")
+    editor, _panel = make_panel(repo / "new.txt")
+
+    branch, user, commits = editor.git.get_info(str(repo / "new.txt"))
+
+    assert branch.strip("*")
+    assert user == "not configured"
+    assert commits == "0"
+
+
+def test_commands_use_repo_root_when_root_opened_directly(tmp_path: Path) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    editor, _panel = make_panel(tracked.parent)
+
+    result = editor.git.run_git_command(
+        ["git", "rev-parse", "--show-toplevel"],
+        file_path_context=str(tracked.parent),
+    )
+
+    assert result.returncode == 0
+    assert Path(result.cwd).resolve() == tracked.parent.resolve()
+    assert Path(result.stdout.strip()).resolve() == tracked.parent.resolve()
+
+
+def test_commands_use_repo_root_for_file_in_subdirectory(tmp_path: Path) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    nested = tracked.parent / "subdir" / "nested.txt"
+    nested.parent.mkdir()
+    nested.write_text("nested\n", encoding="utf-8")
+    editor, _panel = make_panel(nested)
+
+    result = editor.git.run_git_command(
+        ["git", "rev-parse", "--show-toplevel"],
+        file_path_context=str(nested),
+    )
+
+    assert result.returncode == 0
+    assert Path(result.cwd).resolve() == tracked.parent.resolve()
+    assert Path(result.stdout.strip()).resolve() == tracked.parent.resolve()
+
+
+def test_commands_use_repo_root_when_launched_outside_repo_with_relative_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracked = init_repo(tmp_path / "repo")
+    nested = tracked.parent / "subdir" / "nested.txt"
+    nested.parent.mkdir()
+    nested.write_text("nested\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.chdir(tmp_path)
+    relative_file = Path("repo") / "subdir" / "nested.txt"
+    editor, _panel = make_panel(relative_file)
+
+    result = editor.git.run_git_command(
+        ["git", "rev-parse", "--show-toplevel"],
+        file_path_context=str(relative_file),
+    )
+
+    assert result.returncode == 0
+    assert Path(result.cwd).resolve() == tracked.parent.resolve()
+    assert Path(result.stdout.strip()).resolve() == tracked.parent.resolve()
+    assert Path.cwd() != Path(result.cwd)
+
+
+def test_empty_repo_status_uses_repo_root_and_clears_busy(tmp_path: Path) -> None:
+    repo = tmp_path / "empty"
+    repo.mkdir()
+    git(repo, "init")
+    editor, panel = make_panel(repo)
+
+    result = editor.git.run_git_command(
+        ["git", "status", "--short", "--branch"],
+        file_path_context=str(repo),
+    )
+
+    assert result.returncode == 0
+    assert Path(result.cwd).resolve() == repo.resolve()
+
+    panel._run_command_sync(["git", "status", "--short", "--branch"])
+    assert "Running:" not in "\n".join(panel.output_lines)
+    assert panel.is_busy is False

--- a/tests/ui/test_input_routing.py
+++ b/tests/ui/test_input_routing.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Project: Ecli
+# File: tests/ui/test_input_routing.py
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for full license text.
+
+"""Focused tests for global shortcut routing and input error containment."""
+
+from __future__ import annotations
+
+import curses
+import io
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+from ecli.core.Ecli import Ecli
+from ecli.ui.KeyBinder import KeyBinder
+from ecli.ui.PanelManager import PanelManager
+from ecli.utils.logging_config import setup_logging
+
+
+class FakeKeyBinder:
+    def __init__(self) -> None:
+        """Initialize action bindings used by dispatch tests."""
+        self.bindings = {
+            "help": {curses.KEY_F1, 265, "f1"},
+            "toggle_widget_panel": {curses.KEY_F7, 271, "f7"},
+        }
+
+    def is_key_for_action(self, key: int | str, action_name: str) -> bool:
+        return key in self.bindings.get(action_name, set())
+
+
+class FakePanelManager:
+    def __init__(self, panel_name: str) -> None:
+        """Initialize an active panel manager double."""
+        self.active_panel = type(panel_name, (), {"visible": True})()
+        self.panel_key_calls: list[int | str] = []
+        self.close_calls = 0
+
+    def is_panel_active(self) -> bool:
+        return bool(getattr(self.active_panel, "visible", False))
+
+    def handle_key(self, key: int | str) -> bool:
+        self.panel_key_calls.append(key)
+        return True
+
+    def close_active_panel(self) -> None:
+        self.close_calls += 1
+        self.active_panel.visible = False
+
+
+class DispatchEditor:
+    _handle_input_dispatch = Ecli._handle_input_dispatch
+    _is_active_panel_type = Ecli._is_active_panel_type
+    _is_file_browser_active = Ecli._is_file_browser_active
+    _close_file_browser_for_ai = Ecli._close_file_browser_for_ai
+    toggle_widget_panel = Ecli.toggle_widget_panel
+
+    def __init__(self, panel_name: str) -> None:
+        """Create a minimal editor object for dispatch routing."""
+        self.focus = "panel"
+        self.keybinder = FakeKeyBinder()
+        self.panel_manager = FakePanelManager(panel_name)
+        self.status_message = "Ready"
+        self._force_full_redraw = False
+        self.editor_key_calls: list[int | str] = []
+        self.ai_flow_calls = 0
+
+    def handle_input(self, key: int | str) -> bool:
+        if self.keybinder.is_key_for_action(key, "toggle_widget_panel"):
+            return self.toggle_widget_panel()
+        self.editor_key_calls.append(key)
+        return True
+
+    def _set_status_message(self, message: str) -> None:
+        self.status_message = message
+
+    def select_ai_provider_and_ask(self) -> bool:
+        self.ai_flow_calls += 1
+        return True
+
+
+class SelectionEditor:
+    get_selected_text = Ecli.get_selected_text
+    _get_normalized_selection_range = Ecli._get_normalized_selection_range
+
+    def __init__(
+        self,
+        *,
+        text: list[str],
+        start: tuple[int, int] | None,
+        end: tuple[int, int] | None,
+        selecting: bool = True,
+        cursor_y: int = 0,
+    ) -> None:
+        """Create a minimal editor selection state."""
+        self.text = text
+        self.selection_start = start
+        self.selection_end = end
+        self.is_selecting = selecting
+        self.cursor_y = cursor_y
+
+
+class BinderEditor:
+    def __init__(self) -> None:
+        """Create a minimal editor for KeyBinder.handle_input tests."""
+        self.status_message = "Ready"
+        self._state_lock = threading.RLock()
+        self._force_full_redraw = False
+        self.inserted: list[str] = []
+
+    def _set_status_message(self, message: str) -> None:
+        self.status_message = message
+
+    def insert_text(self, text: str) -> bool:
+        self.inserted.append(text)
+        return True
+
+
+def _replace_root_handlers(
+    log_path: Path,
+    *,
+    stream_level: int = logging.ERROR,
+) -> tuple[list[logging.Handler], int, io.StringIO]:
+    root = logging.getLogger()
+    old_handlers = root.handlers[:]
+    old_level = root.level
+    stream = io.StringIO()
+    file_handler = logging.FileHandler(log_path, encoding="utf-8")
+    file_handler.setLevel(logging.DEBUG)
+    stream_handler = logging.StreamHandler(stream)
+    stream_handler.setLevel(stream_level)
+    root.handlers = [file_handler, stream_handler]
+    root.setLevel(logging.DEBUG)
+    return old_handlers, old_level, stream
+
+
+def _restore_root_handlers(
+    old_handlers: list[logging.Handler],
+    old_level: int,
+) -> None:
+    root = logging.getLogger()
+    for handler in root.handlers:
+        handler.close()
+    root.handlers = old_handlers
+    root.setLevel(old_level)
+
+
+def test_f1_routes_to_help_before_git_panel() -> None:
+    editor = DispatchEditor("GitPanel")
+
+    assert editor._handle_input_dispatch(curses.KEY_F1) is True
+
+    assert editor.editor_key_calls == [curses.KEY_F1]
+    assert editor.panel_manager.panel_key_calls == []
+
+
+def test_f1_routes_to_help_before_file_manager() -> None:
+    editor = DispatchEditor("FileBrowserPanel")
+
+    assert editor._handle_input_dispatch(curses.KEY_F1) is True
+
+    assert editor.editor_key_calls == [curses.KEY_F1]
+    assert editor.panel_manager.panel_key_calls == []
+
+
+def test_f1_routes_to_help_before_ai_panel() -> None:
+    editor = DispatchEditor("AiResponsePanel")
+
+    assert editor._handle_input_dispatch(curses.KEY_F1) is True
+
+    assert editor.editor_key_calls == [curses.KEY_F1]
+    assert editor.panel_manager.panel_key_calls == []
+
+
+def test_f7_while_file_manager_active_closes_file_manager_and_starts_ai() -> None:
+    editor = DispatchEditor("FileBrowserPanel")
+
+    assert editor._handle_input_dispatch(curses.KEY_F7) is True
+
+    assert editor.ai_flow_calls == 1
+    assert editor.panel_manager.close_calls == 1
+    assert editor.panel_manager.is_panel_active() is False
+    assert editor.focus == "editor"
+    assert editor.editor_key_calls == []
+    assert editor.panel_manager.panel_key_calls == []
+
+
+def test_f7_while_file_manager_open_with_editor_focus_closes_and_starts_ai() -> None:
+    editor = DispatchEditor("FileBrowserPanel")
+    editor.focus = "editor"
+
+    assert editor._handle_input_dispatch(curses.KEY_F7) is True
+
+    assert editor.ai_flow_calls == 1
+    assert editor.panel_manager.close_calls == 1
+    assert editor.panel_manager.is_panel_active() is False
+    assert editor.focus == "editor"
+
+
+def test_f7_while_non_file_panel_active_is_global_but_conservative() -> None:
+    editor = DispatchEditor("GitPanel")
+
+    assert editor._handle_input_dispatch(curses.KEY_F7) is True
+
+    assert editor.ai_flow_calls == 0
+    assert editor.panel_manager.close_calls == 0
+    assert editor.panel_manager.is_panel_active() is True
+    assert editor.panel_manager.panel_key_calls == []
+    assert (
+        editor.status_message
+        == "AI Code Assistant is available from the editor. Close active panel first."
+    )
+
+
+def test_get_selected_text_empty_buffer_returns_empty_string() -> None:
+    editor = SelectionEditor(text=[], start=(0, 0), end=(0, 1))
+
+    assert editor.get_selected_text() == ""
+
+
+def test_get_selected_text_cursor_row_out_of_range_does_not_raise() -> None:
+    editor = SelectionEditor(
+        text=["alpha"],
+        start=None,
+        end=None,
+        selecting=False,
+        cursor_y=99,
+    )
+
+    assert editor.get_selected_text() == ""
+
+
+def test_get_selected_text_selection_row_out_of_range_returns_empty() -> None:
+    editor = SelectionEditor(text=["alpha"], start=(0, 0), end=(9, 1))
+
+    assert editor.get_selected_text() == ""
+
+
+def test_get_selected_text_invalid_bounds_do_not_emit_console_warning(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "editor.log"
+    old_handlers, old_level, stream = _replace_root_handlers(
+        log_path,
+        stream_level=logging.WARNING,
+    )
+    try:
+        editor = SelectionEditor(text=["alpha"], start=(0, 0), end=(1, 1))
+
+        assert editor.get_selected_text() == ""
+
+        for handler in logging.getLogger().handlers:
+            handler.flush()
+        assert stream.getvalue() == ""
+        assert "get_selected_text: selection rows out of bounds" in log_path.read_text(
+            encoding="utf-8"
+        )
+    finally:
+        _restore_root_handlers(old_handlers, old_level)
+
+
+def test_get_selected_text_reversed_selection_returns_text() -> None:
+    editor = SelectionEditor(text=["abcdef"], start=(0, 4), end=(0, 1))
+
+    assert editor.get_selected_text() == "bcd"
+
+
+def test_get_selected_text_single_line_selection_returns_text() -> None:
+    editor = SelectionEditor(text=["abcdef"], start=(0, 1), end=(0, 4))
+
+    assert editor.get_selected_text() == "bcd"
+
+
+def test_get_selected_text_multi_line_selection_returns_text() -> None:
+    editor = SelectionEditor(
+        text=["alpha", "bravo", "charlie"],
+        start=(0, 2),
+        end=(2, 3),
+    )
+
+    assert editor.get_selected_text() == "pha\nbravo\ncha"
+
+
+def test_keybinder_action_exception_is_file_logged_without_console_traceback(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "editor.log"
+    old_handlers, old_level, stream = _replace_root_handlers(log_path)
+    try:
+        editor = BinderEditor()
+        binder = KeyBinder.__new__(KeyBinder)
+        binder.editor = editor
+        binder.action_map = {"boom": _raise_input_error}
+        binder.keybindings = {}
+
+        assert binder.handle_input("boom") is True
+
+        for handler in logging.getLogger().handlers:
+            handler.flush()
+        log_text = log_path.read_text(encoding="utf-8")
+        assert "Input handler critical error" in log_text
+        assert "RuntimeError: synthetic input failure" in log_text
+        assert stream.getvalue() == ""
+        assert editor.status_message == "Input handler error. See logs."
+        assert editor._force_full_redraw is True
+    finally:
+        _restore_root_handlers(old_handlers, old_level)
+
+
+def test_panel_key_exception_is_file_logged_without_console_traceback(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "editor.log"
+    old_handlers, old_level, stream = _replace_root_handlers(log_path)
+    try:
+        editor = BinderEditor()
+        manager = PanelManager.__new__(PanelManager)
+        manager.editor = editor
+        manager.active_panel = CrashPanel()
+
+        assert manager.handle_key("x") is True
+
+        for handler in logging.getLogger().handlers:
+            handler.flush()
+        log_text = log_path.read_text(encoding="utf-8")
+        assert "Panel key-handler crashed" in log_text
+        assert "RuntimeError: synthetic panel failure" in log_text
+        assert stream.getvalue() == ""
+        assert editor.status_message == "Input handler error. See logs."
+        assert editor._force_full_redraw is True
+    finally:
+        _restore_root_handlers(old_handlers, old_level)
+
+
+def test_setup_logging_uses_file_handlers_only_for_runtime_logging(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    root = logging.getLogger()
+    old_handlers = root.handlers[:]
+    old_level = root.level
+    try:
+        setup_logging({"logging": {"log_to_console": True, "file_level": "DEBUG"}})
+
+        assert any(
+            isinstance(handler, logging.FileHandler) for handler in root.handlers
+        )
+        assert all(
+            isinstance(handler, logging.FileHandler) for handler in root.handlers
+        )
+    finally:
+        for handler in root.handlers:
+            handler.close()
+        root.handlers = old_handlers
+        root.setLevel(old_level)
+
+
+def _raise_input_error() -> bool:
+    raise RuntimeError("synthetic input failure")
+
+
+class CrashPanel:
+    visible = True
+
+    def handle_key(self, _key: Any) -> bool:
+        raise RuntimeError("synthetic panel failure")


### PR DESCRIPTION
## Summary

Prepares the ECLI v0.2.2 bugfix release.

Fixed:
- packaged/frozen runtime startup failure caused by test-only unittest/mock dependency leaking into production runtime
- packaged `ecli --help` and `ecli --version` smoke behavior
- cross-package runtime/import validation
- Git Panel command result delivery, BUSY state reset, repo detection, and output rendering
- global F1 Help routing across active panels
- F7 AI Code Assistant behavior when File Manager is open
- unsafe selection bounds handling in AI flow
- curses UI corruption caused by runtime warnings/tracebacks printed to terminal
- release tooling declaration for twine/build validation

## Verification

- pytest -q
- ruff check src tests scripts/check_runtime_imports.py
- ruff format --check src tests scripts/check_runtime_imports.py
- make PYTHON=python3 validate-gate2
- ./dist/ecli --version
- ./scripts/verify_runtime.sh --allow-nonrelease dist/ecli
- manual visual smoke: Git Panel, File Manager, F1 Help, F7 AI flow