### PR TITLE
Add optional Taskfile command surface

### DIFF
--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -74,6 +74,11 @@ make test
 make lint
 ```
 
+`task help` and other Taskfile commands may be used only as optional developer
+convenience wrappers when they delegate to existing Makefile targets. Makefile
+remains the authoritative build/release contract; do not replace Makefile
+validation, packaging, or release behavior with Taskfile-only commands.
+
 Packaging script-migration and log-invariant checks (read-only, non-publishing):
 
 ```sh

--- a/.codex/prompts/validate.md
+++ b/.codex/prompts/validate.md
@@ -63,6 +63,11 @@ For mypy, highlight P0-related errors separately, especially History.py. For pyt
 
 Do not run git commit, git push, git tag, GitHub write commands, workflow triggers, GitHub release commands, release targets, publish targets, artifact upload commands, twine upload, uv publish, or python -m twine upload.
 
+`Taskfile.yml` is optional developer convenience only. You may use `task` only
+when it delegates to existing Makefile targets. Makefile remains the
+authoritative build/release contract, release/publish tasks must remain guarded,
+and packaging scripts must remain Python entrypoints under `scripts/*.py`.
+
 If a report file is needed, print Markdown only; the maintainer redirects stdout to the target file.
 
 Finish with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,6 +401,13 @@ without building packages, and `make sysinfo` prints configured package
 variables. Release/upload Make targets are maintainer-owned and require an
 explicit confirmation guard.
 
+`Taskfile.yml` is an optional developer convenience wrapper only. Agents may use
+`task` when it delegates to existing `make` targets, but must not replace
+Makefile targets with Taskfile-only behavior. Makefile remains the authoritative
+build/release contract; CI and release gates continue to rely on the existing
+canonical command surfaces. Release/publish tasks must remain guarded, and
+packaging scripts must remain Python entrypoints under `scripts/*.py`.
+
 Do not use bare `python` when the repository workflow expects `uv run python`.
 
 Do not use broad commands such as:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,14 @@ The orchestrator must not bypass `.claude/settings.local.json`.
 
 The orchestrator must not publish, upload, tag, push, commit, trigger release workflows, or run release/publish targets.
 
+`Taskfile.yml` is optional developer convenience only. Claude Code and its
+subagents may use `task` only when it delegates to existing Makefile targets.
+Makefile remains the authoritative build/release contract; do not replace
+Makefile targets with Taskfile-only behavior. Release/publish tasks must remain
+guarded, CI and release gates continue to rely on canonical Makefile/workflow
+surfaces, and packaging scripts must remain Python entrypoints under
+`scripts/*.py`.
+
 ## 2. Required operating model
 
 Claude Code must:

--- a/CODEX.md
+++ b/CODEX.md
@@ -162,6 +162,13 @@ The root `Makefile` is the primary Codex-inspectable command surface. Use
 `make sysinfo` for read-only discovery. Do not run maintainer-owned
 release/upload targets; they are guarded and remain outside Codex execution.
 
+`Taskfile.yml` may be used only as an optional developer convenience wrapper
+around existing Makefile targets. Codex must not introduce Taskfile-only
+build/release behavior, must not weaken release/publish guards, and must keep
+packaging scripts as Python entrypoints under `scripts/*.py`. Makefile remains
+the authoritative build/release contract; CI and release gates continue to use
+the existing canonical command surfaces.
+
 ## Rendering policy
 
 Rendering work is Stage-2-locked unless the maintainer explicitly approves a narrow Stage 1b fix.

--- a/README.md
+++ b/README.md
@@ -362,6 +362,12 @@ make run
 make help              # See all available build targets
 ```
 
+`Taskfile.yml` is available as an optional developer convenience wrapper for
+common local commands such as `task help`, `task validate`, and
+`task validate-packaging`. Makefile remains the authoritative build/release
+contract; CI and release gates continue to rely on the existing canonical
+command surfaces.
+
 ### Build System
 
 ECLI features a comprehensive multi-platform build system. For detailed information:
@@ -375,6 +381,7 @@ ECLI features a comprehensive multi-platform build system. For detailed informat
 ```bash
 # Display all available build targets
 make help
+task help              # Optional wrapper; delegates to make help
 
 # Check system capabilities and available tools
 make sysinfo
