### PR TITLE
chore: add SPDX Apache-2.0 header to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+
+Project: Ecli
+File: CHANGELOG.md
+Website: https://www.ecli.io
+Repository: https://github.com/SSobol77/ecli
+PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+
+Copyright (c) 2026 Siergej Sobolewski
+
+Licensed under the Apache License, Version 2.0.
+See the LICENSE file in the project root for full license text.
+-->
+
 # Changelog
 
 ## 0.2.2 - Packaged Runtime Startup Fixes


### PR DESCRIPTION
## Summary

Completes the Apache-2.0 license metadata normalization (residual file).

`CHANGELOG.md` was the only project-owned file remaining without an SPDX header after the bulk normalization tracked in #39.

## Changes

- Added Apache-2.0 SPDX header block to `CHANGELOG.md` (HTML comment, placed before first heading).

## Out of scope (intentionally skipped)

- `packaging/linux/appimage/AppDirpackaging/**` — generated AppImage staging, gitignored at `.gitignore:188`
- `logs/**` — project logs (per `.gitignore` invariant)
- `.pytest_cache/**` — test cache
- `ecli_github_backlog_bundle_v4_19_clean/**` — local-only bundle, gitignored at `.gitignore:215-217`

## Validation performed locally

| Check | Result |
|---|---|
| TOML parse (`pyproject.toml`, `config.toml`) | OK |
| MIT references in source | 0 hits |
| SPDX header file count | 252 → 253 |
| `python3 -m compileall src main.py` | clean |
| Markdown structure | preserved |

## Risk

Zero. No source code, no build scripts, no CI workflows touched. Only documentation metadata added.

## Related

- Completes the residual scope of #39 (`chore: normalize Apache-2.0 license metadata across repository`)