@@ -386,7 +393,7 @@ make package-macos      # macOS DMG
 make package-windows    # Windows portable EXE + installer
 make package-freebsd    # FreeBSD package
 
-# Release to GitHub (requires GitHub CLI)
+# Maintainer-owned guarded release/publish flow
 make publish-all
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: Taskfile.yml
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+version: "3"
+
+# Optional developer convenience wrapper.
+# The root Makefile remains the authoritative build/release contract.
+
+tasks:
+  help:
+    desc: Show the canonical Makefile command surface.
+    cmds:
+      - make help
+
+  install:
+    desc: Install development dependencies through the Makefile.
+    cmds:
+      - make install
+
+  run:
+    desc: Run ECLI from source through the Makefile.
+    cmds:
+      - make run
+
+  validate:
+    desc: Run the default local validation target.
+    cmds:
+      - make validate
+
+  validate-fast:
+    desc: Run fast local validation.
+    cmds:
+      - make validate-fast
+
+  validate-full:
+    desc: Run full local validation.
+    cmds:
+      - make validate-full
+
+  validate-packaging:
+    desc: Run packaging contract validation.
+    cmds:
+      - make validate-packaging
+
+  doctor:
+    desc: Inspect local tool availability.
+    cmds:
+      - make doctor
+
+  show-artifacts:
+    desc: Show built artifact summary.
+    cmds:
+      - make show-artifacts
+
+  clean:
+    desc: Remove local build and cache outputs.
+    cmds:
+      - make clean
+
+  package-pypi:
+    desc: Build PyPI wheel and source distribution through the Makefile.
+    cmds:
+      - make package-pypi
+
+  package-linux:
+    desc: Build the Linux package group through the Makefile.
+    cmds:
+      - make package-linux
+
+  package-freebsd:
+    desc: Build the native FreeBSD package through the Makefile.
+    cmds:
+      - make package-freebsd
+
+  package-macos:
+    desc: Build macOS artifacts through the Makefile.
+    cmds:
+      - make package-macos
+
+  package-windows:
+    desc: Build Windows artifacts through the Makefile.
+    cmds:
+      - make package-windows
+
+  package-nix:
+    desc: Build Nix outputs through the Makefile.
+    cmds:
+      - make package-nix
+
+  publish-pypi:
+    desc: Run the existing maintainer-owned PyPI publish guard.
+    cmds:
+      - make publish-pypi
+
+  publish-all:
+    desc: Run the existing guarded aggregate publish target.
+    cmds:
+      - make publish-all
+
+  release-linux:
+    desc: Run existing guarded Linux GitHub release upload targets.
+    cmds:
+      - make release-deb
+      - make release-rpm
+      - make release-appimage
+
+  release-freebsd:
+    desc: Run the existing guarded FreeBSD release upload target.
+    cmds:
+      - make release-freebsd
+
+  release-macos:
+    desc: Run the existing guarded macOS release upload target.
+    cmds:
+      - make release-macos
+
+  release-windows:
+    desc: Run the existing guarded Windows release upload target.
+    cmds:
+      - make release-windows
+
+  release-pypi:
+    desc: Run the existing maintainer-owned PyPI publish guard.
+    cmds:
+      - make publish-pypi

--- a/docs/contributor/development-setup.md
+++ b/docs/contributor/development-setup.md
@@ -29,6 +29,7 @@ See the LICENSE file in the project root for full license text.
 |---|---:|---|---|
 | Python 3.11+ | Yes | runtime and build scripts | all platforms |
 | `uv` | Recommended | deterministic dependency workflow | all platforms |
+| `task` | Optional | developer convenience wrapper over Makefile targets | all platforms |
 | `pipx` | Optional | convenient tool installation | all platforms |
 | `ruff` / `pytest` toolchain | Role-dependent | local validation | maintainer-focused |
 | `twine` | Release-only | PyPI artifact validation in `make validate-gate2` | install via `.[release]`, `.[dev]`, or `requirements-dev.txt` |
@@ -49,6 +50,16 @@ See the LICENSE file in the project root for full license text.
    - `uv sync`
 5. Runtime sanity:
    - `python main.py`
+
+## Command Surface
+
+Makefile remains the authoritative build/release contract. Use `make help`,
+`make help-full`, `make doctor`, and `make sysinfo` for canonical discovery.
+`Taskfile.yml` is an optional developer convenience wrapper for common commands
+such as `task help`, `task validate`, and `task validate-packaging`; it must
+delegate to existing Makefile targets and must not define Taskfile-only release
+or packaging behavior. CI and release gates continue to rely on the existing
+canonical command surfaces.
 
 ## Optional Setup by Role
 

--- a/docs/contributor/local-validation.md
+++ b/docs/contributor/local-validation.md
@@ -25,6 +25,7 @@ See the LICENSE file in the project root for full license text.
 | `make doctor` / `make sysinfo` | host/tool inspection without building packages | repository-local command | Optional | Yes |
 | `make validate` / `make validate-fast` | safe local validation entrypoint | repository-local command | Yes | Yes |
 | `make validate-packaging` / `make validate-release-contract` | packaging/release contract checks | repository-local command | Optional | Yes |
+| `task help` / `task validate-packaging` | optional developer convenience wrappers over Makefile targets | repository-local command | Optional | Optional |
 | `pytest` | tests baseline check | partial/validation-required if tests absent | Optional | Yes |
 | `uv run pytest -q tests/packaging` | canonical 21-item packaging release-contract matrix guard | repository-local static check | Optional | Yes |
 | `uv run pytest -q tests/packaging/test_scripts_python_migration_contract.py` | shell-to-Python script migration contract guard | repository-local static check | Optional | Yes |
@@ -36,6 +37,12 @@ The packaging guard enforces the `Canonical 21-Item Platform & Packaging
 Artifact Matrix` in `docs/release/artifact-contract.md`: every one of the 21
 entries must keep a `tests/packaging/` test file, a Claude command mapping, a
 Codex prompt mapping, and (where relevant) a mapped GitHub workflow.
+
+Makefile remains the authoritative build/release contract. `Taskfile.yml` is an
+optional developer convenience wrapper only; it must delegate to existing
+Makefile targets, must not become the sole release contract, and must not bypass
+guarded release or publish behavior. CI and release gates continue to rely on
+the existing canonical command surfaces.
 
 ## Minimum Validation Path (Contributor)
 

--- a/docs/release/packaging-flows.md
+++ b/docs/release/packaging-flows.md
@@ -64,6 +64,15 @@ map, `make list-targets` for public target discovery, `make doctor` for local
 tool availability, and `make sysinfo` for configured package variables.
 Maintainer-owned release/upload targets require `ECLI_ALLOW_RELEASE=1`.
 
+`Taskfile.yml` is an optional developer convenience wrapper. It may expose
+developer-friendly commands such as `task help`, `task validate-packaging`, and
+`task package-linux`, but those commands must delegate to existing Makefile
+targets. Makefile remains the authoritative build/release contract; CI and
+release gates continue to rely on Makefile, canonical Python scripts under
+`scripts/*.py`, and workflow-defined gates. Taskfile tasks must not redefine
+artifact names, bypass guarded release/publish targets, or call removed shell
+wrappers.
+
 ## Linux
 
 - DEB flow: `scripts/build_and_package_deb.py`

--- a/docs/release/release-process.md
+++ b/docs/release/release-process.md
@@ -221,3 +221,10 @@ Maintainer-owned release/upload Make targets are guarded. Set
 `ECLI_ALLOW_RELEASE=1` only when intentionally running targets such as
 `release-deb`, `release-rpm`, `release-appimage`, `release-freebsd`,
 `release-macos`, `release-windows`, or `publish-all`.
+
+`Taskfile.yml` may expose convenience tasks such as `task publish-all`,
+`task release-linux`, `task release-freebsd`, `task release-macos`,
+`task release-windows`, and `task release-pypi`, but those tasks must only wrap
+the existing Makefile targets and preserve their guard behavior. Makefile
+remains the authoritative build/release contract; CI and release gates continue
+to rely on the existing canonical command surfaces.

--- a/tests/packaging/test_taskfile_contract.py
+++ b/tests/packaging/test_taskfile_contract.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/packaging/test_taskfile_contract.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from conftest import CANONICAL_ARTIFACTS, RepoReader
+
+
+REQUIRED_TASKS = (
+    "help",
+    "install",
+    "run",
+    "validate",
+    "validate-fast",
+    "validate-full",
+    "validate-packaging",
+    "doctor",
+    "show-artifacts",
+    "clean",
+    "package-pypi",
+    "package-linux",
+    "package-freebsd",
+    "package-macos",
+    "package-windows",
+    "package-nix",
+    "publish-pypi",
+    "publish-all",
+    "release-linux",
+    "release-freebsd",
+    "release-macos",
+    "release-windows",
+    "release-pypi",
+)
+
+EXPECTED_MAKE_WRAPPERS = {
+    "help": ("make help",),
+    "install": ("make install",),
+    "run": ("make run",),
+    "validate": ("make validate",),
+    "validate-fast": ("make validate-fast",),
+    "validate-full": ("make validate-full",),
+    "validate-packaging": ("make validate-packaging",),
+    "doctor": ("make doctor",),
+    "show-artifacts": ("make show-artifacts",),
+    "clean": ("make clean",),
+    "package-pypi": ("make package-pypi",),
+    "package-linux": ("make package-linux",),
+    "package-freebsd": ("make package-freebsd",),
+    "package-macos": ("make package-macos",),
+    "package-windows": ("make package-windows",),
+    "package-nix": ("make package-nix",),
+    "publish-pypi": ("make publish-pypi",),
+    "publish-all": ("make publish-all",),
+    "release-linux": (
+        "make release-deb",
+        "make release-rpm",
+        "make release-appimage",
+    ),
+    "release-freebsd": ("make release-freebsd",),
+    "release-macos": ("make release-macos",),
+    "release-windows": ("make release-windows",),
+    "release-pypi": ("make publish-pypi",),
+}
+
+FORBIDDEN_DIRECT_RELEASE_TOKENS = (
+    "gh release",
+    "gh workflow",
+    "git push",
+    "git tag",
+    "twine upload",
+    "uv publish",
+    "python -m twine upload",
+)
+
+
+def _task_block(taskfile: str, task_name: str) -> str:
+    pattern = re.compile(
+        rf"^  {re.escape(task_name)}:\n"
+        rf"(?P<body>(?:    .*(?:\n|$)|\n)+)",
+        re.MULTILINE,
+    )
+    match = pattern.search(taskfile)
+    assert match is not None, f"missing task: {task_name}"
+    return match.group("body")
+
+
+def test_taskfile_exists(repo_root: Path) -> None:
+    taskfile = repo_root / "Taskfile.yml"
+
+    assert taskfile.is_file()
+    assert taskfile.stat().st_size > 0
+
+
+def test_taskfile_declares_makefile_as_authoritative(
+    read_repo_text: RepoReader,
+) -> None:
+    taskfile = read_repo_text("Taskfile.yml")
+
+    assert "Makefile remains the authoritative build/release contract" in taskfile
+    assert 'version: "3"' in taskfile
+
+
+def test_taskfile_contains_required_developer_tasks(
+    read_repo_text: RepoReader,
+) -> None:
+    taskfile = read_repo_text("Taskfile.yml")
+
+    for task_name in REQUIRED_TASKS:
+        _task_block(taskfile, task_name)
+
+
+def test_taskfile_references_canonical_make_targets(
+    read_repo_text: RepoReader,
+) -> None:
+    taskfile = read_repo_text("Taskfile.yml")
+    makefile = read_repo_text("Makefile")
+
+    for task_name, commands in EXPECTED_MAKE_WRAPPERS.items():
+        task = _task_block(taskfile, task_name)
+        for command in commands:
+            assert command in task
+            target = command.removeprefix("make ")
+            assert re.search(rf"^\.PHONY: .*{re.escape(target)}", makefile, re.M)
+            assert re.search(rf"^{re.escape(target)}:", makefile, re.M)
+
+
+def test_taskfile_does_not_reference_shell_wrappers_or_scripts_sh(
+    read_repo_text: RepoReader,
+) -> None:
+    taskfile = read_repo_text("Taskfile.yml")
+
+    assert "scripts/" not in taskfile
+    assert ".sh" not in taskfile
+
+
+def test_taskfile_does_not_bypass_guarded_release_or_publish_targets(
+    read_repo_text: RepoReader,
+) -> None:
+    taskfile = read_repo_text("Taskfile.yml")
+
+    for token in FORBIDDEN_DIRECT_RELEASE_TOKENS:
+        assert token not in taskfile
+
+    release_tasks = (
+        "release-linux",
+        "release-freebsd",
+        "release-macos",
+        "release-windows",
+        "publish-all",
+    )
+    for task_name in release_tasks:
+        task = _task_block(taskfile, task_name)
+        assert "make release-" in task or "make publish-all" in task
+
+    assert "make publish-pypi" in _task_block(taskfile, "publish-pypi")
+    assert "make publish-pypi" in _task_block(taskfile, "release-pypi")
+
+
+def test_taskfile_does_not_redefine_artifact_names(
+    read_repo_text: RepoReader,
+) -> None:
+    taskfile = read_repo_text("Taskfile.yml")
+
+    for artifact in CANONICAL_ARTIFACTS:
+        assert artifact.artifact_token not in taskfile
+    assert "ecli_<version>" not in taskfile
+    assert "releases/<version>" not in taskfile
+
+
+def test_taskfile_does_not_become_sole_release_contract(
+    read_repo_text: RepoReader,
+) -> None:
+    taskfile = read_repo_text("Taskfile.yml")
+    docs = "\n".join(
+        read_repo_text(path)
+        for path in (
+            "AGENTS.md",
+            "CODEX.md",
+            "CLAUDE.md",
+            "README.md",
+            "docs/contributor/development-setup.md",
+            "docs/contributor/local-validation.md",
+            "docs/release/release-process.md",
+            "docs/release/packaging-flows.md",
+        )
+    )
+
+    assert "Makefile.yml" not in taskfile
+    assert "Makefile remains the authoritative" in docs
+    assert "Taskfile.yml" in docs
+    assert "optional developer convenience" in docs


### PR DESCRIPTION
## Summary

Add `Taskfile.yml` as an optional developer convenience command surface for ECLI.

This change does not replace the existing `Makefile`. The `Makefile` remains the authoritative build, package, validation, release, and publish contract. The new Taskfile only delegates to existing `make` targets.

## What changed

* Add root `Taskfile.yml`.
* Add developer convenience tasks:

  * `task help`
  * `task install`
  * `task run`
  * `task validate`
  * `task validate-fast`
  * `task validate-full`
  * `task validate-packaging`
  * `task doctor`
  * `task show-artifacts`
  * `task clean`
* Add package wrapper tasks:

  * `task package-pypi`
  * `task package-linux`
  * `task package-freebsd`
  * `task package-macos`
  * `task package-windows`
  * `task package-nix`
* Add guarded release/publish wrapper tasks:

  * `task publish-pypi`
  * `task publish-all`
  * `task release-linux`
  * `task release-freebsd`
  * `task release-macos`
  * `task release-windows`
  * `task release-pypi`
* Update contributor, release, README, and agent contract documentation.
* Add `tests/packaging/test_taskfile_contract.py`.

## Contract guarantees

* `Makefile` remains authoritative.
* `Taskfile.yml` is optional convenience only.
* No Taskfile-only build/package/release behavior was introduced.
* No artifact names were changed.
* The 21-item package/release matrix was not changed.
* Release and publish commands still delegate to existing guarded `make` targets.
* No shell wrappers were reintroduced under `scripts/`.

## Validation

* `uv run ruff format --check .` — passed
* `uv run ruff check . --output-format=concise` — passed
* `uv run pytest -q tests/packaging/test_taskfile_contract.py` — passed, 8 passed
* `uv run pytest -q tests/packaging` — passed, 209 passed
* `uv run pytest -ra -q` — passed, 454 passed
* `python3 tools/license_guard.py --report logs/license-guard.md` — passed
* `git diff --check` — passed
* `make validate-packaging` — passed, 209 passed

## Notes

The local `task` binary was not installed, so runtime Task invocation was not executed locally. The Taskfile contract is covered by text-based packaging tests as intended. All Taskfile commands delegate to existing `make` targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Taskfile.yml` providing optional convenience wrapper commands (e.g., `task help`, `task validate`, `task package-*`, `task release-*`) that delegate to existing Make targets.

* **Documentation**
  * Updated development guides clarifying that Makefile remains the authoritative build/release contract and Taskfile.yml is optional developer convenience only.

* **Tests**
  * Added contract validation tests ensuring Taskfile properly wraps Makefile targets without introducing Taskfile-only release behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->