### PR TITLE
Stabilize editor rendering and terminal UI panels

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,6 +13,13 @@
 
 keybindings = {}
 
+# --- Colour theme -----------------------------------------------------------
+# Pick one of the eight built-in themes by number. Colours (editor surface,
+# syntax highlighting, status bar, diagnostics) all come from the selected theme.
+#   1 = Light Classic    2 = Light Soft    3 = Light High Contrast  4 = Light Solar
+#   5 = Dark Classic     6 = Dark Soft     7 = Dark High Contrast   8 = Dark Neon
+theme = 8
+
 
 [logging]
 file_level = "DEBUG"
@@ -34,40 +41,9 @@ grok = "grok-4-fast"
 huggingface = "meta-llama/Meta-Llama-3.1-405B-Instruct"
 
 
-[colors]
-line_number = "blue"
-cursor = "yellow"
-literal = "magenta"
-decorator = "cyan"
-selector = "magenta"
-property = "cyan"
-punctuation = "white"
-status = "bright_white"
-variable = "white"
-tag = "blue"
-attribute = "cyan"
-magic = "magenta"
-builtin = "yellow"
-exception = "red"
-class = "yellow"
-escape = "cyan"
-background = "#0D1117"
-foreground = "#C9D1D9"
-comment = "#456954"
-keyword = "#D2A8FF"
-string = "#A5D6FF"
-number = "#79C0FF"
-function = "#FFA657"
-constant = "#D29922"
-type = "#F2CC60"
-operator = "#F0F6FC"
-selection_bg = "#264F78"
-search_highlight = "#FF1493"
-status_bg = "#161B22"
-status_fg = "#C9D1D9"
-git_clean = "#79C0FF"
-git_dirty = "#FFAB70"
-error = "#FF7B72"
+# NOTE: Editor colours are now defined by the built-in `theme` selector above.
+# The former free-form [colors] table has been removed; per-colour overrides are
+# no longer read by the editor.
 
 
 [fonts]
@@ -83,24 +59,16 @@ use_spaces = true
 word_wrap = false
 auto_indent = true
 auto_brackets = true
+# Toggle Pygments/custom syntax highlighting on or off.
+syntax_highlighting = true
+# Opt-in mouse support (click to focus/move, wheel to scroll, click to select
+# list rows). Off by default so native terminal text selection still works.
+mouse = false
 
 
 [settings]
 auto_save_interval = 5
 show_git_info = true
-
-
-[theme]
-name = "dark"
-
-
-[theme.ui]
-background = "#252526"
-foreground = "#CCCCCC"
-accent = "#007ACC"
-selection = "#264F78"
-inactive_selection = "#3A3D41"
-cursor = "#AEAFAD"
 
 
 [linter]

--- a/src/ecli/core/Ecli.py
+++ b/src/ecli/core/Ecli.py
@@ -85,14 +85,23 @@ from ecli.integrations.LinterBridge import LinterBridge
 from ecli.services.registry import ServiceRegistry
 from ecli.ui.TerminalAppMode import TerminalAppMode
 from ecli.ui.DrawScreen import DrawScreen
+from ecli.ui.geometry import Rect, compute_layout
 from ecli.ui.KeyBinder import KeyBinder
+from ecli.ui.mouse import (
+    FocusRegion,
+    MouseAction,
+    decode_curses_mouse,
+    hit_test,
+)
 from ecli.ui.PanelManager import PanelManager
 from ecli.ui.panels import FileBrowserPanel, GitPanel
+from ecli.ui.textops import normalize_paste_text, selection_to_text
 from ecli.utils.logging_config import logger, log_record_to_file_handlers
 from ecli.utils.text_buffer import (
     detect_and_decode_text,
     split_text_preserving_content,
 )
+from ecli.utils.themes import ThemePalette, resolve_theme
 from ecli.utils.utils import hex_to_xterm
 
 
@@ -156,6 +165,40 @@ class _LightweightPanelManager:
 
     def draw_active_panel(self) -> None:
         return None
+
+
+#: Per-name terminal attribute and 8-colour fallback for each semantic colour.
+#: Structural and theme-independent; the foreground hex comes from the active
+#: theme palette (see ``Ecli.init_colors`` / ``ecli.utils.themes``).
+_SYNTAX_COLOR_STRUCTURE: dict[str, tuple[int, int]] = {
+    # Syntax Highlighting
+    "default": (curses.COLOR_WHITE, curses.A_NORMAL),
+    "comment": (curses.COLOR_WHITE, curses.A_DIM),
+    "keyword": (curses.COLOR_MAGENTA, curses.A_NORMAL),
+    "string": (curses.COLOR_CYAN, curses.A_NORMAL),
+    "number": (curses.COLOR_BLUE, curses.A_NORMAL),
+    "function": (curses.COLOR_YELLOW, curses.A_BOLD),
+    "class": (curses.COLOR_YELLOW, curses.A_BOLD),
+    "constant": (curses.COLOR_CYAN, curses.A_BOLD),
+    "type": (curses.COLOR_YELLOW, curses.A_NORMAL),
+    "operator": (curses.COLOR_RED, curses.A_NORMAL),
+    "decorator": (curses.COLOR_MAGENTA, curses.A_BOLD),
+    "variable": (curses.COLOR_WHITE, curses.A_NORMAL),
+    "tag": (curses.COLOR_GREEN, curses.A_NORMAL),
+    "attribute": (curses.COLOR_CYAN, curses.A_NORMAL),
+    "builtin": (curses.COLOR_YELLOW, curses.A_NORMAL),
+    # UI Elements
+    "error": (curses.COLOR_RED, curses.A_BOLD),
+    "status": (curses.COLOR_WHITE, curses.A_REVERSE),
+    "status_error": (curses.COLOR_RED, curses.A_REVERSE | curses.A_BOLD),
+    "line_number": (curses.COLOR_YELLOW, curses.A_DIM),
+    # Git statuses
+    "git_info": (curses.COLOR_GREEN, curses.A_NORMAL),  # Untracked, Clean
+    "git_dirty": (curses.COLOR_YELLOW, curses.A_NORMAL),  # Modified
+    "git_added": (curses.COLOR_CYAN, curses.A_NORMAL),  # Added
+    "git_deleted": (curses.COLOR_RED, curses.A_DIM),  # Deleted
+    "search_highlight": (curses.COLOR_BLACK, curses.A_NORMAL),
+}
 
 
 ## ==================== Ecli Class ====================
@@ -578,6 +621,13 @@ class Ecli:
         self.pyclip_available: bool = self._check_pyclip_availability()
         if not self.pyclip_available:
             self.use_system_clipboard = False
+        # Mouse support is opt-in ([editor].mouse = true) so it never disrupts
+        # native terminal text selection by default. Enabled at run() if both
+        # config and the terminal allow it.
+        self.mouse_enabled_config: bool = bool(
+            self.config.get("editor", {}).get("mouse", False)
+        )
+        self.mouse_active: bool = False
         # Setup auto-save
         self._auto_save_thread: Optional[threading.Thread] = None
         self._auto_save_enabled: bool = False
@@ -871,6 +921,31 @@ class Ecli:
         # so a redraw is always required.
         return True
 
+    def toggle_terminal_panel(self) -> bool:
+        """Reserved hook for the future Terminal Panel (F11) — not implemented.
+
+        The Terminal Panel will be a normal right-side panel that reuses the
+        existing split-layout architecture unchanged:
+
+        * 60% editor / 40% side panel via ``ecli.ui.geometry.compute_layout``;
+        * opaque themed panel surface, border/title/footer, no global-footer
+          overlap (``BasePanel._layout_window`` + ``panel_kind = "terminal"``);
+        * the F12 focus-switch model and Esc-to-close;
+        * the same theme roles and resize-safe clipping.
+
+        Future input contract (intentionally NOT wired here): F11 opens/closes
+        the panel, F12 switches focus, Esc closes the focused panel, and Ctrl+C
+        must interrupt the terminal process **only** when the terminal panel is
+        focused (handled by the panel, not the global editor copy binding).
+
+        No PTY, subprocess or terminal UI is started in this pass.
+        """
+        self._set_status_message(
+            "Terminal panel (F11) is reserved and not yet available."
+        )
+        logging.info("toggle_terminal_panel: reserved hook invoked (not implemented).")
+        return True
+
     def _get_service_registry(self) -> ServiceRegistry:
         """Return the editor-owned service registry, creating it lazily."""
         if self.service_registry is not None:
@@ -1145,23 +1220,12 @@ class Ecli:
             )
             return ""
 
-        start_col = max(0, min(start_col, len(self.text[start_row])))
-        end_col = max(0, min(end_col, len(self.text[end_row])))
-
-        if start_row == end_row:
-            # Single-line selection
-            return self.text[start_row][start_col:end_col]
-        # Multi-line selection
-        selected_parts = []
-        # Part of the first line
-        selected_parts.append(self.text[start_row][start_col:])
-        # Full middle lines
-        for i in range(start_row + 1, end_row):
-            selected_parts.append(self.text[i])
-        # Part of the last line
-        selected_parts.append(self.text[end_row][:end_col])
-
-        return "\n".join(selected_parts)
+        # Delegate to the central, buffer-coordinate-only extractor. It returns
+        # file content for the (row, col) span only — never line numbers, the
+        # gutter, borders, or any other rendered UI chrome.
+        return selection_to_text(
+            self.text, (start_row, start_col), (end_row, end_col)
+        )
 
     # --- Copy selected text ---
     def copy(self) -> bool:
@@ -1449,6 +1513,17 @@ class Ecli:
 
         return tokenized_segments
 
+    def _syntax_highlighting_enabled(self) -> bool:
+        """Return whether syntax highlighting is enabled in the active config.
+
+        Controlled by ``[editor].syntax_highlighting`` (default ``True``). A
+        missing or non-boolean value falls back to enabled so highlighting never
+        silently breaks on a malformed config.
+        """
+        editor_config = self.config.get("editor", {}) if isinstance(self.config, dict) else {}
+        value = editor_config.get("syntax_highlighting", True)
+        return bool(value) if isinstance(value, bool) else True
+
     # --- Syntax-highlighting helper ------------------------------
     def apply_syntax_highlighting_with_pygments(
         self,
@@ -1470,6 +1545,13 @@ class Ecli:
             A list of lists, where each inner list contains (substring,
             curses_attribute) tuples for a single line.
         """
+        # Respect the syntax-highlighting toggle. When disabled, every line is
+        # returned as a single default-coloured segment so the renderer draws
+        # plain text without touching the buffer.
+        if not self._syntax_highlighting_enabled():
+            default_color = self.colors.get("default", curses.A_NORMAL)
+            return [[(line, default_color)] for line in lines]
+
         # Ensure a lexer is set, even if it's just TextLexer.
         if self._lexer is None:
             self.detect_language()
@@ -1787,8 +1869,9 @@ class Ecli:
             self._force_full_redraw = True
             new_height, new_width = self.stdscr.getmaxyx()
 
-            # The calculation is correct, but let's log it.
-            self.visible_lines = max(1, new_height - 2)
+            # Reserve rows for the header/status/footer chrome (single source of
+            # truth lives in DrawScreen.content_height).
+            self.visible_lines = DrawScreen.content_height(new_height)
             self.last_window_size = (new_height, new_width)
             self.scroll_left = 0
             logging.debug(
@@ -3373,12 +3456,48 @@ class Ecli:
 
         # Now that the selection is cancelled, we simply insert the text.
         # The insert_text method will no longer see an active selection.
-        text_to_paste = text_to_paste.replace("\r\n", "\n").replace("\r", "\n")
+        # Central sanitiser: strip terminal/bracketed control sequences and
+        # normalise CRLF/CR -> LF while preserving valid Unicode.
+        text_to_paste = normalize_paste_text(text_to_paste)
 
         if self.insert_text(text_to_paste):
             self._set_status_message(f"Pasted from {source_of_paste} clipboard")
             return True
         return False
+
+    def insert_pasted_text(self, text: str) -> bool:
+        """Insert bracketed-paste / clipboard text as a single transaction.
+
+        Sanitises the payload via ``normalize_paste_text`` (strip bracketed-paste
+        markers and ANSI/terminal escape sequences, normalise ``\\r\\n`` / bare
+        ``\\r`` -> ``\\n``) while preserving valid Unicode, inserts the whole
+        payload via ``insert_text`` (one compound undo unit, one redraw), and
+        never interprets the payload as editor shortcuts. Returns True when a
+        redraw is needed.
+        """
+        if not text:
+            return False
+
+        text = normalize_paste_text(text)
+        if not text:
+            return False
+
+        # Mirror into the internal clipboard so a subsequent Ctrl+V is consistent.
+        self.internal_clipboard = text
+
+        # A paste replaces any active selection at the cursor; cancel it first so
+        # insert_text drops the selection inside the same compound action.
+        if self.is_selecting:
+            logging.debug("Bracketed paste over active selection.")
+
+        inserted = self.insert_text(text)
+        if inserted:
+            line_count = text.count("\n") + 1
+            self._set_status_message(
+                f"Pasted {line_count} line{'s' if line_count != 1 else ''} "
+                f"({len(text)} chars)"
+            )
+        return inserted
 
     def delete_selected_text(self) -> None:
         """High-level action to delete the currently selected text and record
@@ -5274,6 +5393,12 @@ class Ecli:
             f"_write_file: Writing to '{target_filename}' with encoding '{self.encoding}'"
         )
 
+        # Deterministic newline policy: logical lines are joined with a single
+        # LF on every platform and written through a binary handle so the OS
+        # text layer never re-translates them. Using os.linesep together with a
+        # text-mode handle double-translated on Windows (LF -> CRLF on a string
+        # that already held CRLF), corrupting the line structure on reopen.
+        newline = "\n"
         content_to_write = ""
         # Create a copy for safe modification
         lines_to_save = list(self.text)
@@ -5282,9 +5407,9 @@ class Ecli:
             if len(lines_to_save) == 1 and not lines_to_save[0]:
                 content_to_write = ""
             else:
-                content_to_write = os.linesep.join(lines_to_save)
+                content_to_write = newline.join(lines_to_save)
                 if getattr(self, "_file_had_final_newline", False):
-                    content_to_write += os.linesep
+                    content_to_write += newline
         else:
             # If the last line is empty and the second-to-last is not, remove it for saving
             if len(lines_to_save) > 1 and not lines_to_save[-1] and lines_to_save[-2]:
@@ -5292,18 +5417,15 @@ class Ecli:
             elif len(lines_to_save) == 1 and not lines_to_save[0]:
                 # If the file contains only one empty line (our technical one)
                 lines_to_save = []  # Save as an empty file
-            content_to_write = os.linesep.join(lines_to_save)
+            content_to_write = newline.join(lines_to_save)
+            # A freshly created buffer is persisted with a trailing newline.
+            if content_to_write:
+                content_to_write += newline
 
         try:
-            with self.safe_open(
-                target_filename, "w", encoding=self.encoding, errors="replace"
-            ) as f:
-                text_f = cast(TextIO, f)
-                text_f.write(content_to_write)
-                if content_to_write and not getattr(
-                    self, "_file_loaded_from_disk", False
-                ):
-                    text_f.write(os.linesep)
+            encoded = content_to_write.encode(self.encoding or "utf-8", errors="replace")
+            with self.safe_open(target_filename, "wb") as f:
+                cast(BinaryIO, f).write(encoded)
 
             logging.debug(f"Successfully wrote to '{target_filename}'")
 
@@ -5315,7 +5437,7 @@ class Ecli:
 
             self.modified = False
             self._file_loaded_from_disk = True
-            self._file_had_final_newline = content_to_write.endswith(os.linesep)
+            self._file_had_final_newline = content_to_write.endswith(newline)
             self.detect_language()
 
             # Update Git information as file state on disk has changed
@@ -6960,7 +7082,10 @@ class Ecli:
                 self.scroll_top <= text_row_idx < self.scroll_top + self.visible_lines
             ):
                 return None
-            screen_y_coord = text_row_idx - self.scroll_top
+            screen_y_coord = (
+                text_row_idx - self.scroll_top
+                + getattr(self, "_content_area_y_offset", 0)
+            )
             try:
                 if not (0 <= text_row_idx < len(self.text)):
                     logging.warning(
@@ -6978,9 +7103,9 @@ class Ecli:
                     f"get_screen_coords_for_highlight: IndexError accessing text for ({text_row_idx},{text_col_idx})."
                 )
                 return None
-            screen_x_coord = (
-                line_num_display_width + prefix_width_unscrolled - self.scroll_left
-            )
+            x_off = getattr(self, "_content_area_x_offset", 0)
+            text_left = line_num_display_width + x_off
+            screen_x_coord = text_left + prefix_width_unscrolled - self.scroll_left
             if text_col_idx >= len(self.text[text_row_idx]):
                 logging.warning(
                     f"get_screen_coords_for_highlight: text_col_idx {text_col_idx} is at or past EOL for line {text_row_idx} (len {len(self.text[text_row_idx])}). Cannot get char width for highlighting."
@@ -6994,13 +7119,13 @@ class Ecli:
                     f"get_screen_coords_for_highlight: Character at ({text_row_idx},{text_col_idx}) has width {char_display_width_at_coord}, not highlighting directly."
                 )
                 return None
+            right_edge = getattr(self, "_content_right_x", 0) or term_width
             if (
-                screen_x_coord >= term_width
-                or (screen_x_coord + char_display_width_at_coord)
-                <= line_num_display_width
+                screen_x_coord >= right_edge
+                or (screen_x_coord + char_display_width_at_coord) <= text_left
             ):
                 return None
-            return screen_y_coord, max(line_num_display_width, screen_x_coord)
+            return screen_y_coord, max(text_left, screen_x_coord)
 
         # 4. Calculate screen coordinates for both brackets
         coords1_on_screen = get_screen_coords_for_highlight(
@@ -7049,10 +7174,120 @@ class Ecli:
                             f"Curses error highlighting bracket 2 at screen ({scr_y2},{scr_x2}): {e}"
                         )
 
+    def _resolve_theme_pair_colors(
+        self,
+        name: str,
+        theme_hex: dict[str, str],
+        palette: ThemePalette,
+        can_use_256_colors: bool,
+        theme_bg: int,
+    ) -> tuple[int, int]:
+        """Resolve the (foreground, background) terminal colours for one pair.
+
+        On 256-colour terminals the foreground comes from the active theme; on
+        legacy terminals a fixed 8-colour fallback is used. ``search_highlight``
+        is special-cased to render on a bright warning swatch.
+        """
+        bg = theme_bg
+        if can_use_256_colors:
+            try:
+                fg = hex_to_xterm(theme_hex.get(name, palette.foreground))
+            except Exception:
+                fg = hex_to_xterm(palette.foreground)
+        else:
+            fg = _SYNTAX_COLOR_STRUCTURE[name][0]
+
+        if name == "search_highlight":
+            if can_use_256_colors:
+                try:
+                    bg = hex_to_xterm(palette.search_background)
+                except Exception:
+                    bg = theme_bg
+            else:
+                fg = curses.COLOR_BLACK
+                bg = curses.COLOR_YELLOW
+
+        return fg, bg
+
+    def _init_chrome_color_pairs(
+        self, palette: ThemePalette, start_pair_id: int, can_use_256_colors: bool
+    ) -> int:
+        """Allocate curses pairs for UI chrome (header/status/footer/border/...).
+
+        Each chrome role is a (fg, bg) pair so the bars render as solid coloured
+        surfaces. On non-256-colour terminals chrome degrades to reverse-video so
+        the bars still stand out from file text. Returns the next free pair id.
+        """
+        pair_id = start_pair_id
+        emphatic = ("accent", "key", "title", "number")
+        for name, (fg_hex, bg_hex) in palette.chrome_color_pairs().items():
+            if not can_use_256_colors:
+                attr = curses.A_REVERSE
+                if name.endswith(emphatic):
+                    attr |= curses.A_BOLD
+                self.colors[name] = attr
+                continue
+            if pair_id >= curses.COLOR_PAIRS:
+                self.colors[name] = curses.A_REVERSE
+                continue
+            try:
+                fg = hex_to_xterm(fg_hex)
+                bg = hex_to_xterm(bg_hex)
+                curses.init_pair(pair_id, fg, bg)
+                self.colors[name] = curses.color_pair(pair_id)
+                pair_id += 1
+            except (curses.error, Exception) as exc:  # noqa: BLE001
+                logging.debug("Chrome pair '%s' fell back to reverse: %s", name, exc)
+                self.colors[name] = curses.A_REVERSE
+        return pair_id
+
+    def _init_current_line_variants(
+        self,
+        palette: ThemePalette,
+        theme_hex: dict[str, str],
+        start_pair_id: int,
+        can_use_256_colors: bool,
+    ) -> int:
+        """Allocate "syntax-on-current-line" pairs and map base pair -> variant.
+
+        Each variant keeps the syntax foreground but swaps the background to the
+        theme's current-line colour, so the active row can be tinted while every
+        token keeps its colour. Returns the next free pair id.
+        """
+        self._current_line_variant = {}
+        if not can_use_256_colors:
+            return start_pair_id
+        try:
+            cur_bg = hex_to_xterm(palette.current_line)
+        except Exception:
+            return start_pair_id
+
+        pair_id = start_pair_id
+        for name in _SYNTAX_COLOR_STRUCTURE:
+            base_attr = self.colors.get(name)
+            if base_attr is None:
+                continue
+            base_pair = curses.pair_number(base_attr)
+            if base_pair == 0 or pair_id >= curses.COLOR_PAIRS:
+                continue
+            try:
+                fg = hex_to_xterm(theme_hex.get(name, palette.foreground))
+            except Exception:
+                fg = hex_to_xterm(palette.foreground)
+            try:
+                curses.init_pair(pair_id, fg, cur_bg)
+                self._current_line_variant[base_pair] = pair_id
+                pair_id += 1
+            except curses.error:
+                continue
+        return pair_id
+
     def init_colors(self) -> None:
         """Initializes curses color pairs with graceful degradation."""
         self.is_256_color_terminal: bool = False
         self.colors = {}  # Start fresh
+        # base_pair_number -> current-line-variant pair number (populated below).
+        self._current_line_variant: dict[int, int] = {}
 
         if not curses.has_colors() or curses.COLORS < 8:
             logging.warning(
@@ -7083,56 +7318,68 @@ class Ecli:
                 "git_deleted": curses.A_DIM,
                 # -----------------------------------------------------------------
                 "search_highlight": curses.A_REVERSE,
+                # --- UI chrome fallbacks for colourless terminals ---
+                "ui_header": curses.A_REVERSE | curses.A_BOLD,
+                "ui_header_accent": curses.A_REVERSE | curses.A_BOLD,
+                "ui_header_dim": curses.A_REVERSE,
+                "ui_status": curses.A_REVERSE,
+                "ui_status_dim": curses.A_REVERSE,
+                "ui_status_accent": curses.A_REVERSE | curses.A_BOLD,
+                "ui_footer": curses.A_REVERSE,
+                "ui_footer_key": curses.A_REVERSE | curses.A_BOLD,
+                "ui_border": curses.A_DIM,
+                "ui_panel_title": curses.A_BOLD,
+                "ui_current_line": curses.A_UNDERLINE,
+                "ui_current_line_number": curses.A_BOLD,
+                "ui_selection": curses.A_REVERSE,
+                "ui_info": curses.A_NORMAL,
+                "ui_success": curses.A_NORMAL,
+                "ui_warning": curses.A_BOLD,
+                "ui_error": curses.A_BOLD,
+                "ui_dim": curses.A_DIM,
+                "ui_panel": curses.A_NORMAL,
+                "ui_panel_dim": curses.A_DIM,
+                "ui_panel_title": curses.A_BOLD,
+                "ui_panel_border": curses.A_NORMAL,
+                "ui_panel_warning": curses.A_BOLD,
+                "ui_panel_error": curses.A_BOLD,
+                "ui_panel_selected": curses.A_REVERSE | curses.A_BOLD,
             }
             return
 
         curses.start_color()
         curses.use_default_colors()
 
-        # --- Adding new semantic names for Git ---
-        color_definitions = {
-            # Syntax Highlighting
-            "default": ("#C9D1D9", curses.COLOR_WHITE, curses.A_NORMAL),
-            "comment": ("#8B949E", curses.COLOR_WHITE, curses.A_DIM),
-            "keyword": ("#FF7B72", curses.COLOR_MAGENTA, curses.A_NORMAL),
-            "string": ("#A5D6FF", curses.COLOR_CYAN, curses.A_NORMAL),
-            "number": ("#79C0FF", curses.COLOR_BLUE, curses.A_NORMAL),
-            "function": ("#D2A8FF", curses.COLOR_YELLOW, curses.A_BOLD),
-            "constant": ("#79C0FF", curses.COLOR_CYAN, curses.A_BOLD),
-            "type": ("#F2CC60", curses.COLOR_YELLOW, curses.A_NORMAL),
-            "operator": ("#FF7B72", curses.COLOR_RED, curses.A_NORMAL),
-            "decorator": ("#D2A8FF", curses.COLOR_MAGENTA, curses.A_BOLD),
-            "variable": ("#C9D1D9", curses.COLOR_WHITE, curses.A_NORMAL),
-            "tag": ("#7EE787", curses.COLOR_GREEN, curses.A_NORMAL),
-            "attribute": ("#79C0FF", curses.COLOR_CYAN, curses.A_NORMAL),
-            # UI Elements
-            "error": ("#F85149", curses.COLOR_RED, curses.A_BOLD),
-            "status": ("#C9D1D9", curses.COLOR_WHITE, curses.A_REVERSE),
-            "status_error": (
-                "#F85149",
-                curses.COLOR_RED,
-                curses.A_REVERSE | curses.A_BOLD,
-            ),
-            "line_number": ("#817248", curses.COLOR_YELLOW, curses.A_DIM),
-            # --- Colors for Git statuses ---
-            "git_info": (
-                "#34913C",
-                curses.COLOR_GREEN,
-                curses.A_NORMAL,
-            ),  # Untracked, Clean
-            "git_dirty": ("#F2CC60", curses.COLOR_YELLOW, curses.A_NORMAL),  # Modified
-            "git_added": ("#A5D6FF", curses.COLOR_CYAN, curses.A_NORMAL),  # Added
-            "git_deleted": ("#F85149", curses.COLOR_RED, curses.A_DIM),  # Deleted
-            # -----------------------------------------
-            "search_highlight": ("#000000", curses.COLOR_BLACK, curses.A_NORMAL),
-        }
+        # Resolve the active built-in theme. Colours come exclusively from the
+        # selected palette (config key ``theme = 1..8``); the legacy free-form
+        # ``[colors]`` table is intentionally ignored so a single, deterministic
+        # source drives both the UI chrome and syntax highlighting.
+        palette: ThemePalette = resolve_theme(self.config)
+        self.active_theme = palette
+        if isinstance(self.config, dict) and self.config.get("colors"):
+            logging.info(
+                "Ignoring deprecated [colors] config section; using built-in "
+                "theme '%s' (theme = %d). Set 'theme = 1..8' to change palette.",
+                palette.name,
+                palette.theme_id,
+            )
 
-        user_colors = self.config.get("colors", {})
-        pair_id_counter = 1
+        theme_hex = palette.syntax_color_hex()
         can_use_256_colors = curses.COLORS >= 256
         self.is_256_color_terminal = can_use_256_colors
 
-        for name, (default_hex, default_8_color, attr) in color_definitions.items():
+        # Apply the theme background only on capable terminals; otherwise keep the
+        # terminal's default background (-1) so 8/16-colour terminals degrade
+        # gracefully to foreground-only theming.
+        theme_bg = -1
+        if can_use_256_colors:
+            try:
+                theme_bg = hex_to_xterm(palette.background)
+            except Exception:
+                theme_bg = -1
+
+        pair_id_counter = 1
+        for name, (_default_8_color, attr) in _SYNTAX_COLOR_STRUCTURE.items():
             if pair_id_counter >= curses.COLOR_PAIRS:
                 logging.warning(
                     f"Ran out of color pairs. Cannot initialize '{name}' \
@@ -7141,26 +7388,9 @@ class Ecli:
                 self.colors[name] = attr
                 continue
 
-            fg, bg = -1, -1
-
-            if can_use_256_colors:
-                hex_code = user_colors.get(name, default_hex)
-                try:
-                    fg = hex_to_xterm(hex_code)
-                except Exception:
-                    fg = hex_to_xterm(default_hex)
-            else:
-                fg = default_8_color
-
-            if name == "search_highlight":
-                bg_hex = user_colors.get("search_highlight_bg", "#FFAB70")
-                if can_use_256_colors:
-                    try:
-                        bg = hex_to_xterm(bg_hex)
-                    except Exception:
-                        bg = 215
-                else:
-                    bg = curses.COLOR_YELLOW
+            fg, bg = self._resolve_theme_pair_colors(
+                name, theme_hex, palette, can_use_256_colors, theme_bg
+            )
 
             try:
                 curses.init_pair(pair_id_counter, fg, bg)
@@ -7169,6 +7399,23 @@ class Ecli:
             except curses.error as e:
                 logging.error(f"Failed to initialize curses pair for '{name}': {e}")
                 self.colors[name] = attr
+
+        # Allocate current-line variants (same fg, current-line background) so the
+        # active row can be tinted without losing syntax colours.
+        pair_id_counter = self._init_current_line_variants(
+            palette, theme_hex, pair_id_counter, can_use_256_colors
+        )
+
+        # Allocate UI-chrome pairs (header/status/footer/border/current-line).
+        self._init_chrome_color_pairs(palette, pair_id_counter, can_use_256_colors)
+
+        # Paint the editor surface with the theme background so cleared regions
+        # (erase / clrtoeol) match the palette instead of the terminal default.
+        if can_use_256_colors and "default" in self.colors:
+            try:
+                self.stdscr.bkgd(" ", self.colors["default"])
+            except (curses.error, AttributeError) as exc:
+                logging.debug("Could not apply theme background to window: %s", exc)
 
     # ==================== HELP ==================================
     def _build_help_lines(self) -> list[str]:  # noqa: python:S3516
@@ -7809,6 +8056,13 @@ class Ecli:
             # Non-fatal on platforms without terminfo
             pass
 
+        # Enable bracketed paste so terminal pastes arrive as one payload.
+        self._set_bracketed_paste(True)
+        # Opt-in mouse support (off by default to keep native text selection).
+        self._enable_mouse()
+        # Surface the effective theme + which config file was actually loaded.
+        self._report_startup_config()
+
         # Input modes: raw/noecho + keypad/meta
         try:
             curses.raw()
@@ -7872,6 +8126,10 @@ class Ecli:
             except Exception:
                 pass
 
+            # Disable mouse + bracketed paste before leaving the alternate screen.
+            self._disable_mouse()
+            self._set_bracketed_paste(False)
+
             # --- EXIT terminal application modes (normal cursor keys + leave alt screen) ---
             try:
                 rmkx  = curses.tigetstr("rmkx")
@@ -7884,6 +8142,170 @@ class Ecli:
                 pass
 
             logger.info("Editor main loop finished.")
+
+    def _set_bracketed_paste(self, enable: bool) -> None:
+        """Enable/disable terminal bracketed-paste mode (best effort)."""
+        seq = "\x1b[?2004h" if enable else "\x1b[?2004l"
+        try:
+            sys.stdout.write(seq)
+            sys.stdout.flush()
+        except Exception:
+            logging.debug("Could not toggle bracketed paste mode.", exc_info=True)
+
+    def _enable_mouse(self) -> None:
+        """Enable curses mouse reporting if configured and supported (opt-in)."""
+        if not getattr(self, "mouse_enabled_config", False):
+            return
+        try:
+            avail = getattr(curses, "ALL_MOUSE_EVENTS", 0) | getattr(
+                curses, "REPORT_MOUSE_POSITION", 0
+            )
+            mask, _ = curses.mousemask(avail)
+            self.mouse_active = mask != 0
+            if self.mouse_active:
+                logging.info("Mouse support enabled.")
+            else:
+                logging.info("Mouse not supported by this terminal.")
+        except (curses.error, AttributeError):
+            self.mouse_active = False
+            logging.debug("Mouse support unavailable.", exc_info=True)
+
+    def _disable_mouse(self) -> None:
+        """Release the mouse mask (best effort)."""
+        if not getattr(self, "mouse_active", False):
+            return
+        try:
+            curses.mousemask(0)
+        except (curses.error, AttributeError):
+            pass
+        self.mouse_active = False
+
+    def _handle_mouse_event(self) -> bool:
+        """Dispatch one mouse event to the focused region (safe, non-destructive).
+
+        Only focus changes, wheel scrolling and list-row *selection* are applied;
+        no editor mutation and no guarded/destructive action (delete/rename/push/
+        publish) is ever triggered by a click. Degrades to a no-op when mouse
+        support is off or unavailable.
+        """
+        if not getattr(self, "mouse_active", False):
+            return False
+        try:
+            _id, x, y, _z, bstate = curses.getmouse()
+        except curses.error:
+            return False
+
+        button, action = decode_curses_mouse(bstate)
+        height, width = self.stdscr.getmaxyx()
+
+        pm = self.panel_manager
+        panel = (
+            getattr(pm, "active_panel", None)
+            if pm is not None and pm.is_panel_active()
+            else None
+        )
+        is_modal = bool(getattr(panel, "_rendered_as_modal", False)) if panel else False
+        side_panel = panel is not None and not is_modal
+        geo = compute_layout(width, height, active_panel=side_panel)
+        modal_rect = (
+            Rect(panel.start_x, panel.start_y, panel.width, panel.height)
+            if is_modal and panel is not None
+            else None
+        )
+        gutter = getattr(self.drawer, "_text_start_x", 0) + getattr(
+            self.drawer, "content_area_x_offset", 0
+        )
+        target = hit_test(geo, x, y, gutter_width=gutter, modal_rect=modal_rect)
+        return self._apply_mouse_target(target, button, action, panel)
+
+    def _apply_mouse_target(
+        self, target: Any, button: Any, action: Any, panel: Any
+    ) -> bool:
+        """Apply a safe intent from a hit-test result. Returns True on change."""
+        region = target.region
+        # Wheel scrolls whichever region it is over.
+        if action is MouseAction.WHEEL:
+            delta = 1 if button.name == "WHEEL_UP" else -1
+            if region is FocusRegion.PANEL and panel is not None:
+                return bool(panel.scroll_by(delta))
+            if region in (FocusRegion.EDITOR, FocusRegion.GUTTER):
+                return self._scroll_editor(delta * 3)
+            return False
+
+        if region is FocusRegion.MODAL:
+            return False  # keep the modal; no destructive action on click
+        if region is FocusRegion.PANEL and panel is not None:
+            changed = self._focus_to("panel")
+            hit = getattr(panel, "hit_entry_index", None)
+            if action is MouseAction.CLICK and callable(hit):
+                idx = hit(target.local_y)
+                if idx is not None and getattr(panel, "idx", None) != idx:
+                    panel.idx = idx  # selection only; never auto-opens
+                    changed = True
+            return changed
+        if region in (FocusRegion.EDITOR, FocusRegion.GUTTER):
+            changed = self._focus_to("editor")
+            if action is MouseAction.CLICK:
+                changed = self._move_cursor_to_click(target) or changed
+            return changed
+        # Header / status / footer / outside: focus editor, never touch buffer.
+        return self._focus_to("editor")
+
+    def _focus_to(self, where: str) -> bool:
+        """Set focus deterministically (mouse mirror of F12). Returns True on change."""
+        if getattr(self, "focus", None) == where:
+            return False
+        self.focus = where
+        return True
+
+    def _scroll_editor(self, rows: int) -> bool:
+        """Wheel-scroll the editor viewport by ``rows`` (positive = up)."""
+        max_scroll = max(0, len(self.text) - max(1, self.visible_lines))
+        new_top = max(0, min(self.scroll_top - rows, max_scroll))
+        if new_top != self.scroll_top:
+            self.scroll_top = new_top
+            return True
+        return False
+
+    def _move_cursor_to_click(self, target: Any) -> bool:
+        """Move the cursor to the clicked editor cell (non-destructive)."""
+        line = self.scroll_top + target.local_y
+        line = max(0, min(line, len(self.text) - 1))
+        gutter = getattr(self.drawer, "_text_start_x", 0)
+        col = self.scroll_left + max(0, target.local_x - gutter)
+        col = max(0, min(col, len(self.text[line])))
+        self.cursor_y, self.cursor_x = line, col
+        self._ensure_cursor_in_bounds()
+        return True
+
+    def _report_startup_config(self) -> None:
+        """Set an initial status line exposing the theme and loaded config path."""
+        try:
+            theme = getattr(self, "active_theme", None)
+            cfg_path = self.config.get("_loaded_config_path", "unknown")
+            if theme is not None:
+                self._set_status_message(
+                    f"Theme {theme.theme_id}: {theme.name} · config: {cfg_path}"
+                )
+        except Exception:
+            logging.debug("Could not report startup config.", exc_info=True)
+
+    def _handle_paste_event(self, text: str) -> bool:
+        """Route a captured bracketed paste to the focused component."""
+        if not text:
+            return False
+        if (
+            self.focus == "panel"
+            and self.panel_manager
+            and self.panel_manager.is_panel_active()
+        ):
+            active = getattr(self.panel_manager, "active_panel", None)
+            handler = getattr(active, "handle_paste", None)
+            if callable(handler):
+                return bool(handler(text))
+            # Panel does not accept paste; ignore to avoid corrupting the editor.
+            return False
+        return self.insert_pasted_text(text)
 
     def _process_events_and_input(self) -> bool:
         """Processes all non-UI events for a single main loop iteration, including
@@ -7920,6 +8342,19 @@ class Ecli:
 
         # Proceed only if a valid key was received (not an error or timeout).
         if key_input != curses.ERR and key_input != -1:
+            # Bracketed paste: insert the whole payload as one transaction and
+            # redraw once, instead of replaying it as individual keystrokes.
+            if key_input == KeyBinder.PASTE_EVENT:
+                if self._handle_paste_event(self.keybinder.last_paste):
+                    redraw_needed = True
+                return redraw_needed
+
+            # Mouse: unified dispatch path (only active when mouse is enabled).
+            if key_input == curses.KEY_MOUSE:
+                if self._handle_mouse_event():
+                    redraw_needed = True
+                return redraw_needed
+
             # Intercept the RESIZE key at the highest level, BEFORE dispatching it
             # to the focused component. This is a global event that affects the
             # entire UI.

--- a/src/ecli/ui/DrawScreen.py
+++ b/src/ecli/ui/DrawScreen.py
@@ -36,6 +36,7 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from wcwidth import wcwidth
+from ecli.ui.geometry import compute_layout
 from ecli.utils.utils import CALM_BG_IDX, WHITE_FG_IDX, get_file_icon
 
 
@@ -131,6 +132,41 @@ class DrawScreen:
     MIN_WINDOW_HEIGHT = 5
     DEFAULT_TAB_WIDTH = 4
 
+    # --- Professional chrome layout ------------------------------------
+    HEADER_HEIGHT = 1
+    STATUS_HEIGHT = 1
+    FOOTER_HEIGHT = 1
+    # Below this window height the header and footer are dropped (status only)
+    # so very small terminals keep the maximum number of editable rows.
+    MIN_HEIGHT_FOR_FULL_CHROME = 8
+
+    @classmethod
+    def chrome_heights(cls, height: int) -> tuple[int, int, int]:
+        """Return ``(header_h, status_h, footer_h)`` for a window height."""
+        if height < cls.MIN_HEIGHT_FOR_FULL_CHROME:
+            return 0, cls.STATUS_HEIGHT, 0
+        return cls.HEADER_HEIGHT, cls.STATUS_HEIGHT, cls.FOOTER_HEIGHT
+
+    @classmethod
+    def content_height(cls, height: int) -> int:
+        """Number of editor text rows available for a window height."""
+        header_h, status_h, footer_h = cls.chrome_heights(height)
+        return max(1, height - header_h - status_h - footer_h)
+
+    # Below this width the vertical viewport borders are dropped.
+    MIN_WIDTH_FOR_BORDERS = 40
+
+    @classmethod
+    def border_cols(cls, height: int, width: int) -> tuple[int, int]:
+        """Return ``(left, right)`` vertical-border widths for the window size.
+
+        Borders only appear alongside the full header/footer chrome and on wide
+        enough terminals; otherwise they degrade to ``(0, 0)``.
+        """
+        if height < cls.MIN_HEIGHT_FOR_FULL_CHROME or width < cls.MIN_WIDTH_FOR_BORDERS:
+            return 0, 0
+        return 1, 1
+
     # Constructor / colour-initialisation
     def __init__(self, editor: "Ecli", config: dict[str, Any]) -> None:
         self.editor = editor
@@ -139,14 +175,19 @@ class DrawScreen:
         self.colors = editor.colors
         self._text_start_x: int = 0
 
-        # panel offsets
-        self.content_area_y_offset = 0
-        self.content_area_x_offset = 0
-
-        # visible line count initially = window height − 2 (numbers + status bar)
+        # Initial chrome geometry; draw() recomputes this every frame from the
+        # live terminal size so resize is always correct.
+        h, w = self.stdscr.getmaxyx()
+        header_h, _status_h, _footer_h = self.chrome_heights(h)
+        left_b, right_b = self.border_cols(h, w)
+        self.content_area_y_offset = header_h
+        self.content_area_x_offset = left_b
+        self._content_right_x = w - right_b
+        self.editor._content_area_y_offset = header_h
+        self.editor._content_area_x_offset = left_b
+        self.editor._content_right_x = self._content_right_x
         if not hasattr(self.editor, "visible_lines"):
-            h, _ = self.stdscr.getmaxyx()
-            self.editor.visible_lines = h - 2
+            self.editor.visible_lines = self.content_height(h)
 
         # ensure calm-dark status colour pairs exist
         self._init_status_colors()
@@ -173,7 +214,12 @@ class DrawScreen:
         except curses.error:
             pass
 
-        pair_norm, pair_err = 15, 16  # pair numbers can remain the same
+        # High pair ids that never collide with the sequential pairs allocated
+        # by Ecli.init_colors (syntax + chrome ~1..45). Previously these were
+        # 15/16, which silently overwrote the 'builtin' and 'error' syntax pairs.
+        max_pairs = curses.COLOR_PAIRS
+        pair_norm = max(1, min(250, max_pairs - 2))
+        pair_err = max(1, min(251, max_pairs - 1))
         max_colors = curses.COLORS
 
         if max_colors >= 256:
@@ -342,10 +388,11 @@ class DrawScreen:
                 logging.warning(f"Curses error clearing text area (no content): {e}")
             return
 
-        # Get the window width once
+        # Clip text to the content right-edge (inside the right border).
         _h, window_width = self.stdscr.getmaxyx()
+        content_right = getattr(self, "_content_right_x", 0) or window_width
 
-        # The padding is now handled by the offset, so we can simplify this.
+        # The left border is accounted for by the x offset.
         text_area_start_x = self._text_start_x + self.content_area_x_offset
 
         logging.debug(
@@ -359,15 +406,28 @@ class DrawScreen:
             self._draw_single_line(
                 screen_row + self.content_area_y_offset,
                 line_data_tuple,
-                window_width,
+                content_right,
                 text_area_start_x,
             )
+
+    @staticmethod
+    def _apply_current_line_variant(token_attr: int, variant_map: dict[int, int]) -> int:
+        """Return *token_attr* remapped to its current-line background variant.
+
+        Keeps the foreground colour and text attributes (bold/dim/...), swapping
+        only the colour pair to the pre-allocated current-line variant. Returns
+        the attribute unchanged when no variant exists for the token's pair.
+        """
+        variant = variant_map.get(curses.pair_number(token_attr))
+        if variant:
+            return curses.color_pair(variant) | (token_attr & ~curses.A_COLOR)
+        return token_attr
 
     def _draw_single_line(
         self,
         screen_row: int,
         line_data: tuple[int, list[tuple[str, int]]],
-        window_width: int,
+        right_edge: int,
         text_area_start_x: int,
     ) -> None:
         """Draw a single logical line of source text on the given screen row,
@@ -377,15 +437,26 @@ class DrawScreen:
         Args:
             screen_row: Absolute Y position in the curses window.
             line_data:  (buffer_index, [(lexeme, attr), ...]).
-            window_width: Current terminal width (in cells).
+            right_edge: Exclusive right boundary for content (inside any border).
             text_area_start_x: The screen column where the text area begins.
         """
         _line_index, tokens_for_this_line = line_data
+        is_current_line = _line_index == self.editor.cursor_y
+        current_line_attr = self.colors.get("ui_current_line", curses.A_NORMAL)
+        variant_map = getattr(self.editor, "_current_line_variant", {})
 
         # Clear the target area first.
         try:
             self.stdscr.move(screen_row, text_area_start_x)
             self.stdscr.clrtoeol()
+            if is_current_line:
+                # Tint the whole active row (incl. the empty tail) up to the
+                # content edge; tokens are repainted over it next.
+                tint_w = max(0, right_edge - text_area_start_x)
+                if tint_w:
+                    self.stdscr.chgat(
+                        screen_row, text_area_start_x, tint_w, current_line_attr
+                    )
         except curses.error as e:
             logging.error("Curses error while clearing line %d: %s", screen_row, e)
             return
@@ -405,8 +476,8 @@ class DrawScreen:
             if ideal_x < text_area_start_x:
                 cells_cut_left = text_area_start_x - ideal_x
 
-            draw_x = max(self._text_start_x, ideal_x)
-            avail_screen_w = window_width - draw_x
+            draw_x = max(text_area_start_x, ideal_x)
+            avail_screen_w = right_edge - draw_x
             if avail_screen_w <= 0:
                 # Nothing further on this line is visible.
                 break
@@ -424,9 +495,17 @@ class DrawScreen:
                 self.editor.get_char_width,
             )
 
+            # On the active row, swap each token's background to the current-line
+            # colour while keeping its foreground and text attributes.
+            draw_attr = (
+                self._apply_current_line_variant(token_attr, variant_map)
+                if is_current_line
+                else token_attr
+            )
+
             if text_to_draw:
                 try:
-                    self.stdscr.addstr(screen_row, draw_x, text_to_draw, token_attr)
+                    self.stdscr.addstr(screen_row, draw_x, text_to_draw, draw_attr)
                 except curses.error as e:
                     # Fallback: draw char-by-char if addstr fails (rare, but safe).
                     logging.debug(
@@ -437,10 +516,10 @@ class DrawScreen:
                     )
                     cx = draw_x
                     for ch in text_to_draw:
-                        if cx >= window_width:
+                        if cx >= right_edge:
                             break
                         try:
-                            self.stdscr.addch(screen_row, cx, ch, token_attr)
+                            self.stdscr.addch(screen_row, cx, ch, draw_attr)
                         except curses.error:
                             break
                         cx += self.editor.get_char_width(ch)
@@ -448,7 +527,7 @@ class DrawScreen:
             logical_col_abs += token_disp_width
 
             # Early exit if we've reached the right edge.
-            if draw_x + visible_w >= window_width:
+            if draw_x + visible_w >= right_edge:
                 break
 
     def draw(self) -> None:
@@ -461,28 +540,49 @@ class DrawScreen:
                 # last_window_size is now correctly set by the handle_resize method
                 return
 
+            # Recompute chrome geometry every frame so resize is always correct
+            # and the single source of truth stays in sync.
+            header_h, status_h, footer_h = self.chrome_heights(height)
+            left_b, right_b = self.border_cols(height, width)
+
+            # When a side panel is open the work area splits ~60/40: clip the
+            # editor content to the editor region and drop the editor's own right
+            # border (the panel's left border is the divider). The global
+            # header/status/footer keep their full-width rows untouched.
+            editor_right = self._side_panel_editor_width(width, height)
+            if editor_right is not None:
+                right_b = 0
+                content_right = editor_right
+            else:
+                content_right = width - right_b
+
+            self.content_area_y_offset = header_h
+            self.content_area_x_offset = left_b
+            self._content_right_x = content_right
+            self.editor._content_area_y_offset = header_h
+            self.editor._content_area_x_offset = left_b
+            self.editor._content_right_x = self._content_right_x
+            self.editor.visible_lines = self.content_height(height)
+
             if self._needs_full_redraw():
                 self.stdscr.erase()
                 self.editor._force_full_redraw = False
             else:
                 self._clear_invalidated_lines()
 
+            if header_h:
+                self._draw_header(width)
+
             self._draw_line_numbers()
             self._draw_text_with_syntax_highlighting()
             self._draw_search_highlights()
             self._draw_selection()
             self.editor.highlight_matching_brackets()
-
-            separator_y = height - 2
-            try:
-                char_with_attr = curses.ACS_HLINE | self.colors.get(
-                    "comment", curses.A_DIM
-                )
-                self.stdscr.hline(separator_y, 0, char_with_attr, width)
-            except curses.error:
-                pass
+            self._draw_borders(height, width, header_h, self.editor.visible_lines)
 
             self._draw_status_bar()
+            if footer_h:
+                self._draw_footer(width)
             self._draw_lint_panel()
 
             # This logic should happen within the try block and before noutrefresh
@@ -498,22 +598,20 @@ class DrawScreen:
             self.editor._set_status_message(f"Draw error: {str(e)[:80]}...")
 
     def _clear_invalidated_lines(self) -> None:
-        """Clears the rows that will be redrawn in this frame.
-        Avoiding global clear()
+        """Clears the editor content rows that will be redrawn in this frame.
+
+        Chrome rows (header/status/footer) are repainted in full every frame, so
+        only the text area is cleared here. Avoids a global clear() to prevent
+        flicker.
         """
+        offset = self.content_area_y_offset
+        text_start = self._text_start_x + self.content_area_x_offset
         for row in range(self.editor.visible_lines):
             try:
-                self.stdscr.move(row, self._text_start_x)
+                self.stdscr.move(row + offset, text_start)
                 self.stdscr.clrtoeol()
             except curses.error:
                 pass
-        # status bar
-        try:
-            h, _ = self.stdscr.getmaxyx()
-            self.stdscr.move(h - 1, 0)
-            self.stdscr.clrtoeol()
-        except curses.error:
-            pass
 
     def _keep_lint_panel_alive(self, hold_ms: int = 400) -> None:
         """Pin the lint-panel open for a minimum time window.
@@ -601,33 +699,43 @@ class DrawScreen:
             return
         # Saving the starting position for text drawing
         self._text_start_x = line_num_width
+        offset = self.content_area_y_offset
+        gutter_x = self.content_area_x_offset  # leave room for the left border
         line_num_color = self.colors.get("line_number", curses.color_pair(7))
+        # Current line gets an emphasised gutter (accent + highlighted background).
+        current_num_color = self.colors.get(
+            "ui_current_line_number", line_num_color | curses.A_BOLD
+        )
+        cursor_y = self.editor.cursor_y
         # Iterating over visible lines on the screen
         for screen_row in range(self.editor.visible_lines):
             # Calculating the line index in self.text
             line_idx = self.editor.scroll_top + screen_row
+            draw_y = screen_row + offset
             # Checking if this line exists in self.text
             if line_idx < len(self.editor.text):
+                is_current = line_idx == cursor_y
+                color = current_num_color if is_current else line_num_color
                 # Formatting the line number (1-based)
                 line_num_str = (
                     f"{line_idx + 1:>{max_line_num_digits}} "  # Right-aligning + space
                 )
                 try:
                     # Drawing the line number
-                    self.stdscr.addstr(screen_row, 0, line_num_str, line_num_color)
+                    self.stdscr.addstr(draw_y, gutter_x, line_num_str, color)
                 except curses.error as e:
                     logging.error(
-                        f"Curses error drawing line number at ({screen_row}, 0): {e}"
+                        f"Curses error drawing line number at ({draw_y}, {gutter_x}): {e}"
                     )
                     # If an error occurs, skip drawing this line and continue
             else:
                 # Drawing empty lines with the desired background in the line number area
                 empty_num_str = " " * line_num_width
                 try:
-                    self.stdscr.addstr(screen_row, 0, empty_num_str, line_num_color)
+                    self.stdscr.addstr(draw_y, gutter_x, empty_num_str, line_num_color)
                 except curses.error as e:
                     logging.error(
-                        f"Curses error drawing empty line number background at ({screen_row}, 0): {e}"
+                        f"Curses error drawing empty line number background at ({draw_y}, {gutter_x}): {e}"
                     )
 
     def _draw_lint_panel(self) -> None:
@@ -645,19 +753,30 @@ class DrawScreen:
         start_y = max(1, (h - panel_height) // 2)
         start_x = max(2, (w - panel_width) // 2)
 
-        # Framing the window
+        # Themed, opaque panel: solid surface + title embedded in the border.
+        border = self.colors.get("ui_panel_border", curses.A_BOLD)
+        fill = self.colors.get("ui_panel", curses.A_NORMAL)
+        dim = self.colors.get("ui_panel_dim", curses.A_DIM)
+        title = " Diagnostics "
+        inner = panel_width - 2
         try:
             for i in range(panel_height):
-                line = ""
                 if i == 0:
-                    line = "┌" + "─" * (panel_width - 2) + "┐"
+                    label = title[: max(0, inner - 2)]
+                    rest = inner - len(label) - 1
+                    line = "┌─" + label + "─" * max(0, rest) + "┐"
                 elif i == panel_height - 1:
-                    line = "└" + "─" * (panel_width - 2) + "┘"
+                    line = "└" + "─" * inner + "┘"
                 else:
-                    line = "│" + " " * (panel_width - 2) + "│"
-                self.stdscr.addstr(start_y + i, start_x, line, curses.A_BOLD)
+                    line = "│" + " " * inner + "│"
+                self.stdscr.addnstr(start_y + i, start_x, line, panel_width, border)
+                # Repaint the hollow interior with the solid panel surface.
+                if 0 < i < panel_height - 1:
+                    self.stdscr.addnstr(
+                        start_y + i, start_x + 1, " " * inner, inner, fill
+                    )
 
-            # Message split into lines
+            # Message split into lines (on the solid surface).
             msg_lines = msg.splitlines()
             for idx, line in enumerate(msg_lines[: panel_height - 3]):
                 self.stdscr.addnstr(
@@ -665,16 +784,16 @@ class DrawScreen:
                     start_x + 2,
                     line.strip(),
                     panel_width - 4,
-                    curses.A_NORMAL,
+                    fill,
                 )
             # Footer
-            footer = "Press Esc to close"
+            footer = "Esc: close"
             self.stdscr.addnstr(
                 start_y + panel_height - 2,
                 start_x + 2,
                 footer,
                 panel_width - 4,
-                curses.A_DIM,
+                dim,
             )
         except curses.error as e:
             logging.error(f"Curses error drawing linter panel: {e}")
@@ -702,6 +821,9 @@ class DrawScreen:
         line_num_width = (
             len(str(max(1, len(self.editor.text)))) + 1
         )  # Width for line numbers plus space
+        # Text starts after the gutter and the left border; clip to the right edge.
+        text_start = line_num_width + self.content_area_x_offset
+        content_right = getattr(self, "_content_right_x", 0) or width
 
         # Iterate through all matches to be highlighted
         for (
@@ -716,7 +838,9 @@ class DrawScreen:
             ):
                 continue
 
-            screen_y = match_row - self.editor.scroll_top  # Screen row for this match
+            screen_y = (
+                match_row - self.editor.scroll_top + self.content_area_y_offset
+            )  # Screen row for this match
             line = self.editor.text[
                 match_row
             ]  # The text of the line containing the match
@@ -726,7 +850,7 @@ class DrawScreen:
                 line[:match_start_idx]
             )
             match_screen_start_x = (
-                line_num_width
+                text_start
                 + match_screen_start_x_before_scroll
                 - self.editor.scroll_left
             )
@@ -735,14 +859,14 @@ class DrawScreen:
                 line[:match_end_idx]
             )
             match_screen_end_x = (
-                line_num_width
+                text_start
                 + match_screen_end_x_before_scroll
                 - self.editor.scroll_left
             )
 
             # Clamp drawing area to the visible screen boundaries
-            draw_start_x = max(line_num_width, match_screen_start_x)
-            draw_end_x = min(width, match_screen_end_x)
+            draw_start_x = max(text_start, match_screen_start_x)
+            draw_end_x = min(content_right, match_screen_end_x)
 
             # Calculate the actual width of the highlight to draw
             highlight_width_on_screen = max(0, draw_end_x - draw_start_x)
@@ -752,7 +876,7 @@ class DrawScreen:
                 try:
                     # Iterate over characters in the line to accurately highlight wide characters
                     current_char_screen_x = (
-                        line_num_width - self.editor.scroll_left
+                        text_start - self.editor.scroll_left
                     )  # Initial X for first char
                     for char_idx, char in enumerate(line):
                         char_width = self.editor.get_char_width(char)
@@ -761,11 +885,11 @@ class DrawScreen:
                         # If this character falls within the match range and is visible
                         if (
                             match_start_idx <= char_idx < match_end_idx
-                            and current_char_screen_x < width
-                            and char_screen_end_x > line_num_width
+                            and current_char_screen_x < content_right
+                            and char_screen_end_x > text_start
                         ):
-                            draw_char_x = max(line_num_width, current_char_screen_x)
-                            draw_char_width = min(char_width, width - draw_char_x)
+                            draw_char_x = max(text_start, current_char_screen_x)
+                            draw_char_width = min(char_width, content_right - draw_char_x)
 
                             if draw_char_width > 0:
                                 try:
@@ -809,8 +933,10 @@ class DrawScreen:
         end_y, end_x = end_coords
 
         _height, width = self.stdscr.getmaxyx()
-        text_area_start_x = self._text_start_x
-        selection_attr = curses.A_REVERSE
+        text_area_start_x = self._text_start_x + self.content_area_x_offset
+        content_right = getattr(self, "_content_right_x", 0) or width
+        offset = self.content_area_y_offset
+        selection_attr = self.colors.get("ui_selection", curses.A_REVERSE)
 
         # Initial log for the selection action
         logging.debug(
@@ -837,7 +963,7 @@ class DrawScreen:
                 )
 
                 draw_start_x = max(text_area_start_x, x_left)
-                draw_end_x = min(width, x_right)
+                draw_end_x = min(content_right, x_right)
                 highlight_w = max(0, draw_end_x - draw_start_x)
 
                 # Logging for single-line highlight
@@ -850,7 +976,7 @@ class DrawScreen:
                 if highlight_w > 0:
                     try:
                         self.stdscr.chgat(
-                            screen_y, draw_start_x, highlight_w, selection_attr
+                            screen_y + offset, draw_start_x, highlight_w, selection_attr
                         )
                     except curses.error as e:
                         logging.error(f"Curses error on single-line chgat: {e}")
@@ -882,7 +1008,7 @@ class DrawScreen:
                 highlight_end_on_screen = highlight_start_on_screen + max_visual_width
 
                 draw_start_x = max(text_area_start_x, highlight_start_on_screen)
-                draw_end_x = min(width, highlight_end_on_screen)
+                draw_end_x = min(content_right, highlight_end_on_screen)
                 highlight_w = max(0, draw_end_x - draw_start_x)
 
                 # Detailed log for each line in the multi-line block
@@ -895,7 +1021,7 @@ class DrawScreen:
                 if highlight_w > 0:
                     try:
                         self.stdscr.chgat(
-                            screen_y, draw_start_x, highlight_w, selection_attr
+                            screen_y + offset, draw_start_x, highlight_w, selection_attr
                         )
                     except curses.error as e:
                         logging.error(
@@ -935,6 +1061,150 @@ class DrawScreen:
 
         return "".join(result)
 
+    # --- Professional chrome: header / footer ---------------------------
+    def _fill_bar(self, y: int, width: int, attr: int) -> None:
+        """Paint a full-width horizontal bar at row *y* without scrolling."""
+        if width <= 0:
+            return
+        try:
+            self.stdscr.addstr(y, 0, " " * (width - 1), attr)
+            # Fill the final cell with insch so the cursor never wraps/scrolls.
+            self.stdscr.insch(y, width - 1, ord(" "), attr)
+        except curses.error:
+            pass
+
+    def _put(self, y: int, x: int, text: str, attr: int, width: int) -> int:
+        """Draw *text* at (y, x), clipped to the window width. Returns next x."""
+        if not text or x >= width:
+            return x
+        max_w = max(0, width - 1 - x)
+        clipped = self.truncate_string(text, max_w)
+        if not clipped:
+            return x
+        try:
+            self.stdscr.addstr(y, x, clipped, attr)
+        except curses.error:
+            pass
+        return x + self.editor.get_string_width(clipped)
+
+    def _shorten_path(self, path: str, max_width: int) -> str:
+        """Shorten *path* to fit *max_width* cells, keeping the basename."""
+        if self.editor.get_string_width(path) <= max_width:
+            return path
+        base = os.path.basename(path)
+        if self.editor.get_string_width(base) + 2 >= max_width:
+            return "…" + self.truncate_string(base, max(1, max_width - 1))
+        head_budget = max_width - self.editor.get_string_width(base) - 2
+        head = self.truncate_string(path, max(0, head_budget))
+        return f"{head}…/{base}"
+
+    def _draw_header(self, width: int) -> None:
+        """Top application header bar: app name, file, modified state, theme."""
+        if self.editor.is_lightweight:
+            return
+        try:
+            bar = self.colors.get("ui_header", curses.A_REVERSE)
+            accent = self.colors.get("ui_header_accent", bar | curses.A_BOLD)
+            dim = self.colors.get("ui_header_dim", bar)
+
+            self._fill_bar(0, width, bar)
+
+            # Right segment: active theme indicator.
+            theme = getattr(self.editor, "active_theme", None)
+            right = f" theme {theme.theme_id} · {theme.name} " if theme else ""
+            right_w = self.editor.get_string_width(right)
+
+            # Left segment: app badge + file name + modified marker.
+            x = self._put(0, 0, " ECLI ", accent, width)
+            fname = self.editor.filename or "No Name"
+            avail = max(8, width - right_w - x - 3)
+            shown = self._shorten_path(fname, avail)
+            marker = " ●" if self.editor.modified else ""
+            x = self._put(0, x, f" {shown}{marker} ", bar, width)
+
+            if right and width - right_w - 1 > x:
+                self._put(0, width - right_w - 1, right, dim, width)
+        except curses.error:
+            pass
+
+    def _draw_footer(self, width: int) -> None:
+        """Bottom shortcut/action strip with compact key hints."""
+        if self.editor.is_lightweight:
+            return
+        height, _ = self.stdscr.getmaxyx()
+        y = height - 1
+        try:
+            bar = self.colors.get("ui_footer", curses.A_REVERSE)
+            key = self.colors.get("ui_footer_key", bar | curses.A_BOLD)
+
+            self._fill_bar(y, width, bar)
+
+            hints = [
+                ("Ctrl+S", "Save"),
+                ("Ctrl+O", "Open"),
+                ("Ctrl+F", "Find"),
+                ("F1", "Help"),
+                ("Ctrl+Q", "Quit"),
+            ]
+            x = 1
+            for k, label in hints:
+                segment_w = self.editor.get_string_width(f"{k} {label}  ")
+                if x + segment_w >= width:
+                    break
+                x = self._put(y, x, f" {k}", key, width)
+                x = self._put(y, x, f" {label} ", bar, width)
+        except curses.error:
+            pass
+
+    def _side_panel_editor_width(self, width: int, height: int) -> int | None:
+        """Editor content width when a non-modal side panel splits the work area.
+
+        Returns ``None`` when no side panel is active (or it is a centered
+        modal), so the editor keeps its normal full width.
+        """
+        pm = getattr(self.editor, "panel_manager", None)
+        is_active = getattr(pm, "is_panel_active", None)
+        if pm is None or not callable(is_active) or not is_active():
+            return None
+        panel = getattr(pm, "active_panel", None)
+        if panel is None or getattr(panel, "_rendered_as_modal", False):
+            return None
+        geo = compute_layout(width, height, active_panel=True)
+        return geo.editor.width if geo.split else None
+
+    def _draw_borders(
+        self, height: int, width: int, content_top: int, content_height: int
+    ) -> None:
+        """Draw the left/right vertical viewport borders on the content rows.
+
+        The header bar forms the top edge and the status/footer bars the bottom
+        edge, so only the verticals are drawn here. Degrades to nothing when
+        ``border_cols`` returns zero (small/narrow terminals).
+        """
+        if self.editor.is_lightweight:
+            return
+        left_b, right_b = self.border_cols(height, width)
+        if self._side_panel_editor_width(width, height) is not None:
+            right_b = 0  # the panel's left border is the divider
+        if not left_b and not right_b:
+            return
+        attr = self.colors.get("ui_border", curses.A_DIM)
+        glyph = "│"
+        for row in range(content_top, content_top + content_height):
+            if row >= height:
+                break
+            if left_b:
+                try:
+                    self.stdscr.addstr(row, 0, glyph, attr)
+                except curses.error:
+                    pass
+            if right_b and width >= 1:
+                try:
+                    # insstr never advances the cursor past the last cell.
+                    self.stdscr.insstr(row, width - 1, glyph, attr)
+                except curses.error:
+                    pass
+
     def _draw_status_bar(self) -> None:
         """Single-line status bar (bottom of the screen).
 
@@ -954,13 +1224,21 @@ class DrawScreen:
             if height <= 2:
                 return  # not enough space
 
-            y = height - 1  # last line
+            # Status sits just above the footer shortcut strip (or on the last
+            # line when chrome is degraded on tiny terminals).
+            _header_h, status_h, footer_h = self.chrome_heights(height)
+            y = height - footer_h - status_h
 
-            # -- colours ----------------------------------------------
-            c_norm = self.colors["status"]  # white on calm-dark
-            c_err = self.colors["status_error"]  # bold white on calm-dark
-            c_git = self.colors.get("git_info", c_norm)
-            c_dirty = self.colors.get("git_dirty", c_norm | curses.A_BOLD)
+            # -- colours (themed status bar) --------------------------
+            c_norm = self.colors.get(
+                "ui_status", self.colors.get("status", curses.A_REVERSE)
+            )
+            c_err = self.colors.get(
+                "ui_error",
+                self.colors.get("status_error", curses.A_REVERSE | curses.A_BOLD),
+            )
+            c_git = self.colors.get("ui_success", c_norm)
+            c_dirty = self.colors.get("ui_warning", c_norm | curses.A_BOLD)
 
             # -- left part --------------------------------------------
             icon = get_file_icon(self.editor.filename, self.config)
@@ -1042,12 +1320,13 @@ class DrawScreen:
         if height <= 2:
             return
 
-        text_area_start_x = self._text_start_x
+        text_area_start_x = self._text_start_x + self.content_area_x_offset
+        content_right = getattr(self, "_content_right_x", 0) or width
 
         # Explicit calculation of the text area height ---
         # Instead of self.editor.visible_lines, which can be 0 during initialization,
-        # we use the actual window dimensions.
-        text_area_height = max(1, height - 2)
+        # we derive it from the live window size and chrome layout.
+        text_area_height = self.content_height(height)
 
         if self.editor.cursor_y >= len(self.editor.text):
             cursor_display_width = 0
@@ -1066,7 +1345,7 @@ class DrawScreen:
             self.editor.scroll_top = self.editor.cursor_y - max_screen_row
 
         # 3. Adjust Horizontal Scroll
-        text_area_width = max(1, width - text_area_start_x)
+        text_area_width = max(1, content_right - text_area_start_x)
         if cursor_display_width < self.editor.scroll_left:
             self.editor.scroll_left = cursor_display_width
         elif cursor_display_width >= self.editor.scroll_left + text_area_width:
@@ -1084,7 +1363,9 @@ class DrawScreen:
             self.content_area_y_offset,
             min(final_screen_y, max_screen_row + self.content_area_y_offset),
         )
-        final_screen_x = max(text_area_start_x, min(final_screen_x, width - 1))
+        final_screen_x = max(
+            text_area_start_x, min(final_screen_x, content_right - 1)
+        )
 
         # 5. Move the Physical Cursor
         try:
@@ -1117,7 +1398,7 @@ class DrawScreen:
             None. All adjustments are logged.
         """
         height, _width = self.stdscr.getmaxyx()
-        text_area_height = max(1, height - 2)
+        text_area_height = self.content_height(height)
 
         # If the total number of lines fits on the screen, always show from the top.
         if len(self.editor.text) <= text_area_height:

--- a/src/ecli/ui/KeyBinder.py
+++ b/src/ecli/ui/KeyBinder.py
@@ -47,9 +47,12 @@ import curses
 import logging
 import re
 from typing import TYPE_CHECKING, Any, Callable, Optional
+
 from wcwidth import wcswidth
 
+from ecli.ui.textops import utf8_continuation_needed
 from ecli.utils.logging_config import log_exception_to_file_handlers
+
 
 if TYPE_CHECKING:
     from ecli.core.Ecli import Ecli
@@ -148,6 +151,130 @@ class KeyBinder:
         # State that now belongs to KeyBinder
         self.keybindings = self._load_keybindings()
         self.action_map = self._setup_action_map()
+
+        # Bracketed-paste payload captured by get_key_input (read by the editor).
+        self.last_paste: str = ""
+
+    # Sentinel returned by get_key_input when a bracketed paste was captured.
+    PASTE_EVENT = "\x00ecli-bracketed-paste\x00"
+    # Bracketed-paste markers (xterm): ESC [ 200 ~  ...  ESC [ 201 ~
+    _PASTE_START = "[200~"
+    _PASTE_END = b"\x1b[201~"
+
+    def _read_bracketed_paste(self, target: Any, initial: str) -> str:
+        """Read a full bracketed-paste payload as one UTF-8 decoded string.
+
+        ``initial`` holds the bytes already read after the ``[200~`` marker
+        (each char is a raw byte in 0..255). Continues reading until the
+        ``ESC [ 201 ~`` end marker, then strips it. Bytes are accumulated and
+        decoded once so multi-byte UTF-8 paste content is preserved.
+        """
+        data = bytearray(initial.encode("latin-1", "ignore"))
+        max_bytes = 8 * 1024 * 1024  # hard cap to avoid runaway reads
+        try:
+            target.nodelay(False)
+            target.timeout(40)
+            idle = 0
+            while self._PASTE_END not in data and len(data) < max_bytes:
+                ch = target.getch()
+                if ch == curses.ERR:
+                    idle += 1
+                    if idle > 6:  # ~240ms with no data: assume the burst ended
+                        break
+                    continue
+                idle = 0
+                if 0 <= ch <= 255:
+                    data.append(ch)
+                # Wide/function-key codes inside a paste are ignored.
+        finally:
+            # Restore the main-loop input cadence.
+            target.nodelay(True)
+            target.timeout(35)
+
+        payload = bytes(data).split(self._PASTE_END, 1)[0]
+        return payload.decode("utf-8", "replace")
+
+    def _drain_text_burst(self, target: Any, first_byte: int) -> str | int | None:
+        """Coalesce an immediate run of text bytes into one paste, if present.
+
+        Reads any bytes already buffered after ``first_byte`` (non-blocking).
+        A control byte or special key code ends the run and is pushed back.
+
+        Returns:
+            * ``PASTE_EVENT`` (with ``self.last_paste`` set) when a multi-character
+              run / newline was collected (a paste);
+            * the decoded character for a single multi-byte UTF-8 keystroke;
+            * ``None`` when only the single ``first_byte`` was available, so the
+              caller keeps its exact fast-path behaviour.
+        """
+        data = bytearray([first_byte])
+        pushed_back: int | None = None
+        target.nodelay(True)
+        try:
+            while True:
+                nx = target.getch()
+                if nx == curses.ERR:
+                    break
+                if 0 <= nx <= 255 and (nx >= 0x20 or nx in (0x09, 0x0A, 0x0D)):
+                    data.append(nx)
+                else:
+                    pushed_back = nx
+                    break
+        finally:
+            target.nodelay(False)
+
+        if pushed_back is not None:
+            try:
+                curses.ungetch(pushed_back)
+            except (curses.error, OverflowError):
+                pass
+
+        # Reassemble a multi-byte UTF-8 character whose continuation bytes had not
+        # arrived yet (split across reads). Without this, a lead byte like 0xE2
+        # ("→") would fall through to chr(byte) and be mis-decoded as Latin-1
+        # U+00E2 — the mojibake reported on paste/typing of Unicode.
+        self._complete_trailing_utf8(target, data)
+
+        if len(data) == 1 and data[0] < 0x80:
+            return None  # plain ASCII keystroke: keep exact fast-path behaviour
+
+        payload = bytes(data).decode("utf-8", "replace")
+        if len(payload) >= 2 or "\n" in payload or "\r" in payload:
+            self.last_paste = payload
+            logging.debug("get_key_input: coalesced %d-char paste burst", len(payload))
+            return self.PASTE_EVENT
+        return payload  # single multi-byte character
+
+    def _complete_trailing_utf8(self, target: Any, data: bytearray) -> None:
+        """Read the continuation bytes needed to finish a trailing UTF-8 char.
+
+        Blocks briefly (per the curses timeout) for each missing continuation
+        byte so a multi-byte character split across reads is decoded as one
+        Unicode code point instead of a run of Latin-1 bytes. Stops early on a
+        non-continuation byte (pushed back) or when no byte arrives.
+        """
+        needed = utf8_continuation_needed(bytes(data))
+        if not needed:
+            return
+        target.nodelay(False)
+        target.timeout(20)
+        try:
+            for _ in range(needed):
+                nx = target.getch()
+                if nx == curses.ERR:
+                    break
+                if 0x80 <= nx <= 0xBF:
+                    data.append(nx)
+                    continue
+                # Not a continuation byte: it belongs to the next key — push back.
+                try:
+                    curses.ungetch(nx)
+                except (curses.error, OverflowError):
+                    pass
+                break
+        finally:
+            target.nodelay(True)
+            target.timeout(35)
 
     def _handle_printable_character(self, key: str | int) -> bool:
         """Handles insertion of a printable character into the buffer."""
@@ -325,6 +452,8 @@ class KeyBinder:
             "select_to_end": [curses.KEY_SEND],
             "handle_backspace": ["backspace", *get_backspace_code()],
             "toggle_file_browser": ["f10", 274],
+            # F11 is reserved for the future Terminal Panel (not implemented yet).
+            "toggle_terminal_panel": ["f11", getattr(curses, "KEY_F11", 275)],
             "toggle_focus": ["f12", 276],
 
             # Selection extensions (Shift/Alt variants)
@@ -723,6 +852,7 @@ class KeyBinder:
             "help": self.editor.show_help,
             "cancel_operation": self.editor.handle_escape,
             "toggle_file_browser": self.editor.toggle_file_browser,
+            "toggle_terminal_panel": self.editor.toggle_terminal_panel,
             "toggle_focus": self.editor.toggle_focus,
             "toggle_system_doctor_panel": self.editor.toggle_system_doctor_panel,
             # --- Git ---
@@ -817,7 +947,15 @@ class KeyBinder:
         try:
             ch = target.getch()
             if ch != 27:
-                return ch  # fast path
+                # Fast path. If this is a text byte and more text is already
+                # buffered, it is almost certainly a paste burst (works even when
+                # the terminal does not support bracketed paste): drain it and
+                # route the whole run through the single paste transaction.
+                if 0x20 <= ch <= 0xFF or ch in (0x09, 0x0A, 0x0D):
+                    drained = self._drain_text_burst(target, ch)
+                    if drained is not None:
+                        return drained
+                return ch  # single keystroke
 
             # ESC received: lone ESC, Alt chord, or an escape sequence
             seq = ""
@@ -839,6 +977,19 @@ class KeyBinder:
             if not seq:
                 logging.debug("get_key_input: standalone ESC")
                 return 27
+
+            # Bracketed paste: ESC [ 200 ~ <payload> ESC [ 201 ~. Capture the whole
+            # payload here so it is inserted as one transaction instead of being
+            # replayed as individual keystrokes (which is slow and auto-indents).
+            if seq.startswith(self._PASTE_START):
+                self.last_paste = self._read_bracketed_paste(
+                    target, seq[len(self._PASTE_START) :]
+                )
+                logging.debug(
+                    "get_key_input: captured bracketed paste (%d chars)",
+                    len(self.last_paste),
+                )
+                return self.PASTE_EVENT
 
             # Some terminals deliver ESC-prefixed sequences: strip any leading ESC.
             if seq and seq[0] == "\x1b":

--- a/src/ecli/ui/design.py
+++ b/src/ecli/ui/design.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/ui/design.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""ECLI Terminal UI Design System.
+
+A single, theme-driven layer that maps **semantic UI roles** (app header,
+panel surfaces, selection/focus states, table headers, footer key hints, ...)
+to concrete curses attributes resolved from the active theme palette.
+
+Panels and chrome should ask for a *role* (``design.attr("panel_selected")``)
+instead of reaching for raw colour keys, so the whole UI shares one design
+language and a theme change re-styles everything consistently.
+
+The underlying colour pairs are allocated by ``Ecli.init_colors`` from
+``ThemePalette.chrome_color_pairs`` / ``syntax_color_hex`` (see
+``ecli.utils.themes``); this module is the stable indirection between those
+``self.colors`` keys and the role vocabulary used by the renderers.
+"""
+
+from __future__ import annotations
+
+import curses
+from typing import Mapping
+
+
+#: Semantic role -> ``Ecli.colors`` key. Roles are the public vocabulary; the
+#: colour keys are the allocated curses pairs. A role with no key (or a missing
+#: key at runtime) falls back to a sensible default at lookup time.
+ROLE_COLOR_KEYS: dict[str, str] = {
+    # Application chrome
+    "app_header": "ui_header",
+    "app_header_accent": "ui_header_accent",
+    "app_header_dim": "ui_header_dim",
+    "menu_bar": "ui_header",
+    # Editor surface
+    "editor_bg": "default",
+    "editor_text": "default",
+    "gutter_bg": "line_number",
+    "gutter_text": "line_number",
+    "current_line": "ui_current_line",
+    "current_line_number": "ui_current_line_number",
+    # Panels / modals
+    "panel_bg": "ui_panel",
+    "panel_text": "ui_panel",
+    "panel_dim": "ui_panel_dim",
+    "panel_border": "ui_panel_border",
+    "panel_title": "ui_panel_title",
+    "panel_selected_bg": "ui_panel_selected",
+    "panel_selected_fg": "ui_panel_selected",
+    "panel_focus_border": "ui_panel_border",
+    "panel_accent": "ui_panel_title",
+    "panel_warning": "ui_panel_warning",
+    "panel_error": "ui_panel_error",
+    # Tables / lists
+    "table_header": "ui_panel_title",
+    "table_separator": "ui_panel_border",
+    # Status / footer
+    "status_bg": "ui_status",
+    "status_fg": "ui_status",
+    "status_accent": "ui_status_accent",
+    "footer_bg": "ui_footer",
+    "footer_fg": "ui_footer",
+    "key_hint": "ui_footer_key",
+    # Diagnostics / semantic
+    "warning": "ui_warning",
+    "error": "ui_error",
+    "success": "ui_success",
+    "info": "ui_info",
+    "git_dirty": "git_dirty",
+    "git_clean": "git_info",
+    "ai_warning": "ui_panel_warning",
+}
+
+#: Stable, documented role vocabulary (sorted for tests / discoverability).
+SEMANTIC_ROLES: tuple[str, ...] = tuple(sorted(ROLE_COLOR_KEYS))
+
+
+class TuiDesign:
+    """Resolves semantic UI roles to curses attributes from a colour map.
+
+    ``colors`` is the live ``Ecli.colors`` dict (role-agnostic curses pairs).
+    Lookups never raise: an unknown role or a colour key missing from a limited
+    terminal degrades to ``curses.A_NORMAL`` (or the caller's default).
+    """
+
+    def __init__(self, colors: Mapping[str, int]) -> None:
+        """Wrap a live ``Ecli.colors`` map for role-based attribute lookups."""
+        self._colors = colors
+
+    def attr(self, role: str, default: int = curses.A_NORMAL) -> int:
+        """Return the curses attribute for ``role`` (or ``default``)."""
+        key = ROLE_COLOR_KEYS.get(role)
+        if key is None:
+            return default
+        return self._colors.get(key, default)
+
+    def selected(self, focused: bool = True) -> int:
+        """Full-row selection attribute; reverse-video fallback when unfocused."""
+        if focused:
+            return self.attr("panel_selected_bg", curses.A_REVERSE | curses.A_BOLD)
+        return self.attr("panel_dim", curses.A_DIM)
+
+    def border(self, focused: bool = False) -> int:
+        """Panel border attribute, bolded when the panel is focused."""
+        base = self.attr("panel_border", curses.A_NORMAL)
+        return base | curses.A_BOLD if focused else base

--- a/src/ecli/ui/geometry.py
+++ b/src/ecli/ui/geometry.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/ui/geometry.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Deterministic terminal split-layout geometry (Midnight Commander discipline).
+
+A single source of truth for *where* the editor, a side panel, and the global
+header/status/footer live, so panels stop being ad-hoc overlays that collide
+with the bottom command/status rows.
+
+Vertical contract (full chrome):
+
+    row 0          global app header / menu bar
+    rows 1..H-3    main work area (editor left, side panel right)
+    row H-2        global status bar
+    row H-1        global command/footer strip
+
+A side panel occupies **only** the work-area rows (``1..H-3``) on the right; it
+never draws into row 0, ``H-2`` or ``H-1``. Horizontally the editor takes ~60%
+and the panel the remaining ~40%. When the terminal is too narrow to honour the
+minimum editor/panel widths, ``split`` is ``False`` and ``panel`` is ``None`` —
+the caller should fall back to a centered modal (or hide the panel with a
+warning).
+
+These constants intentionally mirror ``DrawScreen`` chrome heights so the editor
+and panels agree on the work-area rows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+#: Fraction of the width given to the editor when a side panel is open.
+EDITOR_FRACTION = 0.60
+#: Minimum usable widths before the split is refused (fall back to modal/hide).
+MIN_EDITOR_WIDTH = 30
+MIN_PANEL_WIDTH = 24
+#: Below this height the header/footer collapse (status line only) — matches
+#: ``DrawScreen.MIN_HEIGHT_FOR_FULL_CHROME``.
+MIN_HEIGHT_FOR_FULL_CHROME = 8
+HEADER_HEIGHT = 1
+STATUS_HEIGHT = 1
+FOOTER_HEIGHT = 1
+
+
+@dataclass(frozen=True)
+class Rect:
+    """A terminal rectangle: top-left ``(x, y)`` with ``width`` x ``height``."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+
+    @property
+    def right(self) -> int:
+        """Exclusive right edge (``x + width``)."""
+        return self.x + self.width
+
+    @property
+    def bottom(self) -> int:
+        """Exclusive bottom edge (``y + height``)."""
+        return self.y + self.height
+
+    def contains_cols(self, x0: int, x1: int) -> bool:
+        """True when the column span ``[x0, x1)`` fits inside this rect."""
+        return self.x <= x0 and x1 <= self.right
+
+    def contains(self, x: int, y: int) -> bool:
+        """True when the point ``(x, y)`` lies inside this rectangle."""
+        return self.x <= x < self.right and self.y <= y < self.bottom
+
+
+@dataclass(frozen=True)
+class LayoutGeometry:
+    """Resolved regions for a frame: header, editor, optional panel, chrome."""
+
+    terminal: Rect
+    header: Rect
+    editor: Rect
+    status: Rect
+    footer: Rect
+    panel: Rect | None
+    split: bool  # True when a real left/right split was produced
+
+
+def chrome_heights(height: int) -> tuple[int, int, int]:
+    """Return ``(header_h, status_h, footer_h)`` for a window height."""
+    if height < MIN_HEIGHT_FOR_FULL_CHROME:
+        return 0, STATUS_HEIGHT, 0
+    return HEADER_HEIGHT, STATUS_HEIGHT, FOOTER_HEIGHT
+
+
+def compute_layout(
+    width: int, height: int, active_panel: bool = False
+) -> LayoutGeometry:
+    """Compute the editor/panel/chrome rectangles for a terminal of ``W``x``H``.
+
+    With ``active_panel`` and enough width, the work area splits ~60/40 into an
+    editor region (left) and a panel region (right), both confined to the
+    work-area rows. If the terminal is too narrow, ``split`` is ``False`` and
+    ``panel`` is ``None`` (caller falls back to a modal or hides the panel).
+    """
+    width = max(0, width)
+    height = max(1, height)
+    header_h, status_h, footer_h = chrome_heights(height)
+    top = header_h
+    work_h = max(1, height - header_h - status_h - footer_h)
+
+    terminal = Rect(0, 0, width, height)
+    header = Rect(0, 0, width, header_h)
+    status = Rect(0, height - footer_h - status_h, width, status_h)
+    footer = Rect(0, height - footer_h, width, footer_h)
+    full_editor = Rect(0, top, width, work_h)
+
+    if not active_panel:
+        return LayoutGeometry(
+            terminal, header, full_editor, status, footer, panel=None, split=False
+        )
+
+    editor_w = int(width * EDITOR_FRACTION)
+    panel_w = width - editor_w
+    if (
+        editor_w < MIN_EDITOR_WIDTH
+        or panel_w < MIN_PANEL_WIDTH
+        or width < MIN_EDITOR_WIDTH + MIN_PANEL_WIDTH
+    ):
+        # Too narrow for a usable split: keep the editor full-width and let the
+        # caller present the panel as a centered modal (or hide it).
+        return LayoutGeometry(
+            terminal, header, full_editor, status, footer, panel=None, split=False
+        )
+
+    editor = Rect(0, top, editor_w, work_h)
+    panel = Rect(editor_w, top, panel_w, work_h)
+    return LayoutGeometry(
+        terminal, header, editor, status, footer, panel=panel, split=True
+    )
+
+
+def centered_modal_rect(
+    width: int, height: int, want_width: int, want_height: int
+) -> Rect:
+    """A centered modal rectangle clamped to fit inside the terminal chrome.
+
+    The modal never covers the global footer row (``H-1``) unless the terminal
+    is too small to leave room.
+    """
+    header_h, status_h, footer_h = chrome_heights(height)
+    avail_w = max(1, width - 2)
+    avail_h = max(1, height - header_h - status_h - footer_h)
+    w = max(1, min(want_width, avail_w))
+    h = max(1, min(want_height, avail_h))
+    x = max(0, (width - w) // 2)
+    y = max(header_h, (height - h) // 2)
+    # Keep the modal above the global status/footer when possible.
+    max_y = max(header_h, height - footer_h - status_h - h)
+    if max_y >= header_h:
+        y = min(y, max_y)
+    return Rect(x, y, w, h)

--- a/src/ecli/ui/mouse.py
+++ b/src/ecli/ui/mouse.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/ui/mouse.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Mouse model and hit-testing for the ECLI split-layout UI.
+
+This is the *architecture* layer for mouse support: a terminal-agnostic model
+(``MouseEvent``, ``MouseButton``, ``MouseAction``, ``FocusRegion``,
+``HitTarget``) plus pure functions (``hit_test``, ``decode_curses_mouse``) that
+turn a screen coordinate / curses button-state into an addressable region and a
+high-level action. It deliberately performs **no** editor mutation and triggers
+**no** action — the live handler in ``Ecli`` applies only safe, non-destructive
+intents (focus + scroll + selection) and remains opt-in.
+
+Every drawn region is addressable via the existing ``ecli.ui.geometry`` rects:
+editor, gutter, side panel, global header/status/footer, and centered modals.
+"""
+
+from __future__ import annotations
+
+import curses
+from dataclasses import dataclass
+from enum import Enum, IntEnum
+
+from ecli.ui.geometry import LayoutGeometry, Rect
+
+
+class MouseButton(IntEnum):
+    """Logical mouse buttons (wheel is modelled as up/down 'buttons')."""
+
+    NONE = 0
+    LEFT = 1
+    MIDDLE = 2
+    RIGHT = 3
+    WHEEL_UP = 4
+    WHEEL_DOWN = 5
+
+
+class MouseAction(Enum):
+    """High-level mouse action, decoded from raw curses button state."""
+
+    PRESS = "press"
+    RELEASE = "release"
+    CLICK = "click"
+    DOUBLE_CLICK = "double_click"
+    DRAG = "drag"
+    WHEEL = "wheel"
+    UNKNOWN = "unknown"
+
+
+class FocusRegion(Enum):
+    """Addressable UI regions a click can land in."""
+
+    EDITOR = "editor"
+    GUTTER = "gutter"
+    PANEL = "panel"
+    HEADER = "header"
+    STATUS = "status"
+    FOOTER = "footer"
+    MODAL = "modal"
+    OUTSIDE = "outside"
+
+
+@dataclass(frozen=True)
+class MouseEvent:
+    """A decoded mouse event in absolute terminal coordinates."""
+
+    x: int
+    y: int
+    button: MouseButton
+    action: MouseAction
+
+    @property
+    def is_wheel(self) -> bool:
+        """True for wheel-scroll events."""
+        return self.action is MouseAction.WHEEL
+
+    @property
+    def wheel_delta(self) -> int:
+        """+1 to scroll up, -1 to scroll down, 0 if not a wheel event."""
+        if self.button is MouseButton.WHEEL_UP:
+            return 1
+        if self.button is MouseButton.WHEEL_DOWN:
+            return -1
+        return 0
+
+
+@dataclass(frozen=True)
+class HitTarget:
+    """Result of hit-testing: which region, its rect, and local coordinates."""
+
+    region: FocusRegion
+    rect: Rect | None
+    local_x: int
+    local_y: int
+
+
+def _bit(name: str) -> int:
+    """Resolve a curses mouse-state constant, or 0 when unavailable."""
+    return int(getattr(curses, name, 0) or 0)
+
+
+def decode_curses_mouse(bstate: int) -> tuple[MouseButton, MouseAction]:
+    """Decode a curses ``getmouse`` button-state bitmask defensively.
+
+    Unknown / unsupported states (e.g. terminals without wheel reporting) map to
+    ``(NONE, UNKNOWN)`` so callers never crash. Wheel is detected first because
+    several terminals report it via BUTTON4/BUTTON5 press bits.
+    """
+    if bstate & _bit("BUTTON4_PRESSED"):
+        return MouseButton.WHEEL_UP, MouseAction.WHEEL
+    if bstate & _bit("BUTTON5_PRESSED"):
+        return MouseButton.WHEEL_DOWN, MouseAction.WHEEL
+
+    actions = (
+        ("DOUBLE_CLICKED", MouseAction.DOUBLE_CLICK),
+        ("CLICKED", MouseAction.CLICK),
+        ("PRESSED", MouseAction.PRESS),
+        ("RELEASED", MouseAction.RELEASE),
+    )
+    for button, prefix in (
+        (MouseButton.LEFT, "BUTTON1"),
+        (MouseButton.MIDDLE, "BUTTON2"),
+        (MouseButton.RIGHT, "BUTTON3"),
+    ):
+        for suffix, mapped in actions:
+            if bstate & _bit(f"{prefix}_{suffix}"):
+                return button, mapped
+
+    return MouseButton.NONE, MouseAction.UNKNOWN
+
+
+def hit_test(
+    geometry: LayoutGeometry,
+    x: int,
+    y: int,
+    *,
+    gutter_width: int = 0,
+    modal_rect: Rect | None = None,
+) -> HitTarget:
+    """Map an absolute ``(x, y)`` to a UI region using the layout geometry.
+
+    When ``modal_rect`` is given, a point inside it is ``MODAL`` and a point
+    outside is ``OUTSIDE`` (so the caller can implement click-outside-to-close).
+    Otherwise the global header/status/footer, the side panel (if any) and the
+    editor (split into ``GUTTER`` / ``EDITOR``) are tested in z-order.
+    """
+
+    def target(region: FocusRegion, rect: Rect | None) -> HitTarget:
+        if rect is None:
+            return HitTarget(region, None, x, y)
+        return HitTarget(region, rect, x - rect.x, y - rect.y)
+
+    if modal_rect is not None:
+        inside = modal_rect.contains(x, y)
+        return target(
+            *(
+                (FocusRegion.MODAL, modal_rect)
+                if inside
+                else (FocusRegion.OUTSIDE, None)
+            )
+        )
+
+    chrome = (
+        (FocusRegion.HEADER, geometry.header),
+        (FocusRegion.STATUS, geometry.status),
+        (FocusRegion.FOOTER, geometry.footer),
+        (FocusRegion.PANEL, geometry.panel),
+    )
+    for region, rect in chrome:
+        if rect is not None and rect.height and rect.contains(x, y):
+            return target(region, rect)
+
+    if geometry.editor.contains(x, y):
+        in_gutter = bool(gutter_width) and x < geometry.editor.x + gutter_width
+        region = FocusRegion.GUTTER if in_gutter else FocusRegion.EDITOR
+        return target(region, geometry.editor)
+    return target(FocusRegion.OUTSIDE, None)

--- a/src/ecli/ui/panels.py
+++ b/src/ecli/ui/panels.py
@@ -49,6 +49,7 @@ import shlex
 import shutil
 import textwrap
 import threading
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -56,6 +57,8 @@ import pyperclip
 from wcwidth import wcswidth
 
 from ecli.integrations.GitBridge import GitBridge, GitCommandResult
+from ecli.ui.design import TuiDesign
+from ecli.ui.geometry import centered_modal_rect, compute_layout
 from ecli.services.models.doctor import DoctorContext, DoctorFinding
 from ecli.services.models.plan import CommandPlan
 from ecli.utils.logging_config import logger
@@ -67,15 +70,55 @@ if TYPE_CHECKING:
 CursesWindow = Any
 
 
+# --- Panel-type vocabulary (split-layout architecture) ---------------------
+# All *side* panels are generic consumers of the same split-layout contract:
+# the 60/40 editor/panel split (ecli.ui.geometry.compute_layout), an opaque
+# themed panel surface, the border/title/footer system, the no-overlap rule
+# with the global status/footer, the F12 focus model, Esc-to-close, the theme
+# roles, and resize-safe clipping (BasePanel._layout_window).
+#
+# ``"terminal"`` is RESERVED here for a future Terminal Panel. It is documented
+# now so the layout/panel architecture explicitly supports it, but it is NOT
+# implemented in this pass (no PTY, no subprocess, no terminal UI). A future
+# ``TerminalPanel(BasePanel)`` only needs ``panel_kind = "terminal"`` and
+# ``is_modal_panel = False`` to inherit the entire split layout.
+SIDE_PANEL_KINDS: frozenset[str] = frozenset(
+    {
+        "file_manager",
+        "git_control",
+        "system_doctor",
+        "ai_provider",
+        "command_plan",
+        "services",
+        "terminal",  # reserved — future Terminal Panel (F11), not implemented yet
+    }
+)
+#: Centered modal panels (Help, dialogs); not part of the side-panel split.
+MODAL_PANEL_KINDS: frozenset[str] = frozenset({"help", "confirm", "info"})
+
+
 # ==================== BasePanel Class (Non-Blocking) ====================
 class BasePanel:
-    """A base class for non-blocking, interactive UI panels in the ECLI editor."""
+    """A base class for non-blocking, interactive UI panels in the ECLI editor.
+
+    Side panels (``is_modal_panel = False``) are generic consumers of the
+    split-layout system: ``_layout_window`` places them in the right 40% work
+    area without overlapping the global header/status/footer. A future Terminal
+    Panel (``panel_kind = "terminal"``) will reuse this unchanged — see
+    ``SIDE_PANEL_KINDS``.
+    """
 
     # Shift + Arrow key codes
     key_s_up = getattr(curses, "KEY_SR", 337)
     key_s_down = getattr(curses, "KEY_SF", 336)
     key_s_left = getattr(curses, "KEY_SLEFT", 393)
     key_s_right = getattr(curses, "KEY_SRIGHT", 402)
+
+    #: Panel-type identifier (one of SIDE_PANEL_KINDS / MODAL_PANEL_KINDS).
+    panel_kind: str = "generic"
+
+    #: Side panels occupy the right 40% work area; modal panels are centered.
+    is_modal_panel: bool = False
 
     def __init__(
         self, stdscr: CursesWindow, main_editor_instance: Ecli, **kwargs: Any
@@ -86,7 +129,39 @@ class BasePanel:
         self.visible: bool = False
         self.term_height, self.term_width = self.stdscr.getmaxyx()
         self.win: Optional[CursesWindow] = None
+        self._rendered_as_modal: bool = False
         logger.debug(f"Base class initialized for panel '{self.__class__.__name__}'.")
+
+    def _layout_window(
+        self, modal_width: int = 80, modal_height: int = 24
+    ) -> CursesWindow:
+        """Create the panel's backing window from the split-layout geometry.
+
+        Side panels are placed in the right work-area region (rows ``1..H-3``)
+        so they never collide with the global header/status/footer. When the
+        terminal is too narrow for a split (or the panel is modal), a centered
+        modal rectangle is used instead. The created window is opaque.
+        """
+        self.term_height, self.term_width = self.stdscr.getmaxyx()
+        geo = compute_layout(self.term_width, self.term_height, active_panel=True)
+        if self.is_modal_panel or geo.panel is None:
+            rect = centered_modal_rect(
+                self.term_width, self.term_height, modal_width, modal_height
+            )
+            self._rendered_as_modal = True
+        else:
+            rect = geo.panel
+            self._rendered_as_modal = False
+
+        self.start_x = rect.x
+        self.start_y = rect.y
+        self.width = rect.width
+        self.height = rect.height
+        win = curses.newwin(rect.height, rect.width, rect.y, rect.x)
+        win.keypad(True)
+        self.win = win
+        self._make_opaque(win)
+        return win
 
     def resize(self) -> None:
         """Recalculates terminal dimensions. Must be implemented in subclasses."""
@@ -110,6 +185,120 @@ class BasePanel:
         raise NotImplementedError(
             "The 'draw' method must be implemented in a child class."
         )
+
+    def scroll_by(self, delta: int) -> bool:
+        """Scroll the panel content by ``delta`` rows (wheel; +1 = up).
+
+        Non-destructive: adjusts a ``scroll`` offset or a list ``idx`` if the
+        panel has one. Returns True when the view changed.
+        """
+        scroll = getattr(self, "scroll", None)
+        if isinstance(scroll, int):
+            new = max(0, scroll - delta)
+            if new != scroll:
+                self.scroll = new
+                return True
+            return False
+        idx = getattr(self, "idx", None)
+        entries = getattr(self, "entries", None)
+        if isinstance(idx, int) and entries:
+            new = max(0, min(len(entries) - 1, idx - delta))
+            if new != idx:
+                self.idx = new
+                return True
+        return False
+
+    def _panel_bg_attr(self) -> int:
+        """Opaque, themed background attribute for this panel's window."""
+        return self.editor.colors.get("ui_panel", curses.A_REVERSE)
+
+    def _panel_border_attr(self, focused: bool = False) -> int:
+        """Single source of truth for panel border styling.
+
+        Every panel/modal resolves its border through this one role
+        (``panel_border``) and focus convention, so borders share one
+        thickness, one colour role and one style — no per-panel ad-hoc curses
+        pairs and no mixed border colours between panels. A deliberate severity
+        state must come from a design-system role, not a hardcoded local pair.
+        """
+        return TuiDesign(self.editor.colors).border(focused)
+
+    def _draw_panel_frame(
+        self,
+        win: Optional[CursesWindow],
+        title: str = "",
+        *,
+        focused: bool = False,
+        footer: str = "",
+    ) -> None:
+        """Draw the shared panel frame used by every panel and modal.
+
+        One single-thickness border in the ``panel_border`` role, the title
+        embedded into the top edge (``panel_title`` role) and an optional footer
+        label embedded into the bottom edge of the panel's own window — never
+        into the global footer, since the window is bounded by ``_layout_window``
+        to rows ``1..H-3``.
+        """
+        if win is None:
+            return
+        try:
+            h, w = win.getmaxyx()
+        except (curses.error, AttributeError):
+            return
+        border_attr = self._panel_border_attr(focused)
+        title_attr = self.editor.colors.get("ui_panel_title", border_attr)
+        try:
+            win.attron(border_attr)
+            win.border()
+            win.attroff(border_attr)
+        except curses.error:
+            pass
+        if title and w > 6:
+            label = f" {title.strip()} "[: max(0, w - 4)]
+            try:
+                win.addstr(0, 2, label, title_attr)
+            except curses.error:
+                pass
+        if footer and h >= 2 and w > 6:
+            label = f" {footer.strip()} "[: max(0, w - 4)]
+            try:
+                win.addstr(h - 1, 2, label, border_attr)
+            except curses.error:
+                pass
+
+    def _make_opaque(self, win: Optional[CursesWindow]) -> None:
+        """Give *win* a solid themed background so it never shows ghosting.
+
+        Setting ``bkgd`` makes ``erase`` fill every cell with the panel surface
+        colour (not transparent spaces), so no editor text bleeds through.
+        """
+        if win is None or not hasattr(win, "bkgd"):
+            return
+        try:
+            win.bkgd(" ", self._panel_bg_attr())
+        except curses.error:
+            pass
+
+    def _present(self, win: Optional[CursesWindow]) -> None:
+        """Refresh *win*, forcing a full re-copy to defeat overlay ghosting.
+
+        ``touchwin`` marks every cell dirty so ``noutrefresh`` re-copies the
+        whole panel over the editor, instead of skipping cells curses thinks are
+        unchanged (which is how editor text bled through on redraw).
+        """
+        if win is None:
+            return
+        if hasattr(win, "touchwin"):
+            try:
+                win.touchwin()
+            except curses.error:
+                pass
+        refresh = getattr(win, "noutrefresh", None) or getattr(win, "refresh", None)
+        if refresh is not None:
+            try:
+                refresh()
+            except curses.error:
+                pass
 
     def handle_key(self, key: Any) -> bool:
         """Handles a single key press event directed to the panel.
@@ -191,13 +380,9 @@ class AiResponsePanel(BasePanel):
         raw = kwargs.get("content", "(no data)")
         self.lines: list[str] = raw.splitlines() or [""]
 
-        self.width = int(self.term_width * 0.40)
-        self.height = self.term_height - 1
-        self.start_x = self.term_width - self.width
-        self.start_y = 0
-
-        self.win = curses.newwin(self.height, self.width, self.start_y, self.start_x)
-        self.win.keypad(True)
+        # Side-panel geometry (right 40% work area; never overlaps global chrome).
+        self.panel_kind = "ai_provider"
+        self._layout_window(modal_width=72, modal_height=22)
 
         self.cursor_y = 0
         self.cursor_x = 0
@@ -215,12 +400,7 @@ class AiResponsePanel(BasePanel):
     def resize(self) -> None:
         """Handle terminal resize by recalculating dimensions and recreating the window."""
         super().resize()
-        self.width = int(self.term_width * 0.40)
-        self.height = self.term_height - 1
-        self.start_x = self.term_width - self.width
-        self.start_y = 0
-        self.win = curses.newwin(self.height, self.width, self.start_y, self.start_x)
-        self.win.keypad(True)
+        self._layout_window(modal_width=72, modal_height=22)
 
     def _init_colors(self) -> None:
         """Initializes curses color pairs specific to this panel.
@@ -408,7 +588,7 @@ class AiResponsePanel(BasePanel):
 
             # If there's no space to draw, exit early.
             if viewport_height <= 0 or wrap_width <= 0:
-                self.win.noutrefresh()
+                self._present(self.win)
                 return
 
             # --- Calculate line wrapping and cursor position ---
@@ -441,7 +621,7 @@ class AiResponsePanel(BasePanel):
                     self._draw_cursor(row_y, visual_cursor_x, chunk)
 
             # Stage the changes for the next screen update without blocking.
-            self.win.noutrefresh()
+            self._present(self.win)
 
         except curses.error as e:
             # Catch any unexpected curses errors during the draw cycle to prevent a crash.
@@ -812,11 +992,8 @@ class FileBrowserPanel(BasePanel):
             **kwargs: Catches any additional keyword arguments.
         """
         super().__init__(stdscr, main_editor_instance, **kwargs)
-        self.width = int(self.term_width * 0.40)
-        self.height = self.term_height - 1
-        self.start_x = self.term_width - self.width
-        self.win = curses.newwin(self.height, self.width, 0, self.start_x)
-        self.win.keypad(True)
+        self.panel_kind = "file_manager"
+        self._layout_window()  # right 40% work area; no global-chrome overlap
         self.cwd = Path(start_path or os.getcwd()).resolve()
         self.entries: list[Optional[os.DirEntry]] = []
         self.idx = 0
@@ -831,11 +1008,7 @@ class FileBrowserPanel(BasePanel):
     def resize(self) -> None:
         """Handle terminal resize by recalculating dimensions and recreating the window."""
         super().resize()
-        self.width = int(self.term_width * 0.40)
-        self.height = self.term_height - 1
-        self.start_x = self.term_width - self.width
-        self.win = curses.newwin(self.height, self.width, 0, self.start_x)
-        self.win.keypad(True)
+        self._layout_window()
 
     def set_git_panel(self, git_panel: GitPanel) -> None:
         """Sets a link to GitPanel for integration."""
@@ -997,116 +1170,243 @@ class FileBrowserPanel(BasePanel):
         attr = self.editor.colors.get(color_key, 0) if color_key else 0
         return prefix, attr
 
+    # --- Midnight Commander-style rendering ----------------------------
+    @staticmethod
+    def _format_size(num: int) -> str:
+        """Human-readable file size in <=6 chars (e.g. '4.2K', '1.1M')."""
+        size = float(num)
+        for unit in ("B", "K", "M", "G", "T"):
+            if size < 1024 or unit == "T":
+                if unit == "B":
+                    return f"{int(size)}{unit}"
+                return f"{size:.1f}{unit}"
+            size /= 1024
+        return f"{int(size)}T"
+
+    @staticmethod
+    def _format_mtime(ts: float) -> str:
+        """Compact modified time: 'HH:MM' today, else 'MMM DD' / 'YYYY-MM-DD'."""
+        when = datetime.fromtimestamp(ts)
+        now = datetime.now()
+        if when.year != now.year:
+            return when.strftime("%Y-%m-%d")
+        if (now - when).days < 1 and when.day == now.day:
+            return when.strftime("%H:%M")
+        return when.strftime("%b %d")
+
+    def _is_dir(self, entry: Optional[os.DirEntry]) -> bool:
+        if entry is None:
+            return True
+        try:
+            return entry.is_dir(follow_symlinks=False)
+        except OSError:
+            return False
+
+    def _entry_meta(self, entry: Optional[os.DirEntry]) -> tuple[str, str, str]:
+        """Return (display_name, size_str, mtime_str) for a list entry."""
+        if entry is None:
+            return ("..", "", "")
+        is_dir = self._is_dir(entry)
+        name = entry.name + ("/" if is_dir else "")
+        try:
+            st = entry.stat(follow_symlinks=False)
+            size_str = "<DIR>" if is_dir else self._format_size(st.st_size)
+            mtime_str = self._format_mtime(st.st_mtime)
+        except OSError:
+            size_str, mtime_str = ("<DIR>" if is_dir else "—"), "—"
+        return (name, size_str, mtime_str)
+
+    def _git_marker(self, entry: Optional[os.DirEntry]) -> tuple[str, str]:
+        """Return (1-char git status marker, color_key) for an entry."""
+        prefix, _attr = self._get_git_entry_info(entry)
+        prefix = (prefix or " ")[:1]
+        key = {"M": "git_dirty", "?": "git_clean", "A": "git_clean", "D": "error"}.get(
+            prefix.strip(), "panel_dim"
+        )
+        return prefix, key
+
+    def _column_widths(self, inner: int) -> tuple[int, int, int]:
+        """Return (name_w, size_w, mod_w); drops columns on narrow panels."""
+        usable = inner - 2  # git marker + trailing margin
+        if usable >= 40:
+            size_w, mod_w = 7, 12
+        elif usable >= 26:
+            size_w, mod_w = 7, 0
+        else:
+            size_w, mod_w = 0, 0
+        gaps = (1 if size_w else 0) + (1 if mod_w else 0)
+        name_w = max(4, usable - size_w - mod_w - gaps)
+        return name_w, size_w, mod_w
+
+    def hit_entry_index(self, local_y: int) -> Optional[int]:
+        """Map a panel-local row (0-based) to the entry index it shows.
+
+        Returns ``None`` for clicks on the title/header/footer rows or empty
+        list area. Pure given the geometry recorded by the last ``draw``; never
+        opens or mutates anything — selection only.
+        """
+        list_top = getattr(self, "_list_first_row", 2)
+        list_bottom = getattr(self, "_list_last_row", self.height - 3)
+        if not (list_top <= local_y < list_bottom):
+            return None
+        idx = getattr(self, "_visible_top", 0) + (local_y - list_top)
+        if 0 <= idx < len(self.entries):
+            return idx
+        return None
+
     def draw(self) -> None:
-        """Draws the file browser's interface, including files, folders, and Git statuses."""
+        """Draw the MC-style file browser: breadcrumb, columns, full-row selection."""
         if not self.visible or self.win is None:
             if self.win is None:
                 logger.error("FileBrowserPanel.draw() called, but self.win is None.")
             return
-
-        # Guard clause: If the panel window is too small after a resize,
-        # abort drawing to prevent a curses error.
-        # A height/width of 4 is a safe minimum for borders and some content.
-        if self.height < 4 or self.width < 4:
+        if self.height < 6 or self.width < 10:
             return
 
-        self.win.erase()
+        d = TuiDesign(self.editor.colors)
         is_focused = self.editor.focus == "panel"
-        self._draw_frame(is_focused)
+        inner = self.width - 2
 
-        logger.debug(f"Drawing FileBrowserPanel, git_panel is: {self.git_panel}")
+        self.win.erase()
+        self._draw_frame(is_focused, d)
 
-        # The viewport height for listing files, accounting for top/bottom chrome.
-        viewport_h = self.height - 4
-        top = max(0, self.idx - viewport_h + 1) if self.idx >= viewport_h else 0
+        name_w, size_w, mod_w = self._column_widths(inner)
+        name_x, size_x = 3, 3 + name_w + 1
+        mod_x = size_x + size_w + 1
 
-        for n, entry in enumerate(self.entries[top : top + viewport_h]):
-            row = n + 1
-            # Ensure we don't try to draw outside the allocated vertical space.
-            if row >= self.height - 2:
-                break
-
-            is_selected = (top + n) == self.idx
-            is_dir = entry is None or entry.is_dir()
-            base_attr = self.attr_dir if is_dir else self.attr_file
-
-            if entry is None:
-                label = "/.."
-            else:
-                prefix, git_attr = self._get_git_entry_info(entry)
-                base_attr |= git_attr
-                icon = "📂" if is_dir else self._icon(entry.name)
-                dir_slash = "/" if is_dir else ""
-                label = f" {prefix} {icon} {entry.name}{dir_slash}"
-
-            # Correctly combine attributes for the final display.
-            final_attr = base_attr | (
-                self.attr_sel if is_selected and is_focused else 0
-            )
-
-            try:
-                # Use addnstr to prevent writing past the edge of the window.
-                self.win.addnstr(row, 1, label, self.width - 2, final_attr)
-            except curses.error:
-                # Silently fail if curses has an issue with this specific line.
-                pass
-
-        # --- Footer section ---
-        sep_y = self.height - 3
-
-        # Use a more robust method to draw the horizontal line that is less
-        # prone to errors on different terminal emulators or with edge-case dimensions.
+        # Column header row.
+        header_attr = d.attr("table_header", self.attr_dim)
         try:
-            # Combine the line character and its attribute into a single value before drawing.
-            char_with_attr = curses.ACS_HLINE | self.attr_border
-            # Use the 4-argument version of hline, which is generally more stable.
-            self.win.hline(sep_y, 1, char_with_attr, self.width - 2)
+            self.win.addnstr(1, 1, " " * inner, inner, header_attr)
+            self.win.addnstr(1, name_x, "Name"[:name_w], name_w, header_attr)
+            if size_w:
+                self.win.addnstr(1, size_x, "Size".rjust(size_w), size_w, header_attr)
+            if mod_w:
+                self.win.addnstr(1, mod_x, "Modified"[:mod_w], mod_w, header_attr)
         except curses.error:
-            # If drawing the line still fails (e.g., due to extreme dimensions),
-            # just skip it to prevent a crash.
             pass
 
-        hint_line1 = "F2:NewFile F3:NewFld F5:Copy F6:Rename Del:Delete"
-        hint_line2 = "F10/q:Close F12:Focus Enter:Open"
+        # File list with full-row selection.
+        list_top, list_bottom = 2, self.height - 3
+        viewport_h = max(0, list_bottom - list_top)
+        top = (
+            max(0, self.idx - viewport_h + 1)
+            if viewport_h and self.idx >= viewport_h
+            else 0
+        )
+        # Remember the list geometry so a mouse click can be mapped to an entry.
+        self._list_first_row = list_top
+        self._list_last_row = list_bottom
+        self._visible_top = top
+        sel_attr = d.selected(is_focused)
+        dir_attr = d.attr("panel_accent", self.attr_dir)
+        file_attr = d.attr("panel_text", self.attr_file)
+        dim_attr = d.attr("panel_dim", self.attr_dim)
 
-        # Only draw hint lines if they fit within the panel's current width.
-        if len(hint_line1) < self.width - 2:
-            self.win.addnstr(
-                self.height - 2, 2, hint_line1, self.width - 4, self.attr_dim
-            )
-        if len(hint_line2) < self.width - 2:
-            self.win.addnstr(self.height - 1, 2, hint_line2, self.attr_dim)
+        for n, entry in enumerate(self.entries[top : top + viewport_h]):
+            gi = top + n
+            row_y = list_top + n
+            is_selected = gi == self.idx
+            is_dir = self._is_dir(entry)
+            name, size_str, mtime_str = self._entry_meta(entry)
+            gchar, gkey = self._git_marker(entry)
 
-        self.win.noutrefresh()
+            row_bg = sel_attr if is_selected else file_attr
+            name_attr = sel_attr if is_selected else (dir_attr if is_dir else file_attr)
+            meta_attr = sel_attr if is_selected else dim_attr
+            git_attr = sel_attr if is_selected else d.attr(gkey, dim_attr)
+            try:
+                self.win.addnstr(row_y, 1, " " * inner, inner, row_bg)  # full-row
+                self.win.addnstr(row_y, 1, gchar, 1, git_attr)
+                self.win.addnstr(row_y, name_x, name, name_w, name_attr)
+                if size_w:
+                    self.win.addnstr(
+                        row_y, size_x, size_str.rjust(size_w)[:size_w], size_w, meta_attr
+                    )
+                if mod_w:
+                    self.win.addnstr(row_y, mod_x, mtime_str[:mod_w], mod_w, meta_attr)
+            except curses.error:
+                pass
 
-    def _draw_frame(self, is_focused: bool) -> None:
-        """Draws the panel's border and title.
+        self._draw_status_line(self.height - 2, inner, d)
+        self._draw_action_bar(self.height - 1, inner, d)
+        self._present(self.win)  # touchwin + noutrefresh: opaque, no ghosting
 
-        The border style is intensified if the panel currently has focus. The
-        title displays the current working directory, truncating it if necessary
-        to fit the panel's width.
+    def _draw_status_line(self, y: int, inner: int, d: TuiDesign) -> None:
+        """Metadata line for the selected entry (name · type · size · modified)."""
+        attr = d.attr("panel_dim", self.attr_dim)
+        entry = (
+            self.entries[self.idx]
+            if self.entries and 0 <= self.idx < len(self.entries)
+            else None
+        )
+        name, size_str, mtime_str = self._entry_meta(entry)
+        kind = "dir" if self._is_dir(entry) else "file"
+        parts = [name.rstrip("/")]
+        parts.append(kind)
+        if size_str and size_str != "<DIR>":
+            parts.append(size_str)
+        if mtime_str and mtime_str != "—":
+            parts.append(mtime_str)
+        line = " " + " · ".join(parts)
+        try:
+            self.win.addnstr(y, 1, " " * inner, inner, attr)
+            self.win.addnstr(y, 1, line, inner, attr)
+        except curses.error:
+            pass
 
-        Args:
-            is_focused: True if the panel is the active input target.
-        """
+    def _draw_action_bar(self, y: int, inner: int, d: TuiDesign) -> None:
+        """Bottom action bar with compact, themed function-key hints."""
+        bar = d.attr("panel_bg", self.attr_dim)
+        key = d.attr("panel_accent", curses.A_BOLD)
+        try:
+            self.win.addnstr(y, 1, " " * inner, inner, bar)
+        except curses.error:
+            pass
+        hints = [
+            ("F2", "New"),
+            ("F3", "Dir"),
+            ("F5", "Copy"),
+            ("F6", "Ren"),
+            ("Del", "Del"),
+            ("Enter", "Open"),
+            ("F10", "Close"),
+        ]
+        x = 1
+        for k, label in hints:
+            seg = f"{k} {label} "
+            if x + wcswidth(seg) >= inner + 1:
+                break
+            try:
+                self.win.addnstr(y, x, k, len(k), key)
+                self.win.addnstr(y, x + len(k), f" {label} ", len(label) + 2, bar)
+            except curses.error:
+                break
+            x += wcswidth(seg)
+
+    def _draw_frame(self, is_focused: bool, d: TuiDesign | None = None) -> None:
+        """Draw the panel border with the current directory embedded as title."""
         assert self.win is not None, "self.win should not be None when drawing frame"
+        if d is None:
+            d = TuiDesign(self.editor.colors)
+        border_attr = d.border(is_focused)
+        title_attr = d.attr("panel_title", border_attr)
 
-        border_attr = self.attr_border
-        if is_focused:
-            border_attr |= curses.A_BOLD
+        # Breadcrumb: shortened current directory path.
+        path = str(self.cwd)
+        max_title = max(3, self.width - 6)
+        if wcswidth(path) > max_title:
+            path = "…" + path[-(max_title - 1) :]
+        title_display = f" {path} "
 
-        title_text = str(self.cwd)
-        title_len = wcswidth(title_text)
-        if title_len > self.width - 4:
-            title_text = "..." + title_text[-(self.width - 7) :]
-        title_display = f" {title_text} "
         self.win.attron(border_attr)
         self.win.border()
-        if wcswidth(title_display) < self.width - 2:
-            self.win.addstr(
-                0, max(1, (self.width - wcswidth(title_display)) // 2), title_display
-            )
         self.win.attroff(border_attr)
+        if wcswidth(title_display) <= self.width - 2:
+            try:
+                self.win.addnstr(0, 2, title_display, self.width - 4, title_attr)
+            except curses.error:
+                pass
 
     def _enter_selected(self) -> None:
         """Handles the 'Enter' key press on the currently selected item.
@@ -1391,35 +1691,33 @@ class _ReadOnlyRightPanel(BasePanel):
     """Shared right-side panel chrome for read-only service views."""
 
     title = " Service Panel "
+    panel_kind = "services"
     close_key = getattr(curses, "KEY_F8", 272)
 
     def __init__(
         self, stdscr: CursesWindow, main_editor_instance: Ecli, **kwargs: Any
     ) -> None:
         super().__init__(stdscr, main_editor_instance, **kwargs)
-        self.width = int(self.term_width * 0.45)
-        self.height = self.term_height - 1
-        self.start_x = self.term_width - self.width
-        self.win = curses.newwin(self.height, self.width, 0, self.start_x)
-        self.win.keypad(True)
+        self._layout_window()  # right 40% work area; no global-chrome overlap
         self.scroll = 0
         self.registry = kwargs.get("registry")
-        self.attr_border = self.editor.colors.get("status", curses.A_BOLD)
-        self.attr_title = self.editor.colors.get("function", curses.A_BOLD)
-        self.attr_text = self.editor.colors.get("default", curses.A_NORMAL)
-        self.attr_dim = self.editor.colors.get("comment", curses.A_DIM)
-        self.attr_selected = curses.A_REVERSE | curses.A_BOLD
-        self.attr_warning = self.editor.colors.get("warning", curses.A_BOLD)
-        self.attr_error = self.editor.colors.get("error", curses.A_BOLD)
+        # Panel chrome uses the solid panel-surface colour roles so the modal is
+        # opaque and themed (no transparent overlay, no ghosting).
+        self.attr_panel = self.editor.colors.get("ui_panel", curses.A_REVERSE)
+        self.attr_border = self.editor.colors.get("ui_panel_border", self.attr_panel)
+        self.attr_title = self.editor.colors.get("ui_panel_title", curses.A_BOLD)
+        self.attr_text = self.attr_panel
+        self.attr_dim = self.editor.colors.get("ui_panel_dim", self.attr_panel)
+        self.attr_selected = self.editor.colors.get(
+            "ui_panel_selected", curses.A_REVERSE | curses.A_BOLD
+        )
+        self.attr_warning = self.editor.colors.get("ui_panel_warning", curses.A_BOLD)
+        self.attr_error = self.editor.colors.get("ui_panel_error", curses.A_BOLD)
 
     def resize(self) -> None:
         """Handle terminal resize by recreating the backing panel window."""
         super().resize()
-        self.width = int(self.term_width * 0.45)
-        self.height = self.term_height - 1
-        self.start_x = self.term_width - self.width
-        self.win = curses.newwin(self.height, self.width, 0, self.start_x)
-        self.win.keypad(True)
+        self._layout_window()
 
     def open(self) -> None:
         """Open the read-only panel and hide the editor cursor."""
@@ -1498,13 +1796,8 @@ class _ReadOnlyRightPanel(BasePanel):
         return False
 
     def _refresh_window(self) -> None:
-        try:
-            if hasattr(self.win, "noutrefresh"):
-                self.win.noutrefresh()
-            else:
-                self.win.refresh()
-        except curses.error:
-            pass
+        # touchwin forces a full re-copy so the editor never bleeds through.
+        self._present(self.win)
 
     def _service_registry(self) -> Any:
         if self.registry is not None:
@@ -1521,6 +1814,7 @@ class SystemDoctorPanel(_ReadOnlyRightPanel):
     """Read-only right-side panel for structured SystemDoctor findings."""
 
     title = " System Doctor "
+    panel_kind = "system_doctor"
 
     def __init__(
         self, stdscr: CursesWindow, main_editor_instance: Ecli, **kwargs: Any
@@ -1654,6 +1948,7 @@ class CommandPlanPanel(_ReadOnlyRightPanel):
     """Preview-only right-side panel for draft CommandPlan objects."""
 
     title = " Command Plans "
+    panel_kind = "command_plan"
 
     def __init__(
         self, stdscr: CursesWindow, main_editor_instance: Ecli, **kwargs: Any
@@ -1869,12 +2164,9 @@ class GitPanel(BasePanel):
         """Initialize GitPanel with given curseswindow and editor instance."""
         super().__init__(stdscr, main_editor_instance, **kwargs)
         logger.debug("GitPanel: Initializing...")
+        self.panel_kind = "git_control"
 
-        self.width = int(self.term_width * 0.50)
-        self.height = self.term_height - 1
-        self.start_x = self.term_width - self.width
-        self.win = curses.newwin(self.height, self.width, 0, self.start_x)
-        self.win.keypad(True)
+        self._layout_window()  # right 40% work area; no global-chrome overlap
 
         if main_editor_instance.git is None:
             raise ValueError(
@@ -1935,11 +2227,7 @@ class GitPanel(BasePanel):
     def resize(self) -> None:
         """Handle terminal resize by recalculating dimensions and recreating the window."""
         super().resize()
-        self.width = int(self.term_width * 0.50)
-        self.height = self.term_height - 1
-        self.start_x = self.term_width - self.width
-        self.win = curses.newwin(self.height, self.width, 0, self.start_x)
-        self.win.keypad(True)
+        self._layout_window()  # right 40% work area; no global-chrome overlap
 
     def _init_colors(self) -> None:
         """Uses centralized colors from the editor."""
@@ -2570,7 +2858,7 @@ class GitPanel(BasePanel):
             # 7. Finalize Frame
             # Stage all the drawing changes to the virtual screen (buffer).
             # The physical terminal screen will be updated in the main loop's `curses.doupdate()`.
-            self.win.noutrefresh()
+            self._present(self.win)
 
         except curses.error as e:
             # Catch any other unexpected curses errors during the draw cycle to prevent a crash.

--- a/src/ecli/ui/textops.py
+++ b/src/ecli/ui/textops.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/ui/textops.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Central, pure text utilities for copy / paste / selection.
+
+These are the single source of truth for turning a buffer selection into
+clipboard text (buffer content only — never UI chrome / line numbers / borders)
+and for sanitising pasted text (strip bracketed-paste and ANSI control
+sequences, normalise newlines) while preserving valid Unicode. They are
+deliberately free of curses / editor state so they can be unit-tested directly.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+# Bracketed-paste markers, then OSC, then CSI (SGR/cursor/etc.), then 2-char
+# escapes. Stripping order matters so multi-byte sequences are removed whole.
+_BRACKETED_PASTE = re.compile(r"\x1b\[20[01]~")
+_ANSI_OSC = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+_ANSI_CSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_ANSI_TWO_CHAR = re.compile(r"\x1b[@-Z\\-_]")
+# Control characters except TAB (\t), LF (\n) and CR (\r, normalised later).
+_FORBIDDEN_CONTROL = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def strip_terminal_paste_sequences(text: str) -> str:
+    r"""Remove bracketed-paste markers, ANSI escape sequences and stray control
+    characters from *text*, while preserving printable Unicode, ``\\t`` and
+    newlines. Never raises; never introduces replacement characters.
+    """
+    text = _BRACKETED_PASTE.sub("", text)
+    text = _ANSI_OSC.sub("", text)
+    text = _ANSI_CSI.sub("", text)
+    text = _ANSI_TWO_CHAR.sub("", text)
+    return _FORBIDDEN_CONTROL.sub("", text)
+
+
+def normalize_paste_text(text: str) -> str:
+    r"""Sanitise a paste payload: strip terminal control sequences and normalise
+    ``\\r\\n`` / ``\\r`` to ``\\n``. Valid Unicode is preserved exactly.
+    """
+    text = strip_terminal_paste_sequences(text)
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def selection_to_text(
+    buffer_lines: list[str],
+    start: tuple[int, int],
+    end: tuple[int, int],
+) -> str:
+    """Extract the selected text from logical buffer lines (buffer coords only).
+
+    Returns only file content for the (row, col) span — never line numbers,
+    gutter markers, borders or any UI chrome. Coordinates are clamped and
+    normalised so start <= end. Multi-line selections preserve line breaks.
+    """
+    if not buffer_lines:
+        return ""
+
+    if start > end:
+        start, end = end, start
+    start_row, start_col = start
+    end_row, end_col = end
+
+    last = len(buffer_lines) - 1
+    start_row = max(0, min(start_row, last))
+    end_row = max(0, min(end_row, last))
+    start_col = max(0, min(start_col, len(buffer_lines[start_row])))
+    end_col = max(0, min(end_col, len(buffer_lines[end_row])))
+
+    if start_row == end_row:
+        return buffer_lines[start_row][start_col:end_col]
+
+    parts = [buffer_lines[start_row][start_col:]]
+    parts.extend(buffer_lines[start_row + 1 : end_row])
+    parts.append(buffer_lines[end_row][:end_col])
+    return "\n".join(parts)
+
+
+def utf8_continuation_needed(data: bytes) -> int:
+    """Return how many more bytes are needed to finish a trailing UTF-8 char.
+
+    Used by the input layer to reassemble a multi-byte character whose bytes
+    arrived split across reads (otherwise a lead byte like ``0xE2`` would be
+    mis-decoded as Latin-1, producing mojibake such as U+00E2. Returns 0 when
+    the data ends on a complete character or an invalid lead byte.
+    """
+    if not data:
+        return 0
+    i = len(data) - 1
+    trailing = 0
+    while i >= 0 and 0x80 <= data[i] <= 0xBF:
+        trailing += 1
+        i -= 1
+    if i < 0:
+        return 0  # only continuation bytes: nothing to anchor to
+    lead = data[i]
+    if lead < 0x80:
+        return 0  # ASCII; complete
+    if 0xC0 <= lead <= 0xDF:
+        total = 2
+    elif 0xE0 <= lead <= 0xEF:
+        total = 3
+    elif 0xF0 <= lead <= 0xF7:
+        total = 4
+    else:
+        return 0  # invalid lead byte; do not block waiting for more
+    return max(0, total - (trailing + 1))

--- a/src/ecli/utils/text_buffer.py
+++ b/src/ecli/utils/text_buffer.py
@@ -17,11 +17,19 @@ from __future__ import annotations
 
 import codecs
 import logging
+import re
 
 import chardet
 
 
 MIN_DETECTOR_CONFIDENCE = 0.80
+
+# Logical line terminators recognised by the editor. Deliberately restricted to
+# the three real end-of-line conventions (CRLF / CR / LF). ``str.splitlines()``
+# additionally breaks on form-feed, vertical-tab, NEL and the Unicode line/para
+# separators, which would silently split a single logical source line in two and
+# corrupt the buffer (e.g. a ``.py`` file containing a ``\f`` page break).
+_LINE_TERMINATOR_RE = re.compile(r"\r\n|\r|\n")
 RISKY_LEGACY_ENCODINGS = frozenset(
     {
         "mac",
@@ -37,19 +45,26 @@ RISKY_LEGACY_ENCODINGS = frozenset(
 
 
 def split_text_preserving_content(raw: str) -> list[str]:
-    """Preserve every character except line terminators."""
+    r"""Split file text into logical lines, preserving every non-terminator byte.
+
+    Only ``\r\n``, ``\r`` and ``\n`` are treated as line boundaries. Any other
+    character that ``str.splitlines()`` would treat as a break (form-feed,
+    vertical-tab, NEL, U+2028/U+2029, ...) is preserved inside the logical line so
+    that a single source line never collapses or splits unexpectedly.
+
+    A trailing terminator does not produce an extra empty line; that final-newline
+    state is tracked separately by the caller.
+    """
     if raw == "":
         return [""]
 
-    lines = raw.splitlines(keepends=True)
     result: list[str] = []
-    for line in lines:
-        if line.endswith("\r\n"):
-            result.append(line[:-2])
-        elif line.endswith("\n") or line.endswith("\r"):
-            result.append(line[:-1])
-        else:
-            result.append(line)
+    position = 0
+    for match in _LINE_TERMINATOR_RE.finditer(raw):
+        result.append(raw[position : match.start()])
+        position = match.end()
+    if position < len(raw):
+        result.append(raw[position:])
     return result
 
 

--- a/src/ecli/utils/themes.py
+++ b/src/ecli/utils/themes.py
@@ -1,0 +1,580 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/utils/themes.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Fixed, built-in colour themes for the editor.
+
+The editor no longer reads a free-form ``[colors]`` table from ``config.toml``.
+Instead the user selects one of eight immutable, hand-tuned palettes with a
+single integer key::
+
+    theme = 1   # in config.toml
+
+* ``1``-``4`` are light themes.
+* ``5``-``8`` are dark themes.
+
+``resolve_theme()`` validates the configured value and always returns a concrete
+``ThemePalette`` (falling back deterministically to the default theme), so the
+rendering layer never has to deal with missing or malformed colour data.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from enum import IntEnum
+from typing import Any, cast
+
+
+logger = logging.getLogger("ecli")
+
+
+class ThemeId(IntEnum):
+    """Stable integer identifiers for the eight built-in themes."""
+
+    LIGHT_CLASSIC = 1
+    LIGHT_SOFT = 2
+    LIGHT_HIGH_CONTRAST = 3
+    LIGHT_SOLAR = 4
+    DARK_CLASSIC = 5
+    DARK_SOFT = 6
+    DARK_HIGH_CONTRAST = 7
+    DARK_NEON = 8
+
+
+#: Theme used whenever the configured value is missing, malformed or out of range.
+DEFAULT_THEME_ID: int = int(ThemeId.DARK_CLASSIC)
+
+
+@dataclass(frozen=True)
+class ThemePalette:
+    """An immutable colour palette.
+
+    Every colour is an ``#rrggbb`` hex string. The renderer converts these to the
+    closest terminal colour at start-up; the palette itself stays terminal-agnostic
+    so it can be reasoned about and tested without curses.
+    """
+
+    theme_id: int
+    name: str
+    is_dark: bool
+    # Editor surfaces.
+    background: str
+    foreground: str
+    cursor: str
+    selection: str
+    status: str
+    line_number: str
+    current_line: str
+    # Syntax tokens.
+    comment: str
+    keyword: str
+    string: str
+    number: str
+    function: str
+    klass: str
+    constant: str
+    type_: str
+    operator: str
+    decorator: str
+    variable: str
+    tag: str
+    attribute: str
+    builtin: str
+    # Diagnostics.
+    error: str
+    warning: str
+    # UI chrome roles. Default to "" and are filled deterministically in
+    # __post_init__ from coherent palette fallbacks, so every theme always
+    # defines a complete set of chrome colours even when not specified verbatim.
+    dim: str = ""
+    header_bg: str = ""
+    header_fg: str = ""
+    status_bg: str = ""
+    status_fg: str = ""
+    footer_bg: str = ""
+    footer_fg: str = ""
+    border: str = ""
+    panel_title: str = ""
+    info: str = ""
+    success: str = ""
+
+    def __post_init__(self) -> None:
+        """Fill any unspecified chrome role from coherent palette fallbacks."""
+        fallbacks = {
+            "dim": self.comment,
+            "header_bg": self.current_line,
+            "header_fg": self.foreground,
+            "status_bg": self.current_line,
+            "status_fg": self.foreground,
+            "footer_bg": self.current_line,
+            "footer_fg": self.foreground,
+            "border": self.comment,
+            "panel_title": self.function,
+            "info": self.number,
+            "success": self.tag,
+        }
+        for name, value in fallbacks.items():
+            if not getattr(self, name):
+                object.__setattr__(self, name, value)
+
+    def syntax_color_hex(self) -> dict[str, str]:
+        """Return the semantic-name -> hex map consumed by ``Ecli.init_colors``.
+
+        The keys here are exactly the colour names the renderer and the syntax
+        highlighter look up in ``self.colors`` so the active palette fully drives
+        the on-screen appearance.
+        """
+        return {
+            "default": self.foreground,
+            "comment": self.comment,
+            "keyword": self.keyword,
+            "string": self.string,
+            "number": self.number,
+            "function": self.function,
+            "class": self.klass,
+            "constant": self.constant,
+            "type": self.type_,
+            "operator": self.operator,
+            "decorator": self.decorator,
+            "variable": self.variable,
+            "tag": self.tag,
+            "attribute": self.attribute,
+            "builtin": self.builtin,
+            "error": self.error,
+            "status": self.status,
+            "status_error": self.error,
+            "line_number": self.line_number,
+            # Git status colours are derived from the palette so they stay coherent.
+            "git_info": self.comment,
+            "git_dirty": self.warning,
+            "git_added": self.string,
+            "git_deleted": self.error,
+            "search_highlight": self.background,
+        }
+
+    @property
+    def search_background(self) -> str:
+        """Background colour used behind highlighted search matches."""
+        return self.warning
+
+    def chrome_color_pairs(self) -> dict[str, tuple[str, str]]:
+        """Return UI-chrome colour pairs as ``name -> (fg_hex, bg_hex)``.
+
+        These drive the header bar, status bar, footer shortcut strip, panel
+        borders/titles and the current-line highlight. Keys are namespaced with
+        ``ui_`` so they never collide with syntax-token colour names.
+        """
+        return {
+            "ui_header": (self.header_fg, self.header_bg),
+            "ui_header_accent": (self.panel_title, self.header_bg),
+            "ui_header_dim": (self.dim, self.header_bg),
+            "ui_status": (self.status_fg, self.status_bg),
+            "ui_status_dim": (self.dim, self.status_bg),
+            "ui_status_accent": (self.panel_title, self.status_bg),
+            "ui_footer": (self.footer_fg, self.footer_bg),
+            "ui_footer_key": (self.panel_title, self.footer_bg),
+            "ui_border": (self.border, self.background),
+            "ui_current_line": (self.foreground, self.current_line),
+            "ui_current_line_number": (self.panel_title, self.current_line),
+            "ui_selection": (self.foreground, self.selection),
+            "ui_info": (self.info, self.background),
+            "ui_success": (self.success, self.background),
+            "ui_warning": (self.warning, self.background),
+            "ui_error": (self.error, self.background),
+            "ui_dim": (self.dim, self.background),
+            # Solid panel surface (header-bar colour) so modals are opaque.
+            "ui_panel": (self.foreground, self.header_bg),
+            "ui_panel_dim": (self.dim, self.header_bg),
+            "ui_panel_title": (self.panel_title, self.header_bg),
+            "ui_panel_border": (self.border, self.header_bg),
+            "ui_panel_warning": (self.warning, self.header_bg),
+            "ui_panel_error": (self.error, self.header_bg),
+            "ui_panel_selected": (self.header_bg, self.panel_title),
+        }
+
+
+_THEMES: dict[int, ThemePalette] = {
+    int(ThemeId.LIGHT_CLASSIC): ThemePalette(
+        theme_id=int(ThemeId.LIGHT_CLASSIC),
+        name="Light Classic",
+        is_dark=False,
+        background="#FFFFFF",
+        foreground="#1F2328",
+        cursor="#1F2328",
+        selection="#B6E3FF",
+        status="#1F2328",
+        line_number="#8C959F",
+        current_line="#F6F8FA",
+        comment="#6E7781",
+        keyword="#CF222E",
+        string="#0A3069",
+        number="#0550AE",
+        function="#8250DF",
+        klass="#953800",
+        constant="#0550AE",
+        type_="#953800",
+        operator="#CF222E",
+        decorator="#8250DF",
+        variable="#1F2328",
+        tag="#116329",
+        attribute="#0550AE",
+        builtin="#6639BA",
+        error="#CF222E",
+        warning="#9A6700",
+    ),
+    int(ThemeId.LIGHT_SOFT): ThemePalette(
+        theme_id=int(ThemeId.LIGHT_SOFT),
+        name="Light Soft",
+        is_dark=False,
+        background="#FBF1C7",
+        foreground="#3C3836",
+        cursor="#3C3836",
+        selection="#EBDBB2",
+        status="#3C3836",
+        line_number="#A89984",
+        current_line="#F2E5BC",
+        comment="#928374",
+        keyword="#9D0006",
+        string="#79740E",
+        number="#8F3F71",
+        function="#B57614",
+        klass="#B57614",
+        constant="#8F3F71",
+        type_="#B57614",
+        operator="#9D0006",
+        decorator="#AF3A03",
+        variable="#3C3836",
+        tag="#427B58",
+        attribute="#076678",
+        builtin="#8F3F71",
+        error="#9D0006",
+        warning="#B57614",
+    ),
+    int(ThemeId.LIGHT_HIGH_CONTRAST): ThemePalette(
+        theme_id=int(ThemeId.LIGHT_HIGH_CONTRAST),
+        name="Light High Contrast",
+        is_dark=False,
+        background="#FFFFFF",
+        foreground="#000000",
+        cursor="#000000",
+        selection="#FFE000",
+        status="#000000",
+        line_number="#333333",
+        current_line="#F0F0F0",
+        comment="#4B4B4B",
+        keyword="#B30000",
+        string="#006400",
+        number="#00008B",
+        function="#6A0DAD",
+        klass="#8B4500",
+        constant="#00008B",
+        type_="#8B4500",
+        operator="#B30000",
+        decorator="#6A0DAD",
+        variable="#000000",
+        tag="#006400",
+        attribute="#00008B",
+        builtin="#6A0DAD",
+        error="#B30000",
+        warning="#8B4500",
+    ),
+    int(ThemeId.LIGHT_SOLAR): ThemePalette(
+        theme_id=int(ThemeId.LIGHT_SOLAR),
+        name="Light Solar",
+        is_dark=False,
+        background="#FDF6E3",
+        foreground="#657B83",
+        cursor="#586E75",
+        selection="#EEE8D5",
+        status="#586E75",
+        line_number="#93A1A1",
+        current_line="#EEE8D5",
+        comment="#93A1A1",
+        keyword="#859900",
+        string="#2AA198",
+        number="#D33682",
+        function="#268BD2",
+        klass="#B58900",
+        constant="#6C71C4",
+        type_="#B58900",
+        operator="#859900",
+        decorator="#6C71C4",
+        variable="#657B83",
+        tag="#268BD2",
+        attribute="#268BD2",
+        builtin="#CB4B16",
+        error="#DC322F",
+        warning="#B58900",
+    ),
+    int(ThemeId.DARK_CLASSIC): ThemePalette(
+        theme_id=int(ThemeId.DARK_CLASSIC),
+        name="Dark Classic",
+        is_dark=True,
+        background="#0D1117",
+        foreground="#C9D1D9",
+        cursor="#C9D1D9",
+        selection="#264F78",
+        status="#C9D1D9",
+        line_number="#6E7681",
+        current_line="#161B22",
+        comment="#8B949E",
+        keyword="#FF7B72",
+        string="#A5D6FF",
+        number="#79C0FF",
+        function="#D2A8FF",
+        klass="#F2CC60",
+        constant="#79C0FF",
+        type_="#F2CC60",
+        operator="#FF7B72",
+        decorator="#D2A8FF",
+        variable="#C9D1D9",
+        tag="#7EE787",
+        attribute="#79C0FF",
+        builtin="#FFA657",
+        error="#F85149",
+        warning="#D29922",
+    ),
+    int(ThemeId.DARK_SOFT): ThemePalette(
+        theme_id=int(ThemeId.DARK_SOFT),
+        name="Dark Soft",
+        is_dark=True,
+        background="#282828",
+        foreground="#EBDBB2",
+        cursor="#EBDBB2",
+        selection="#504945",
+        status="#EBDBB2",
+        line_number="#7C6F64",
+        current_line="#3C3836",
+        comment="#928374",
+        keyword="#FB4934",
+        string="#B8BB26",
+        number="#D3869B",
+        function="#FABD2F",
+        klass="#FABD2F",
+        constant="#D3869B",
+        type_="#FABD2F",
+        operator="#FE8019",
+        decorator="#8EC07C",
+        variable="#EBDBB2",
+        tag="#8EC07C",
+        attribute="#83A598",
+        builtin="#FE8019",
+        error="#FB4934",
+        warning="#FABD2F",
+    ),
+    int(ThemeId.DARK_HIGH_CONTRAST): ThemePalette(
+        theme_id=int(ThemeId.DARK_HIGH_CONTRAST),
+        name="Dark High Contrast",
+        is_dark=True,
+        background="#000000",
+        foreground="#FFFFFF",
+        cursor="#FFFFFF",
+        selection="#44475A",
+        status="#FFFFFF",
+        line_number="#BBBBBB",
+        current_line="#1A1A1A",
+        comment="#9E9E9E",
+        keyword="#FF5555",
+        string="#50FA7B",
+        number="#8BE9FD",
+        function="#BD93F9",
+        klass="#FFB86C",
+        constant="#8BE9FD",
+        type_="#FFB86C",
+        operator="#FF79C6",
+        decorator="#BD93F9",
+        variable="#FFFFFF",
+        tag="#50FA7B",
+        attribute="#8BE9FD",
+        builtin="#FFB86C",
+        error="#FF5555",
+        warning="#F1FA8C",
+    ),
+    int(ThemeId.DARK_NEON): ThemePalette(
+        theme_id=int(ThemeId.DARK_NEON),
+        name="Dark Neon",
+        is_dark=True,
+        background="#0A0E14",
+        foreground="#B3B1AD",
+        cursor="#FFCC66",
+        selection="#1F2430",
+        status="#B3B1AD",
+        line_number="#3D4751",
+        current_line="#131721",
+        comment="#5C6773",
+        keyword="#FF8F40",
+        string="#C2D94C",
+        number="#FFEE99",
+        function="#59C2FF",
+        klass="#FFB454",
+        constant="#E6B450",
+        type_="#FFB454",
+        operator="#F29668",
+        decorator="#FFB454",
+        variable="#B3B1AD",
+        tag="#95E6CB",
+        attribute="#59C2FF",
+        builtin="#FFB454",
+        error="#FF3333",
+        warning="#E6B450",
+    ),
+}
+
+
+def _chrome(
+    bar: tuple[str, str],
+    border: str,
+    panel_title: str,
+    info: str,
+    success: str,
+) -> dict[str, str]:
+    """Expand a compact chrome seed into explicit header/status/footer roles.
+
+    ``bar`` is the shared ``(bg, fg)`` colour used by the header, status and
+    footer bars for a coherent, btop-style look while still populating every
+    individually-required chrome field.
+    """
+    bar_bg, bar_fg = bar
+    return {
+        "header_bg": bar_bg,
+        "header_fg": bar_fg,
+        "status_bg": bar_bg,
+        "status_fg": bar_fg,
+        "footer_bg": bar_bg,
+        "footer_fg": bar_fg,
+        "border": border,
+        "panel_title": panel_title,
+        "info": info,
+        "success": success,
+    }
+
+
+# Distinctive, professional chrome bars per theme (id -> chrome overrides).
+_CHROME_OVERRIDES: dict[int, dict[str, str]] = {
+    int(ThemeId.LIGHT_CLASSIC): _chrome(
+        ("#EAEEF2", "#1F2328"), "#D0D7DE", "#0969DA", "#0969DA", "#1A7F37"
+    ),
+    int(ThemeId.LIGHT_SOFT): _chrome(
+        ("#EBDBB2", "#3C3836"), "#D5C4A1", "#B57614", "#076678", "#79740E"
+    ),
+    int(ThemeId.LIGHT_HIGH_CONTRAST): _chrome(
+        ("#000000", "#FFFFFF"), "#000000", "#B30000", "#00008B", "#006400"
+    ),
+    int(ThemeId.LIGHT_SOLAR): _chrome(
+        ("#EEE8D5", "#586E75"), "#93A1A1", "#268BD2", "#268BD2", "#859900"
+    ),
+    int(ThemeId.DARK_CLASSIC): _chrome(
+        ("#161B22", "#C9D1D9"), "#30363D", "#58A6FF", "#58A6FF", "#3FB950"
+    ),
+    int(ThemeId.DARK_SOFT): _chrome(
+        ("#3C3836", "#EBDBB2"), "#504945", "#83A598", "#83A598", "#B8BB26"
+    ),
+    int(ThemeId.DARK_HIGH_CONTRAST): _chrome(
+        ("#1A1A1A", "#FFFFFF"), "#5A5A5A", "#8BE9FD", "#8BE9FD", "#50FA7B"
+    ),
+    int(ThemeId.DARK_NEON): _chrome(
+        ("#131721", "#B3B1AD"), "#1F2430", "#59C2FF", "#59C2FF", "#C2D94C"
+    ),
+}
+
+# Apply the chrome overrides, keeping the palettes immutable.
+_THEMES = {
+    tid: replace(palette, **cast("dict[str, Any]", _CHROME_OVERRIDES.get(tid, {})))
+    for tid, palette in _THEMES.items()
+}
+
+
+def get_theme(theme_id: int) -> ThemePalette:
+    """Return the palette for ``theme_id`` or the default palette if unknown."""
+    return _THEMES.get(int(theme_id), _THEMES[DEFAULT_THEME_ID])
+
+
+#: Environment variable that overrides the configured theme (highest precedence).
+THEME_ENV_VAR = "ECLI_THEME"
+
+
+def _legacy_theme_id(table: Mapping[str, Any]) -> int | None:
+    """Resolve a theme id from a legacy ``[theme]`` table (id wins, then name)."""
+    table_id = table.get("id")
+    if (
+        isinstance(table_id, int)
+        and not isinstance(table_id, bool)
+        and table_id in _THEMES
+    ):
+        return table_id
+    name = table.get("name")
+    if isinstance(name, str):
+        lowered = name.strip().lower()
+        if "dark" in lowered:
+            return int(ThemeId.DARK_CLASSIC)
+        if "light" in lowered:
+            return int(ThemeId.LIGHT_CLASSIC)
+    return None
+
+
+def _coerce_theme_id(raw: Any) -> int | None:
+    """Parse a raw theme value into a known theme id, or ``None`` if unusable.
+
+    Returns ``None`` (rather than the default) when the value cannot be
+    interpreted, so callers can try the next source in the precedence chain.
+
+    * ``int`` / integer-like ``str`` (``"3"``) -> that id when 1-8.
+    * legacy ``[theme]`` table (``Mapping``) -> ``id`` (1-8) or ``name``
+      (``"dark"`` -> 5, ``"light"`` -> 1) for backward compatibility.
+    * ``bool`` / out-of-range / unparseable -> ``None``.
+    """
+    if raw is None or isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw if raw in _THEMES else None
+    if isinstance(raw, str):
+        try:
+            candidate = int(raw.strip())
+        except ValueError:
+            return None
+        return candidate if candidate in _THEMES else None
+    if isinstance(raw, Mapping):
+        return _legacy_theme_id(raw)
+    return None
+
+
+def resolve_theme(config: Mapping[str, Any] | None) -> ThemePalette:
+    """Resolve the active palette from env + application config.
+
+    Precedence (highest first): ``ECLI_THEME`` env var, the root-level ``theme``
+    key in the effective config, then the deterministic default. Never raises;
+    invalid values are logged and the next source is tried.
+    """
+    sources: list[tuple[str, Any]] = []
+    env_value = os.environ.get(THEME_ENV_VAR)
+    if env_value is not None and env_value.strip():
+        sources.append((f"{THEME_ENV_VAR} env", env_value))
+    if isinstance(config, Mapping):
+        sources.append(("config 'theme'", config.get("theme")))
+
+    for label, raw in sources:
+        if raw is None:
+            continue
+        theme_id = _coerce_theme_id(raw)
+        if theme_id is not None:
+            return get_theme(theme_id)
+        logger.warning(
+            "Ignoring invalid theme from %s (%r); falling back to default %d.",
+            label,
+            raw,
+            DEFAULT_THEME_ID,
+        )
+
+    return get_theme(DEFAULT_THEME_ID)

--- a/src/ecli/utils/utils.py
+++ b/src/ecli/utils/utils.py
@@ -37,6 +37,7 @@ embedded defaults.
 
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -65,10 +66,14 @@ HUGGINGFACE_API_KEY=
 # This dictionary is a direct, hardcoded representation of `default_config.toml`.
 # It serves as the ultimate fallback, ensuring the application can ALWAYS start.
 DEFAULT_CONFIG: dict[str, Any] = {
+    # Built-in colour theme (1-4 light, 5-8 dark). See ecli.utils.themes.
+    "theme": 5,
     "colors": {"error": "red", "status": "bright_white", "green": "green"},
     "editor": {
         "use_system_clipboard": True, "default_new_filename": "new_file.py",
-        "tab_size": 4, "use_spaces": True,
+        "tab_size": 4, "use_spaces": True, "syntax_highlighting": True,
+        # Opt-in mouse support (off by default to preserve native text selection).
+        "mouse": False,
     },
     "fonts": {"font_family": "monospace", "font_size": 12},
     "keybindings": {
@@ -210,8 +215,90 @@ def ensure_user_config_exists() -> None:
             user_env_path.write_text(ENV_TEMPLATE, encoding="utf-8")
             logger.info(f"Created user .env template at: {user_env_path}")
 
+        migrate_legacy_theme_config(user_config_path)
+
     except Exception as e:
         logger.critical(f"Could not create user configuration files: {e}", exc_info=True)
+
+
+def migrate_legacy_theme_config(user_config_path: Path) -> bool:
+    """Upgrade a legacy ``[theme]``-table config to a root ``theme = N`` key.
+
+    Old configs used ``[theme]``/``[theme.ui]``/``[colors]`` tables that the
+    editor no longer reads, leaving users unable to switch themes by editing the
+    file. This is a one-time, backed-up, conservative migration: the dead tables
+    are commented out (never deleted) and a single editable ``theme = N`` line is
+    inserted, derived from the legacy ``name``/``id``. No-op when the config
+    already has a root ``theme`` key, has no legacy ``[theme]`` table, or cannot
+    be read. Returns True when a migration was written.
+    """
+    try:
+        text = user_config_path.read_text(encoding="utf-8")
+    except Exception:
+        return False
+
+    if re.search(r"(?m)^\s*theme\s*=\s*\d", text):
+        return False  # already has a root theme = N
+    if not re.search(r"(?m)^\s*\[theme\]", text):
+        return False  # no legacy table to migrate
+
+    theme_id = _derive_legacy_theme_id(text)
+
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    commenting = False
+    for line in lines:
+        stripped = line.lstrip()
+        if re.match(r"\[(colors|theme(\.ui)?)\]", stripped):
+            commenting = True
+        elif stripped.startswith("["):
+            commenting = False
+        if commenting and stripped and not stripped.startswith("#"):
+            out.append("# " + line)
+        else:
+            out.append(line)
+    migrated = "".join(out)
+
+    insertion = (
+        "# Active colour theme (1-4 light, 5-8 dark). Edit this number to switch.\n"
+        f"theme = {theme_id}\n\n"
+    )
+    first_table = re.search(r"(?m)^\s*\[", migrated)
+    if first_table:
+        migrated = migrated[: first_table.start()] + insertion + migrated[first_table.start() :]
+    else:
+        migrated = insertion + migrated
+
+    try:
+        backup = user_config_path.with_name(user_config_path.name + ".bak")
+        if not backup.exists():
+            backup.write_text(text, encoding="utf-8")
+        user_config_path.write_text(migrated, encoding="utf-8")
+        logger.warning(
+            "Migrated legacy [theme] config to 'theme = %d' at %s (backup: %s).",
+            theme_id,
+            user_config_path,
+            backup,
+        )
+        return True
+    except Exception:
+        logger.exception("Legacy theme config migration failed; left config unchanged.")
+        return False
+
+
+def _derive_legacy_theme_id(text: str) -> int:
+    """Best-effort theme id from a legacy ``[theme]`` table's id/name."""
+    id_match = re.search(r"(?ms)^\s*\[theme\].*?^\s*id\s*=\s*(\d+)", text)
+    if id_match:
+        candidate = int(id_match.group(1))
+        if 1 <= candidate <= 8:
+            return candidate
+    name_match = re.search(
+        r"(?ms)^\s*\[theme\].*?^\s*name\s*=\s*[\"']([^\"']+)[\"']", text
+    )
+    if name_match and "light" in name_match.group(1).lower():
+        return 1
+    return 5
 
 
 
@@ -226,14 +313,30 @@ def load_config() -> dict[str, Any]:
     ensure_user_config_exists()
 
     user_config_path = Path.home() / ".config" / "ecli" / "config.toml"
+    loaded_from = "(built-in defaults only)"
     if user_config_path.is_file():
         try:
             user_config = toml.load(user_config_path)
             final_config = deep_merge(final_config, user_config)
-            logger.info(f"Successfully loaded and merged user config from {user_config_path}")
+            loaded_from = str(user_config_path)
+            logger.info("Loaded user config from %s", user_config_path)
+            if isinstance(user_config.get("theme"), dict):
+                logger.warning(
+                    "User config %s uses the legacy [theme] table. Set a root-level "
+                    "'theme = 1..8' (or [theme] id = N), or run with ECLI_THEME=N.",
+                    user_config_path,
+                )
         except Exception as e:
-            logger.error(f"Could not parse user config '{user_config_path}': {e}. Using defaults.")
+            logger.error(
+                "Could not parse user config '%s': %s. Using defaults.",
+                user_config_path,
+                e,
+            )
+            loaded_from = f"{user_config_path} (parse error; using defaults)"
 
+    # Record the effective config path so the runtime/UI can report which file
+    # was actually loaded (root-cause aid for "my config changes do nothing").
+    final_config["_loaded_config_path"] = loaded_from
     return final_config
 
 
@@ -333,26 +436,58 @@ def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]
     return result
 
 
+# xterm-256 colour-cube channel levels (indices 16..231).
+_CUBE_LEVELS = (0, 95, 135, 175, 215, 255)
+
+
+def _xterm_index_rgb(index: int) -> tuple[int, int, int]:
+    """Return the approximate RGB of an xterm-256 colour index (16..255)."""
+    if index < 16:
+        return (0, 0, 0)
+    if index < 232:
+        i = index - 16
+        return (
+            _CUBE_LEVELS[(i // 36) % 6],
+            _CUBE_LEVELS[(i // 6) % 6],
+            _CUBE_LEVELS[i % 6],
+        )
+    gray = 8 + 10 * (index - 232)
+    return (gray, gray, gray)
+
+
 def hex_to_xterm(hex_color: str) -> int:
-    """
-    Converts a hexadecimal color string to the nearest xterm-256 color index.
+    """Convert a hex colour to the nearest xterm-256 index.
+
+    Considers both the 6x6x6 colour cube *and* the 24-step grayscale ramp (plus
+    pure black/white), returning whichever is closest in RGB space. This keeps
+    dark, near-neutral colours (e.g. ``#161B22``) on the grey ramp instead of
+    snapping them to a saturated cube cell.
     """
     hex_color = hex_color.lstrip("#")
     if len(hex_color) != 6:
         return WHITE_FG_IDX
     try:
-        r, g, b = (int(hex_color[i:i+2], 16) for i in (0, 2, 4))
+        r, g, b = (int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
     except ValueError:
         return WHITE_FG_IDX
 
-    if r == g == b:
-        if r < 8: return 16
-        if r > 248: return 231
-        return round(((r - 8) / 247) * 24) + 232
+    def _nearest_level(value: int) -> int:
+        return min(range(6), key=lambda i: abs(_CUBE_LEVELS[i] - value))
 
-    return int(
+    candidates = [
         16
-        + (36 * round(r / 255 * 5))
-        + (6 * round(g / 255 * 5))
-        + round(b / 255 * 5)
-    )
+        + 36 * _nearest_level(r)
+        + 6 * _nearest_level(g)
+        + _nearest_level(b),  # colour cube
+        16,  # black
+        231,  # white
+    ]
+    # Nearest grayscale-ramp step (indices 232..255).
+    gray_step = round((((r + g + b) / 3) - 8) / 10)
+    candidates.append(232 + max(0, min(23, gray_step)))
+
+    def _distance(index: int) -> int:
+        cr, cg, cb = _xterm_index_rgb(index)
+        return (cr - r) ** 2 + (cg - g) ** 2 + (cb - b) ** 2
+
+    return min(candidates, key=_distance)

--- a/tests/characterization/test_existing_keybindings.py
+++ b/tests/characterization/test_existing_keybindings.py
@@ -169,6 +169,9 @@ class FakeEditor:
     def toggle_file_browser(self) -> bool:
         return self._record("toggle_file_browser")
 
+    def toggle_terminal_panel(self) -> bool:
+        return self._record("toggle_terminal_panel")
+
     def toggle_focus(self) -> bool:
         return self._record("toggle_focus")
 

--- a/tests/characterization/test_existing_tui_panels.py
+++ b/tests/characterization/test_existing_tui_panels.py
@@ -169,7 +169,9 @@ def test_panel_labels_and_titles_remain_stable() -> None:
     source = Path("src/ecli/ui/panels.py").read_text(encoding="utf-8")
     assert 'self.title: str = kwargs.get("title", "AI Response")' in source
     assert 'title = " Git Control "' in source
-    assert "F10/q:Close F12:Focus Enter:Open" in source
+    # File Manager now uses an MC-style action bar (F2/F3/F5/F6/Del/Enter/F10).
+    assert '("F10", "Close")' in source
+    assert '("Enter", "Open")' in source
     assert "^C:Copy | Shift+arr:Select | F7:Close | F12:Focus" in source
 
 

--- a/tests/core/test_color_mapping.py
+++ b/tests/core/test_color_mapping.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/core/test_color_mapping.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for hex -> xterm-256 colour mapping (grayscale-aware nearest)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ecli.utils.utils import WHITE_FG_IDX, hex_to_xterm
+
+
+GRAY_RAMP = {16, 231} | set(range(232, 256))
+
+
+@pytest.mark.parametrize(
+    "hex_color",
+    ["#161B22", "#0D1117", "#1A1A1A", "#282828", "#131721", "#30363D"],
+)
+def test_dark_near_neutral_maps_to_grey_not_saturated_cube(hex_color: str) -> None:
+    # The previous cube-only mapping snapped these to dark-cyan (index 23);
+    # they must now land on the grayscale ramp / black.
+    assert hex_to_xterm(hex_color) in GRAY_RAMP
+
+
+def test_pure_greys_stay_on_ramp() -> None:
+    for value in (0x10, 0x40, 0x80, 0xC0, 0xF0):
+        h = f"#{value:02X}{value:02X}{value:02X}"
+        assert hex_to_xterm(h) in GRAY_RAMP
+
+
+def test_vivid_primaries_map_to_cube_cells() -> None:
+    assert hex_to_xterm("#FF0000") == 196  # red
+    assert hex_to_xterm("#00FF00") == 46  # green
+    assert hex_to_xterm("#0000FF") == 21  # blue
+    assert hex_to_xterm("#FFFFFF") in (231, 255)
+    assert hex_to_xterm("#000000") in (16, 232)
+
+
+def test_malformed_input_falls_back() -> None:
+    assert hex_to_xterm("#xyz") == WHITE_FG_IDX
+    assert hex_to_xterm("#12345") == WHITE_FG_IDX
+    assert hex_to_xterm("") == WHITE_FG_IDX

--- a/tests/core/test_config_loading.py
+++ b/tests/core/test_config_loading.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/core/test_config_loading.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Effective-config / theme-precedence tests using an isolated HOME."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ecli.utils.themes import THEME_ENV_VAR, resolve_theme
+from ecli.utils.utils import load_config
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv(THEME_ENV_VAR, raising=False)
+    cfg_dir = tmp_path / ".config" / "ecli"
+    cfg_dir.mkdir(parents=True)
+    return cfg_dir
+
+
+def test_user_config_theme_overrides_default(isolated_home: Path) -> None:
+    (isolated_home / "config.toml").write_text("theme = 4\n", encoding="utf-8")
+
+    config = load_config()
+
+    assert config["theme"] == 4  # user value beats DEFAULT_CONFIG (5)
+    assert resolve_theme(config).theme_id == 4
+    assert config["_loaded_config_path"] == str(isolated_home / "config.toml")
+
+
+def test_effective_config_theme_1_resolves_theme_1(isolated_home: Path) -> None:
+    (isolated_home / "config.toml").write_text("theme = 1\n", encoding="utf-8")
+    assert resolve_theme(load_config()).theme_id == 1
+
+
+def test_effective_config_theme_8_resolves_theme_8(isolated_home: Path) -> None:
+    (isolated_home / "config.toml").write_text("theme = 8\n", encoding="utf-8")
+    assert resolve_theme(load_config()).theme_id == 8
+
+
+def test_legacy_theme_table_config_is_migrated_to_root_theme(
+    isolated_home: Path,
+) -> None:
+    cfg = isolated_home / "config.toml"
+    cfg.write_text(
+        '[theme]\nname = "dark"\n[theme.ui]\nbackground = "#252526"\n[editor]\ntab_size = 4\n',
+        encoding="utf-8",
+    )
+    config = load_config()
+    # load_config migrates the file: 'theme' is now a root int, resolving to dark.
+    assert config["theme"] == 5
+    assert resolve_theme(config).theme_id == 5
+    # The on-disk file gained an editable root 'theme = N' and kept other sections.
+    text = cfg.read_text(encoding="utf-8")
+    assert "theme = 5" in text
+    assert "[editor]" in text
+    assert cfg.with_name("config.toml.bak").exists()
+    # The user can now switch by editing that single line.
+    cfg.write_text(text.replace("theme = 5", "theme = 2"), encoding="utf-8")
+    assert resolve_theme(load_config()).theme_id == 2
+
+
+def test_light_legacy_theme_migrates_to_theme_one(isolated_home: Path) -> None:
+    (isolated_home / "config.toml").write_text(
+        '[theme]\nname = "light"\n', encoding="utf-8"
+    )
+    assert resolve_theme(load_config()).theme_id == 1
+
+
+def test_migration_is_noop_for_root_theme_config(isolated_home: Path) -> None:
+    cfg = isolated_home / "config.toml"
+    cfg.write_text("theme = 7\n[editor]\ntab_size = 4\n", encoding="utf-8")
+    load_config()
+    # No legacy table -> no migration, no backup.
+    assert not cfg.with_name("config.toml.bak").exists()
+    assert "theme = 7" in cfg.read_text(encoding="utf-8")
+
+
+def test_env_overrides_user_config_via_load(isolated_home: Path, monkeypatch) -> None:
+    (isolated_home / "config.toml").write_text("theme = 2\n", encoding="utf-8")
+    monkeypatch.setenv(THEME_ENV_VAR, "6")
+    assert resolve_theme(load_config()).theme_id == 6
+
+
+def test_loaded_config_path_recorded_when_present(isolated_home: Path) -> None:
+    (isolated_home / "config.toml").write_text("theme = 3\n", encoding="utf-8")
+    config = load_config()
+    assert "_loaded_config_path" in config
+    assert config["_loaded_config_path"].endswith("config.toml")

--- a/tests/core/test_file_roundtrip_stability.py
+++ b/tests/core/test_file_roundtrip_stability.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/core/test_file_roundtrip_stability.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Regression coverage for the editor save/load round-trip.
+
+These tests exercise the *real* ``open_file`` -> modify -> ``save_file`` ->
+reopen path (the same path ``Ctrl+S`` uses) and assert that logical lines never
+collapse into a single line and that newline separators survive on disk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ecli.core.Ecli import Ecli
+
+
+class FakeHistory:
+    def clear(self) -> None:
+        return None
+
+    def add_action(self, _action: dict[str, Any]) -> None:
+        return None
+
+
+def make_editor() -> Ecli:
+    editor = Ecli.__new__(Ecli)
+    editor.text = [""]
+    editor.cursor_x = 0
+    editor.cursor_y = 0
+    editor.scroll_top = 0
+    editor.scroll_left = 0
+    editor.modified = False
+    editor.encoding = "utf-8"
+    editor.filename = None
+    editor.status_message = "Ready"
+    editor.is_selecting = False
+    editor.selection_start = None
+    editor.selection_end = None
+    editor.highlighted_matches = []
+    editor.search_matches = []
+    editor.search_term = ""
+    editor.current_match_idx = -1
+    editor.history = FakeHistory()
+    editor.git = None
+    editor.git_panel_instance = None
+    editor._lexer = None
+    editor.current_language = None
+    editor.custom_syntax_patterns = []
+    editor.colors = {"default": 0}
+    editor.config = {}
+    editor.is_256_color_terminal = True
+    editor._force_full_redraw = False
+    editor._file_loaded_from_disk = False
+    editor._file_had_final_newline = False
+    # Keep the linter thread from doing real work during tests.
+    editor.run_lint_async = lambda *_a, **_k: False  # type: ignore[method-assign]
+    return editor
+
+
+PY_LINES = [
+    "import os",
+    "",
+    "",
+    "def main() -> None:",
+    '    x = {"a": 1, "b": 2}',
+    "    for key, value in x.items():",
+    "        print(key, value)",
+    "",
+    "",
+    "if __name__ == '__main__':",
+    "    main()",
+]
+
+
+def _open_modify_save_reopen(tmp_path: Path, raw: bytes, name: str) -> Ecli:
+    """Open ``raw`` bytes, flag the buffer modified, save, then reopen."""
+    source = tmp_path / name
+    source.write_bytes(raw)
+
+    editor = make_editor()
+    assert editor.open_file(str(source)) is True
+    loaded_after_open = list(editor.text)
+
+    # Force the real write path: ``save_file`` short-circuits when not modified.
+    editor.modified = True
+    assert editor.save_file() is True
+
+    reopened = make_editor()
+    assert reopened.open_file(str(source)) is True
+    # Stash the post-open snapshot for callers that want it.
+    reopened._loaded_after_first_open = loaded_after_open  # type: ignore[attr-defined]
+    return reopened
+
+
+def test_roundtrip_lf_with_final_newline_keeps_lines_separate(tmp_path: Path) -> None:
+    raw = ("\n".join(PY_LINES) + "\n").encode("utf-8")
+    editor = _open_modify_save_reopen(tmp_path, raw, "lf.py")
+
+    assert editor.text == PY_LINES
+    assert len(editor.text) == len(PY_LINES)
+    # No single-line collapse.
+    assert len(editor.text) > 1
+
+
+def test_roundtrip_lf_without_final_newline(tmp_path: Path) -> None:
+    raw = "\n".join(PY_LINES).encode("utf-8")
+    editor = _open_modify_save_reopen(tmp_path, raw, "lf_no_final.py")
+
+    assert editor.text == PY_LINES
+    assert len(editor.text) == len(PY_LINES)
+
+
+def test_roundtrip_crlf_normalizes_to_lf_without_collapse(tmp_path: Path) -> None:
+    raw = ("\r\n".join(PY_LINES) + "\r\n").encode("utf-8")
+    editor = _open_modify_save_reopen(tmp_path, raw, "crlf.py")
+
+    # The important guarantee: lines stay separate (no collapse, no doubling).
+    assert editor.text == PY_LINES
+    assert len(editor.text) == len(PY_LINES)
+
+
+def test_saved_file_on_disk_contains_newline_separators(tmp_path: Path) -> None:
+    raw = ("\n".join(PY_LINES) + "\n").encode("utf-8")
+    source = tmp_path / "disk.py"
+    source.write_bytes(raw)
+
+    editor = make_editor()
+    assert editor.open_file(str(source)) is True
+    editor.modified = True
+    assert editor.save_file() is True
+
+    on_disk = source.read_bytes()
+    assert b"\n" in on_disk
+    # The file must not be a single physical line.
+    assert on_disk.count(b"\n") >= len(PY_LINES) - 1
+    # Lines must remain individually recoverable.
+    assert source.read_text(encoding="utf-8").split("\n")[0] == "import os"
+
+
+def test_roundtrip_form_feed_line_stays_single_logical_line(tmp_path: Path) -> None:
+    # A .py file whose single logical line embeds a form-feed must not be split
+    # into two lines on open, nor corrupted into two real lines after save.
+    lines = ["import os", "x = 1\x0cy = 2", "print(x, y)"]
+    raw = ("\n".join(lines) + "\n").encode("utf-8")
+    editor = _open_modify_save_reopen(tmp_path, raw, "formfeed.py")
+
+    assert editor.text == lines
+    assert editor.text[1] == "x = 1\x0cy = 2"
+    assert len(editor.text) == 3
+
+
+def test_new_buffer_save_then_reopen_keeps_lines(tmp_path: Path) -> None:
+    target = tmp_path / "fresh.py"
+    editor = make_editor()
+    editor.text = list(PY_LINES)
+    editor.filename = str(target)
+    editor.encoding = "utf-8"
+    editor._file_loaded_from_disk = False
+    editor._file_had_final_newline = False
+    editor.modified = True
+
+    assert editor.save_file() is True
+
+    reopened = make_editor()
+    assert reopened.open_file(str(target)) is True
+    assert reopened.text == PY_LINES
+    assert len(reopened.text) == len(PY_LINES)

--- a/tests/core/test_paste_transaction.py
+++ b/tests/core/test_paste_transaction.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/core/test_paste_transaction.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for bracketed-paste / clipboard insertion as a single transaction."""
+
+from __future__ import annotations
+
+import time
+from threading import RLock
+from typing import Any, cast
+
+from ecli.core.Ecli import Ecli
+from ecli.core.History import History
+
+
+def make_editor(lines: list[str]) -> Ecli:
+    editor = Ecli.__new__(Ecli)
+    editor.text = list(lines)
+    editor.cursor_x = 0
+    editor.cursor_y = 0
+    editor.scroll_top = 0
+    editor.scroll_left = 0
+    editor.modified = False
+    editor.is_selecting = False
+    editor.selection_start = None
+    editor.selection_end = None
+    editor.status_message = "Ready"
+    editor.internal_clipboard = ""
+    editor._state_lock = RLock()
+    editor.history = History(cast(Any, editor))
+    editor._set_status_message = lambda msg, *a, **k: setattr(  # type: ignore[method-assign]
+        editor, "status_message", msg
+    )
+    return editor
+
+
+def test_paste_inserts_multiple_lines_not_flattened() -> None:
+    editor = make_editor([""])
+    assert editor.insert_pasted_text("L1\nL2\nL3") is True
+    assert editor.text[:3] == ["L1", "L2", "L3"]
+    assert len(editor.text) >= 3  # not collapsed into one line
+
+
+def test_paste_crlf_is_normalized() -> None:
+    editor = make_editor([""])
+    editor.insert_pasted_text("a\r\nb\r\nc")
+    assert editor.text[:3] == ["a", "b", "c"]
+
+
+def test_paste_bare_cr_is_normalized() -> None:
+    editor = make_editor([""])
+    editor.insert_pasted_text("a\rb\rc")
+    assert editor.text[:3] == ["a", "b", "c"]
+
+
+def test_paste_preserves_indentation_without_extra_auto_indent() -> None:
+    editor = make_editor([""])
+    editor.insert_pasted_text("def f():\n    return 1\n        deep = 2")
+    assert editor.text[0] == "def f():"
+    assert editor.text[1] == "    return 1"
+    assert editor.text[2] == "        deep = 2"
+
+
+def test_paste_is_single_undo_unit() -> None:
+    editor = make_editor([""])
+    editor.insert_pasted_text("a\nb\nc\nd")
+    # Exactly one 'insert' action carrying the whole payload (one undo step).
+    assert len(editor.history._action_history) == 1
+    action = editor.history._action_history[0]
+    assert action["type"] == "insert"
+    assert action["text"] == "a\nb\nc\nd"
+
+
+def test_paste_does_not_execute_shortcut_text() -> None:
+    editor = make_editor([""])
+    payload = "import os\nsave\nquit\nfind\nctrl+s"
+    editor.insert_pasted_text(payload)
+    # Shortcut-looking lines are inserted verbatim, never dispatched as actions.
+    assert "save" in editor.text
+    assert "quit" in editor.text
+    assert "ctrl+s" in editor.text
+    assert len(editor.history._action_history) == 1
+
+
+def test_large_paste_completes_as_one_transaction() -> None:
+    editor = make_editor([""])
+    payload = "\n".join(f"line{i:03d}" for i in range(200))
+
+    start = time.perf_counter()
+    assert editor.insert_pasted_text(payload) is True
+    elapsed = time.perf_counter() - start
+
+    assert editor.text[:200] == [f"line{i:03d}" for i in range(200)]
+    # One transaction, not 200 per-character/per-line actions.
+    assert len(editor.history._action_history) == 1
+    assert elapsed < 2.0
+
+
+def test_empty_paste_is_noop() -> None:
+    editor = make_editor(["x"])
+    assert editor.insert_pasted_text("") is False
+    assert editor.text == ["x"]
+    assert len(editor.history._action_history) == 0

--- a/tests/core/test_syntax_highlighting_toggle.py
+++ b/tests/core/test_syntax_highlighting_toggle.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/core/test_syntax_highlighting_toggle.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests that the [editor].syntax_highlighting config key actually controls
+highlighting and that highlighting never mutates the buffer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pygments.lexers import PythonLexer
+
+from ecli.core.Ecli import Ecli
+
+
+def make_editor(config: dict[str, Any]) -> Ecli:
+    editor = Ecli.__new__(Ecli)
+    editor.text = ["def main():", "    return 42"]
+    editor.config = config
+    editor.colors = {"default": 0, "keyword": 7, "number": 3, "comment": 1}
+    editor.is_256_color_terminal = True
+    editor._lexer = PythonLexer()
+    editor.current_language = "python"
+    editor.custom_syntax_patterns = []
+    return editor
+
+
+CODE = ["def main():", "    x = 42  # answer"]
+
+
+def test_highlighting_enabled_by_default_preserves_line_content() -> None:
+    editor = make_editor({})
+    result = editor.apply_syntax_highlighting_with_pygments(CODE, [0, 1])
+
+    # Content is reconstructable from tokens and the buffer is untouched.
+    assert ["".join(tok for tok, _ in line) for line in result] == CODE
+    assert editor.text == ["def main():", "    return 42"]
+    # A keyword line yields more than a single flat segment when highlighting is on.
+    assert len(result[0]) > 1
+
+
+def test_highlighting_disabled_returns_single_default_segment() -> None:
+    editor = make_editor({"editor": {"syntax_highlighting": False}})
+    result = editor.apply_syntax_highlighting_with_pygments(CODE, [0, 1])
+
+    default_attr = editor.colors["default"]
+    assert result == [[(CODE[0], default_attr)], [(CODE[1], default_attr)]]
+
+
+def test_highlighting_toggle_is_explicit_per_config() -> None:
+    enabled = make_editor({"editor": {"syntax_highlighting": True}})
+    disabled = make_editor({"editor": {"syntax_highlighting": False}})
+
+    enabled_tokens = enabled.apply_syntax_highlighting_with_pygments(CODE, [0, 1])
+    disabled_tokens = disabled.apply_syntax_highlighting_with_pygments(CODE, [0, 1])
+
+    assert len(enabled_tokens[0]) > 1
+    assert len(disabled_tokens[0]) == 1
+
+
+def test_malformed_toggle_value_defaults_to_enabled() -> None:
+    editor = make_editor({"editor": {"syntax_highlighting": "yes-please"}})
+    result = editor.apply_syntax_highlighting_with_pygments(CODE, [0, 1])
+
+    # Non-boolean -> highlighting stays on (never silently broken).
+    assert len(result[0]) > 1

--- a/tests/core/test_text_buffer.py
+++ b/tests/core/test_text_buffer.py
@@ -91,6 +91,28 @@ def test_split_text_empty_file_model_is_single_empty_line() -> None:
     assert split_text_preserving_content("") == [""]
 
 
+def test_split_text_does_not_break_on_form_feed_page_break() -> None:
+    # A form feed (\x0c) is a legal in-line character in Python source. It must
+    # stay inside a single logical line, not split it the way str.splitlines does.
+    raw = "x = 1\x0cy = 2"
+
+    assert split_text_preserving_content(raw) == ["x = 1\x0cy = 2"]
+
+
+def test_split_text_does_not_break_on_exotic_unicode_separators() -> None:
+    # Vertical tab, NEL and the Unicode line/paragraph separators are content,
+    # not editor line boundaries.
+    for separator in ("\x0b", "\x85", " ", " ", "\x1c", "\x1d", "\x1e"):
+        raw = f"left{separator}right"
+        assert split_text_preserving_content(raw) == [f"left{separator}right"]
+
+
+def test_split_text_mixed_real_and_exotic_terminators() -> None:
+    raw = "a\nb\x0cstill-b\r\nc"
+
+    assert split_text_preserving_content(raw) == ["a", "b\x0cstill-b", "c"]
+
+
 def test_detect_and_decode_prefers_strict_utf8_for_cyrillic_source() -> None:
     source = "".join(
         [

--- a/tests/core/test_theme_system.py
+++ b/tests/core/test_theme_system.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/core/test_theme_system.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for the fixed built-in theme system and syntax-highlighting toggle."""
+
+from __future__ import annotations
+
+import pytest
+
+from ecli.utils.themes import (
+    DEFAULT_THEME_ID,
+    THEME_ENV_VAR,
+    ThemeId,
+    get_theme,
+    resolve_theme,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_theme_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure ECLI_THEME never leaks into config-based theme tests."""
+    monkeypatch.delenv(THEME_ENV_VAR, raising=False)
+
+
+# Colour names the renderer / highlighter look up in ``self.colors``.
+RENDERER_COLOR_KEYS = {
+    "default",
+    "comment",
+    "keyword",
+    "string",
+    "number",
+    "function",
+    "class",
+    "type",
+    "constant",
+    "operator",
+    "decorator",
+    "variable",
+    "tag",
+    "attribute",
+    "builtin",
+    "error",
+    "status",
+    "status_error",
+    "line_number",
+    "git_info",
+    "git_dirty",
+    "git_added",
+    "git_deleted",
+    "search_highlight",
+}
+
+
+def test_exactly_eight_themes_exist() -> None:
+    ids = [int(member) for member in ThemeId]
+    assert ids == [1, 2, 3, 4, 5, 6, 7, 8]
+
+
+def test_four_light_and_four_dark_themes() -> None:
+    light = [tid for tid in range(1, 9) if not get_theme(tid).is_dark]
+    dark = [tid for tid in range(1, 9) if get_theme(tid).is_dark]
+    assert light == [1, 2, 3, 4]
+    assert dark == [5, 6, 7, 8]
+
+
+def test_get_theme_returns_matching_id() -> None:
+    for tid in range(1, 9):
+        assert get_theme(tid).theme_id == tid
+
+
+@pytest.mark.parametrize("tid", list(range(1, 9)))
+def test_every_palette_defines_all_renderer_colors(tid: int) -> None:
+    color_map = get_theme(tid).syntax_color_hex()
+    assert RENDERER_COLOR_KEYS <= set(color_map)
+    # Every value is a #rrggbb hex string.
+    for name, value in color_map.items():
+        assert isinstance(value, str) and value.startswith("#") and len(value) == 7, (
+            name,
+            value,
+        )
+
+
+@pytest.mark.parametrize("tid", list(range(1, 9)))
+def test_palette_defines_required_surfaces(tid: int) -> None:
+    palette = get_theme(tid)
+    for field in (
+        palette.background,
+        palette.foreground,
+        palette.cursor,
+        palette.selection,
+        palette.status,
+        palette.line_number,
+        palette.current_line,
+        palette.warning,
+    ):
+        assert field.startswith("#") and len(field) == 7
+
+
+# Chrome roles required by the professional UI (header/status/footer/...).
+CHROME_ROLES = (
+    "dim",
+    "header_bg",
+    "header_fg",
+    "status_bg",
+    "status_fg",
+    "footer_bg",
+    "footer_fg",
+    "border",
+    "panel_title",
+    "info",
+    "success",
+)
+
+
+@pytest.mark.parametrize("tid", list(range(1, 9)))
+def test_every_theme_defines_all_chrome_roles(tid: int) -> None:
+    palette = get_theme(tid)
+    for role in CHROME_ROLES:
+        value = getattr(palette, role)
+        assert isinstance(value, str) and value.startswith("#") and len(value) == 7, (
+            tid,
+            role,
+            value,
+        )
+
+
+@pytest.mark.parametrize("tid", list(range(1, 9)))
+def test_chrome_color_pairs_are_complete_fg_bg_hex(tid: int) -> None:
+    pairs = get_theme(tid).chrome_color_pairs()
+    expected = {
+        "ui_header",
+        "ui_status",
+        "ui_footer",
+        "ui_footer_key",
+        "ui_border",
+        "ui_panel_title",
+        "ui_current_line",
+        "ui_current_line_number",
+        "ui_selection",
+        "ui_info",
+        "ui_success",
+        "ui_error",
+        "ui_warning",
+    }
+    assert expected <= set(pairs)
+    for name, (fg, bg) in pairs.items():
+        assert fg.startswith("#") and len(fg) == 7, (name, fg)
+        assert bg.startswith("#") and len(bg) == 7, (name, bg)
+
+
+def test_resolve_theme_reads_config_value() -> None:
+    assert resolve_theme({"theme": 1}).name == "Light Classic"
+    assert resolve_theme({"theme": 8}).name == "Dark Neon"
+
+
+def test_resolve_theme_missing_uses_default() -> None:
+    assert resolve_theme({}).theme_id == DEFAULT_THEME_ID
+    assert resolve_theme(None).theme_id == DEFAULT_THEME_ID
+
+
+def test_resolve_theme_out_of_range_falls_back() -> None:
+    assert resolve_theme({"theme": 0}).theme_id == DEFAULT_THEME_ID
+    assert resolve_theme({"theme": 99}).theme_id == DEFAULT_THEME_ID
+    assert resolve_theme({"theme": -3}).theme_id == DEFAULT_THEME_ID
+
+
+def test_resolve_theme_integer_like_string_is_accepted() -> None:
+    assert resolve_theme({"theme": "3"}).theme_id == 3
+
+
+def test_resolve_theme_non_integer_string_falls_back() -> None:
+    assert resolve_theme({"theme": "dark"}).theme_id == DEFAULT_THEME_ID
+    assert resolve_theme({"theme": 2.5}).theme_id == DEFAULT_THEME_ID
+
+
+def test_resolve_theme_boolean_is_rejected() -> None:
+    # bool is an int subclass; it must not be treated as theme 1/0.
+    assert resolve_theme({"theme": True}).theme_id == DEFAULT_THEME_ID
+    assert resolve_theme({"theme": False}).theme_id == DEFAULT_THEME_ID
+
+
+def test_env_var_overrides_config_theme(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(THEME_ENV_VAR, "7")
+    assert resolve_theme({"theme": 2}).theme_id == 7
+
+
+def test_invalid_env_var_falls_back_to_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(THEME_ENV_VAR, "not-a-theme")
+    assert resolve_theme({"theme": 2}).theme_id == 2
+
+
+def test_blank_env_var_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(THEME_ENV_VAR, "   ")
+    assert resolve_theme({"theme": 4}).theme_id == 4
+
+
+def test_legacy_theme_table_name_maps_to_default_dark_or_light() -> None:
+    # Stale configs ship a [theme] table; map its name without forcing theme 5.
+    assert resolve_theme({"theme": {"name": "dark"}}).theme_id == int(
+        ThemeId.DARK_CLASSIC
+    )
+    assert resolve_theme({"theme": {"name": "light"}}).theme_id == int(
+        ThemeId.LIGHT_CLASSIC
+    )
+
+
+def test_legacy_theme_table_id_is_honoured() -> None:
+    assert resolve_theme({"theme": {"id": 3}}).theme_id == 3
+    # id wins over name.
+    assert resolve_theme({"theme": {"id": 8, "name": "light"}}).theme_id == 8
+
+
+def test_legacy_theme_table_without_id_or_name_uses_default() -> None:
+    assert (
+        resolve_theme({"theme": {"ui": {"background": "#fff"}}}).theme_id
+        == DEFAULT_THEME_ID
+    )
+
+
+def test_legacy_colors_table_does_not_override_theme() -> None:
+    # A [colors] table must not change the resolved built-in theme.
+    cfg = {"theme": 6, "colors": {"keyword": "red", "background": "#000000"}}
+    assert resolve_theme(cfg).theme_id == 6

--- a/tests/ui/test_design_system.py
+++ b/tests/ui/test_design_system.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/ui/test_design_system.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for the Terminal UI Design System role layer."""
+
+from __future__ import annotations
+
+import curses
+
+from ecli.ui.design import ROLE_COLOR_KEYS, TuiDesign
+from ecli.utils.themes import get_theme
+
+
+# Roles the design brief requires the design system to define.
+REQUIRED_ROLES = {
+    "app_header",
+    "menu_bar",
+    "editor_bg",
+    "editor_text",
+    "gutter_bg",
+    "gutter_text",
+    "current_line",
+    "panel_bg",
+    "panel_border",
+    "panel_title",
+    "panel_text",
+    "panel_dim",
+    "panel_selected_bg",
+    "panel_selected_fg",
+    "panel_focus_border",
+    "table_header",
+    "table_separator",
+    "status_bg",
+    "status_fg",
+    "footer_bg",
+    "footer_fg",
+    "key_hint",
+    "warning",
+    "error",
+    "success",
+    "info",
+    "git_dirty",
+    "git_clean",
+    "ai_warning",
+}
+
+
+def test_all_required_roles_are_defined() -> None:
+    assert REQUIRED_ROLES <= set(ROLE_COLOR_KEYS)
+
+
+def test_every_role_maps_to_a_color_key_present_in_chrome_or_syntax() -> None:
+    # Every mapped colour key must be a key the renderer actually allocates,
+    # i.e. a chrome pair name or a syntax/git colour name.
+    palette = get_theme(5)
+    available = set(palette.chrome_color_pairs()) | set(palette.syntax_color_hex())
+    for role, key in ROLE_COLOR_KEYS.items():
+        assert key in available, (role, key)
+
+
+def test_design_resolves_roles_from_colors_map() -> None:
+    colors = {"ui_panel_selected": 42, "ui_panel": 7, "default": 1}
+    design = TuiDesign(colors)
+    assert design.attr("panel_selected_bg") == 42
+    assert design.attr("panel_bg") == 7
+    assert design.attr("editor_text") == 1
+
+
+def test_design_unknown_role_and_missing_key_use_defaults() -> None:
+    design = TuiDesign({})
+    assert design.attr("nonexistent-role", default=99) == 99
+    # Known role but colour key absent (limited terminal) -> default.
+    assert design.attr("panel_bg", default=5) == 5
+
+
+def test_selected_and_border_helpers_apply_focus() -> None:
+    design = TuiDesign({"ui_panel_selected": 8, "ui_panel_border": 4})
+    assert design.selected(focused=True) == 8
+    assert design.selected(focused=False) != 8  # dim/unfocused fallback
+    assert design.border(focused=True) == (4 | curses.A_BOLD)
+    assert design.border(focused=False) == 4

--- a/tests/ui/test_git_panel.py
+++ b/tests/ui/test_git_panel.py
@@ -45,6 +45,12 @@ class FakeWindow:
     def keypad(self, value: bool) -> None:
         self.keypad_values.append(value)
 
+    def bkgd(self, ch: str, attr: int = 0) -> None:
+        return None
+
+    def touchwin(self) -> None:
+        return None
+
     def erase(self) -> None:
         return None
 

--- a/tests/ui/test_layout_geometry.py
+++ b/tests/ui/test_layout_geometry.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/ui/test_layout_geometry.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for the deterministic split-layout geometry."""
+
+from __future__ import annotations
+
+import pytest
+
+from ecli.ui.geometry import (
+    EDITOR_FRACTION,
+    MIN_EDITOR_WIDTH,
+    MIN_PANEL_WIDTH,
+    centered_modal_rect,
+    compute_layout,
+)
+
+
+def test_no_panel_editor_uses_full_width() -> None:
+    geo = compute_layout(120, 40, active_panel=False)
+    assert geo.split is False
+    assert geo.panel is None
+    assert geo.editor.x == 0
+    assert geo.editor.width == 120
+
+
+@pytest.mark.parametrize("width", [100, 120, 160, 200])
+def test_active_panel_splits_60_40(width: int) -> None:
+    geo = compute_layout(width, 40, active_panel=True)
+    assert geo.split is True
+    assert geo.panel is not None
+    assert geo.editor.x == 0
+    assert geo.editor.width == int(width * EDITOR_FRACTION)
+    # Panel starts exactly where the editor ends and runs to the right edge.
+    assert geo.panel.x == geo.editor.right
+    assert geo.panel.right == width
+
+
+def test_work_area_rows_and_chrome_separation() -> None:
+    geo = compute_layout(120, 40, active_panel=True)
+    # Header is row 0, status is H-2, footer is H-1.
+    assert geo.header.y == 0 and geo.header.height == 1
+    assert geo.status.y == 40 - 2
+    assert geo.footer.y == 40 - 1
+    # Editor and panel both live in the work area: rows 1 .. H-3.
+    assert geo.editor.y == 1 and geo.panel.y == 1
+    assert geo.editor.bottom == 40 - 2  # ends before the status row
+    assert geo.panel.bottom == 40 - 2
+    # The panel must NOT extend into the global status/footer rows.
+    assert geo.panel.bottom <= geo.status.y
+    assert geo.panel.bottom <= geo.footer.y
+
+
+def test_narrow_terminal_refuses_split() -> None:
+    # Too narrow to honour both minimum widths -> no split, panel is None.
+    geo = compute_layout(MIN_EDITOR_WIDTH + MIN_PANEL_WIDTH - 1, 40, active_panel=True)
+    assert geo.split is False
+    assert geo.panel is None
+    assert geo.editor.width == MIN_EDITOR_WIDTH + MIN_PANEL_WIDTH - 1
+
+
+def test_minimum_widths_respected_when_split() -> None:
+    geo = compute_layout(MIN_EDITOR_WIDTH + MIN_PANEL_WIDTH, 40, active_panel=True)
+    if geo.split:
+        assert geo.editor.width >= MIN_EDITOR_WIDTH
+        assert geo.panel.width >= MIN_PANEL_WIDTH
+
+
+def test_small_height_collapses_chrome_but_keeps_status() -> None:
+    geo = compute_layout(120, 6, active_panel=True)
+    # Below the full-chrome threshold: no header/footer, status only.
+    assert geo.header.height == 0
+    assert geo.footer.height == 0
+    assert geo.status.height == 1
+
+
+def test_centered_modal_stays_inside_and_above_footer() -> None:
+    rect = centered_modal_rect(120, 40, want_width=80, want_height=20)
+    assert rect.x >= 0 and rect.right <= 120
+    assert rect.y >= 1  # below the header
+    assert rect.bottom <= 40 - 2  # above the global status/footer

--- a/tests/ui/test_mouse_model.py
+++ b/tests/ui/test_mouse_model.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/ui/test_mouse_model.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for the mouse model and hit-testing (no real terminal needed)."""
+
+from __future__ import annotations
+
+import curses
+
+import pytest
+
+from ecli.ui.geometry import Rect, compute_layout
+from ecli.ui.mouse import (
+    FocusRegion,
+    MouseAction,
+    MouseButton,
+    MouseEvent,
+    decode_curses_mouse,
+    hit_test,
+)
+from ecli.ui.panels import FileBrowserPanel, SystemDoctorPanel
+
+
+# --- hit testing ---------------------------------------------------------
+
+
+def test_hit_test_editor_and_gutter() -> None:
+    geo = compute_layout(120, 40, active_panel=False)
+    editor = hit_test(geo, 10, 5)
+    assert editor.region is FocusRegion.EDITOR
+    assert editor.local_x == 10
+    assert editor.local_y == 5 - geo.editor.y
+    gutter = hit_test(geo, 2, 5, gutter_width=5)
+    assert gutter.region is FocusRegion.GUTTER
+
+
+def test_hit_test_split_panel_and_editor() -> None:
+    geo = compute_layout(120, 40, active_panel=True)
+    assert hit_test(geo, 90, 5).region is FocusRegion.PANEL  # right 40%
+    assert hit_test(geo, 10, 5).region is FocusRegion.EDITOR  # left 60%
+    # Panel-local coordinates are relative to the panel rect.
+    target = hit_test(geo, 90, 5)
+    assert target.local_x == 90 - geo.panel.x
+    assert target.local_y == 5 - geo.panel.y
+
+
+def test_hit_test_global_header_status_footer() -> None:
+    geo = compute_layout(120, 40, active_panel=False)
+    assert hit_test(geo, 5, 0).region is FocusRegion.HEADER
+    assert hit_test(geo, 5, 38).region is FocusRegion.STATUS  # H-2
+    assert hit_test(geo, 5, 39).region is FocusRegion.FOOTER  # H-1
+
+
+def test_hit_test_modal_inside_and_outside() -> None:
+    geo = compute_layout(120, 40, active_panel=False)
+    modal = Rect(40, 10, 40, 15)
+    assert hit_test(geo, 50, 15, modal_rect=modal).region is FocusRegion.MODAL
+    assert hit_test(geo, 5, 5, modal_rect=modal).region is FocusRegion.OUTSIDE
+
+
+# --- curses decode (constants probed: present on this ncurses) ------------
+
+
+def test_decode_left_click_double_and_press() -> None:
+    assert decode_curses_mouse(curses.BUTTON1_CLICKED) == (
+        MouseButton.LEFT,
+        MouseAction.CLICK,
+    )
+    assert decode_curses_mouse(curses.BUTTON1_DOUBLE_CLICKED) == (
+        MouseButton.LEFT,
+        MouseAction.DOUBLE_CLICK,
+    )
+    assert decode_curses_mouse(curses.BUTTON1_PRESSED) == (
+        MouseButton.LEFT,
+        MouseAction.PRESS,
+    )
+
+
+def test_decode_wheel_up_down() -> None:
+    assert decode_curses_mouse(curses.BUTTON4_PRESSED) == (
+        MouseButton.WHEEL_UP,
+        MouseAction.WHEEL,
+    )
+    assert decode_curses_mouse(curses.BUTTON5_PRESSED) == (
+        MouseButton.WHEEL_DOWN,
+        MouseAction.WHEEL,
+    )
+
+
+def test_decode_unknown_state_is_safe() -> None:
+    assert decode_curses_mouse(0) == (MouseButton.NONE, MouseAction.UNKNOWN)
+
+
+def test_mouse_event_wheel_delta() -> None:
+    up = MouseEvent(0, 0, MouseButton.WHEEL_UP, MouseAction.WHEEL)
+    down = MouseEvent(0, 0, MouseButton.WHEEL_DOWN, MouseAction.WHEEL)
+    click = MouseEvent(0, 0, MouseButton.LEFT, MouseAction.CLICK)
+    assert up.is_wheel and up.wheel_delta == 1
+    assert down.wheel_delta == -1
+    assert not click.is_wheel and click.wheel_delta == 0
+
+
+# --- File Manager row hit-testing & wheel scroll -------------------------
+
+
+def _make_file_browser(
+    entry_count: int, height: int = 24, top: int = 0
+) -> FileBrowserPanel:
+    fb = FileBrowserPanel.__new__(FileBrowserPanel)
+    fb.entries = list(range(entry_count))  # type: ignore[assignment]
+    fb.height = height
+    fb._list_first_row = 2
+    fb._list_last_row = height - 3
+    fb._visible_top = top
+    return fb
+
+
+def test_file_manager_click_maps_to_entry_index() -> None:
+    fb = _make_file_browser(10, height=24, top=0)
+    assert fb.hit_entry_index(2) == 0  # first list row
+    assert fb.hit_entry_index(5) == 3
+    assert fb.hit_entry_index(11) == 9  # last entry
+    # Title/header rows and beyond-list clicks select nothing.
+    assert fb.hit_entry_index(0) is None
+    assert fb.hit_entry_index(1) is None
+    assert fb.hit_entry_index(12) is None  # past the entries
+    assert fb.hit_entry_index(21) is None  # the list-bottom boundary
+
+
+def test_file_manager_click_respects_scroll() -> None:
+    fb = _make_file_browser(50, height=24, top=20)
+    assert fb.hit_entry_index(2) == 20
+    assert fb.hit_entry_index(4) == 22
+
+
+def test_wheel_scroll_moves_list_selection() -> None:
+    fb = _make_file_browser(10)
+    fb.idx = 5
+    assert fb.scroll_by(-1) is True  # wheel down -> next
+    assert fb.idx == 6
+    assert fb.scroll_by(1) is True  # wheel up -> previous
+    assert fb.idx == 5
+
+
+def test_wheel_scroll_adjusts_scroll_offset_panel() -> None:
+    panel = SystemDoctorPanel.__new__(SystemDoctorPanel)
+    panel.scroll = 5
+    assert panel.scroll_by(1) is True  # wheel up
+    assert panel.scroll == 4
+    panel.scroll = 0
+    assert panel.scroll_by(1) is False  # clamped at top
+
+
+def test_scroll_by_noop_without_scroll_or_idx() -> None:
+    bare = FileBrowserPanel.__new__(FileBrowserPanel)
+    # No 'scroll', no 'idx'/'entries' attributes -> safe no-op.
+    assert bare.scroll_by(1) is False
+
+
+def test_mouse_dispatch_is_noop_when_disabled() -> None:
+    # With mouse support off/unavailable the handler must not touch curses or crash.
+    from ecli.core.Ecli import Ecli
+
+    editor = Ecli.__new__(Ecli)
+    editor.mouse_active = False
+    assert editor._handle_mouse_event() is False
+
+
+def test_focus_helper_is_deterministic() -> None:
+    from ecli.core.Ecli import Ecli
+
+    editor = Ecli.__new__(Ecli)
+    editor.focus = "editor"
+    assert editor._focus_to("editor") is False  # no change
+    assert editor._focus_to("panel") is True
+    assert editor.focus == "panel"

--- a/tests/ui/test_professional_chrome.py
+++ b/tests/ui/test_professional_chrome.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/ui/test_professional_chrome.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Tests for the professional chrome (header/status/footer) layout and the
+guarantee that chrome rendering never mutates the editor buffer.
+"""
+
+from __future__ import annotations
+
+import curses
+
+import pytest
+from wcwidth import wcswidth
+
+from ecli.ui.DrawScreen import DrawScreen
+from ecli.utils.themes import get_theme
+
+
+# --- Pure geometry -------------------------------------------------------
+
+
+@pytest.mark.parametrize("height", [5, 6, 7, 8, 10, 24, 40, 120])
+def test_content_plus_chrome_equals_height(height: int) -> None:
+    header_h, status_h, footer_h = DrawScreen.chrome_heights(height)
+    content = DrawScreen.content_height(height)
+    assert content >= 1
+    assert content + header_h + status_h + footer_h == height
+
+
+def test_full_chrome_on_tall_terminal() -> None:
+    assert DrawScreen.chrome_heights(24) == (1, 1, 1)
+    # 24 - header - status - footer
+    assert DrawScreen.content_height(24) == 21
+
+
+def test_chrome_degrades_on_small_terminal() -> None:
+    # Below the threshold the header and footer are dropped (status only),
+    # maximising editable rows on tiny terminals.
+    header_h, status_h, footer_h = DrawScreen.chrome_heights(6)
+    assert (header_h, status_h, footer_h) == (0, 1, 0)
+    assert DrawScreen.content_height(6) == 5
+
+
+def test_content_height_never_zero() -> None:
+    for height in range(1, 200):
+        assert DrawScreen.content_height(height) >= 1
+
+
+# --- Vertical-border geometry --------------------------------------------
+
+
+def test_borders_present_on_full_size_terminal() -> None:
+    assert DrawScreen.border_cols(24, 84) == (1, 1)
+    assert DrawScreen.border_cols(40, 120) == (1, 1)
+
+
+def test_borders_dropped_on_narrow_terminal() -> None:
+    assert DrawScreen.border_cols(24, 30) == (0, 0)
+
+
+def test_borders_dropped_on_short_terminal() -> None:
+    # Below the full-chrome height threshold there is no top/bottom frame, so
+    # the verticals are dropped too.
+    assert DrawScreen.border_cols(6, 120) == (0, 0)
+
+
+@pytest.mark.parametrize("width", [40, 84, 120, 200])
+def test_content_width_inside_borders_is_positive(width: int) -> None:
+    left, right = DrawScreen.border_cols(24, width)
+    content_width = width - left - right
+    assert content_width > 0
+    assert content_width == width - 2  # both borders present at these widths
+
+
+# --- Chrome rendering does not mutate the buffer -------------------------
+
+
+class FakeWin:
+    """Minimal curses-window stand-in that records written cells."""
+
+    def __init__(self, rows: int, cols: int) -> None:
+        """Create a blank fake window of the given size."""
+        self.rows = rows
+        self.cols = cols
+        self.cells: dict[tuple[int, int], str] = {}
+
+    def getmaxyx(self) -> tuple[int, int]:
+        return (self.rows, self.cols)
+
+    def addstr(self, y: int, x: int, text: str, _attr: int = 0) -> None:
+        if y < 0 or y >= self.rows or x < 0:
+            raise curses.error("out of bounds")
+        if x + len(text) > self.cols:
+            raise curses.error("would write past EOL")
+        for i, ch in enumerate(text):
+            self.cells[(y, x + i)] = ch
+
+    def insch(self, y: int, x: int, ch: int | str, _attr: int = 0) -> None:
+        if y < 0 or y >= self.rows or x < 0 or x >= self.cols:
+            raise curses.error("out of bounds")
+        self.cells[(y, x)] = chr(ch) if isinstance(ch, int) else ch
+
+    def chgat(self, *_a: object, **_k: object) -> None:
+        return None
+
+
+class FakeEditor:
+    def __init__(self) -> None:
+        """Create a fake editor with a small multi-line buffer."""
+        self.text = ["import os", "", "def main():", "    return 1"]
+        self.filename = "/home/user/projects/ecli/src/sample.py"
+        self.modified = True
+        self.is_lightweight = False
+        self.active_theme = get_theme(5)
+        self.cursor_y = 0
+
+    def get_string_width(self, text: str) -> int:
+        width = wcswidth(text)
+        return len(text) if width < 0 else width
+
+
+def _make_drawscreen(win: FakeWin) -> DrawScreen:
+    ds = DrawScreen.__new__(DrawScreen)
+    ds.editor = FakeEditor()  # type: ignore[assignment]
+    ds.stdscr = win  # type: ignore[assignment]
+    ds.colors = {}  # exercise the .get(...) defaults path
+    ds.config = {}
+    ds.content_area_y_offset = 1
+    ds._text_start_x = 0
+    return ds
+
+
+def _row_text(win: FakeWin, y: int) -> str:
+    xs = [x for (yy, x) in win.cells if yy == y]
+    if not xs:
+        return ""
+    return "".join(win.cells.get((y, x), " ") for x in range(max(xs) + 1))
+
+
+def test_header_renders_app_file_and_theme_within_bounds() -> None:
+    win = FakeWin(24, 90)
+    ds = _make_drawscreen(win)
+    before = list(ds.editor.text)
+
+    ds._draw_header(90)
+
+    row0 = _row_text(win, 0)
+    assert "ECLI" in row0
+    assert "sample.py" in row0
+    assert "theme 5" in row0 or "Dark Classic" in row0
+    # Every write stays within the terminal width.
+    assert all(0 <= x < 90 for (_y, x) in win.cells)
+    # Buffer is untouched by chrome rendering.
+    assert ds.editor.text == before
+
+
+def test_footer_renders_shortcuts_within_bounds() -> None:
+    win = FakeWin(24, 90)
+    ds = _make_drawscreen(win)
+    before = list(ds.editor.text)
+
+    ds._draw_footer(90)
+
+    last = _row_text(win, 23)
+    assert "Ctrl+S" in last and "Save" in last
+    assert "Quit" in last
+    assert all(0 <= x < 90 for (_y, x) in win.cells)
+    assert ds.editor.text == before
+
+
+def test_footer_truncates_on_narrow_terminal_without_error() -> None:
+    win = FakeWin(24, 24)
+    ds = _make_drawscreen(win)
+    ds._draw_footer(24)
+    # Nothing was written past the (narrow) width.
+    assert all(0 <= x < 24 for (_y, x) in win.cells)
+
+
+def test_shorten_path_keeps_basename() -> None:
+    win = FakeWin(24, 90)
+    ds = _make_drawscreen(win)
+    long_path = "/very/deeply/nested/directory/structure/module_name.py"
+    out = ds._shorten_path(long_path, 25)
+    assert ds.editor.get_string_width(out) <= 25
+    assert "module_name.py" in out
+
+
+def test_header_and_footer_do_not_write_into_buffer_lines() -> None:
+    win = FakeWin(24, 90)
+    ds = _make_drawscreen(win)
+    sentinel = list(ds.editor.text)
+    ds._draw_header(90)
+    ds._draw_footer(90)
+    # No file content leaked into chrome, no chrome leaked into the buffer.
+    assert ds.editor.text == sentinel
+    assert "ECLI" not in "".join(ds.editor.text)

--- a/tests/ui/test_service_panels.py
+++ b/tests/ui/test_service_panels.py
@@ -38,12 +38,17 @@ class FakeWindow:
         """Initialize a fake curses window."""
         self.keypad_values: list[bool] = []
         self.drawn_text: list[str] = []
+        self.bkgd_calls: list[tuple[str, int]] = []
+        self.touch_count = 0
 
     def getmaxyx(self) -> tuple[int, int]:
         return (32, 120)
 
     def keypad(self, value: bool) -> None:
         self.keypad_values.append(value)
+
+    def bkgd(self, ch: str, attr: int = 0) -> None:
+        self.bkgd_calls.append((ch, attr))
 
     def erase(self) -> None:
         self.drawn_text.clear()
@@ -53,6 +58,9 @@ class FakeWindow:
 
     def addnstr(self, _y: int, _x: int, text: str, _width: int, _attr: int = 0) -> None:
         self.drawn_text.append(text)
+
+    def touchwin(self) -> None:
+        self.touch_count += 1
 
     def refresh(self) -> None:
         return None
@@ -181,6 +189,57 @@ def test_system_doctor_panel_renders_structured_findings() -> None:
     assert "DOCTOR-CONFIG-001" in text
     assert "Repository logs directory is missing" in text
     assert "remediation=yes" in text
+
+
+def test_panel_applies_opaque_background_and_touches_window() -> None:
+    # Opaque background + full re-copy each frame => no editor text bleeds
+    # through the panel (no ghosting overlay).
+    registry = FakeRegistry([finding()])
+    editor = FakeEditor(registry)
+    panel = SystemDoctorPanel(editor.stdscr, editor, registry=registry)
+
+    panel.open()
+    panel.draw()
+
+    assert panel.win.bkgd_calls, "panel must paint an opaque themed background"
+    assert panel.win.touch_count >= 1, "panel must touch its window before refresh"
+
+
+def test_side_panel_occupies_work_area_not_global_chrome() -> None:
+    # FakeWindow is 32x120: editor 60% / panel 40%, work-area rows only.
+    from ecli.ui.geometry import compute_layout
+
+    registry = FakeRegistry([finding()])
+    editor = FakeEditor(registry)
+    panel = SystemDoctorPanel(editor.stdscr, editor, registry=registry)
+
+    geo = compute_layout(120, 32, active_panel=True)
+    assert geo.split is True
+    assert panel.start_y == geo.panel.y == 1  # below the global header
+    assert panel.start_x == geo.panel.x == geo.editor.width  # 60% split
+    assert panel.start_x + panel.width == 120  # ends at the right edge
+    # The panel must stop before the global status/footer rows (no overlap).
+    status_y = 32 - 2
+    assert panel.start_y + panel.height <= status_y
+    assert panel._rendered_as_modal is False
+
+
+class NarrowWindow(FakeWindow):
+    def getmaxyx(self) -> tuple[int, int]:
+        return (6, 20)
+
+
+def test_panel_narrow_terminal_does_not_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("ecli.ui.panels.curses.newwin", lambda *args: NarrowWindow())
+    registry = FakeRegistry([finding()])
+    editor = FakeEditor(registry)
+    editor.stdscr = NarrowWindow()
+    panel = SystemDoctorPanel(editor.stdscr, editor, registry=registry)
+
+    panel.open()
+    panel.draw()  # must not raise on a tiny terminal
 
 
 def test_system_doctor_panel_opens_command_plan_preview_for_finding() -> None:

--- a/tests/ui/test_terminal_panel_reservation.py
+++ b/tests/ui/test_terminal_panel_reservation.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/ui/test_terminal_panel_reservation.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Architecture-readiness tests for the future Terminal Panel (not implemented).
+
+These assert that the generic split-layout/panel system explicitly *reserves*
+the ``terminal`` panel kind and the F11 keybinding, and that a future terminal
+side panel would inherit the existing split layout unchanged — without any PTY,
+subprocess or terminal UI being present yet.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+import ecli.ui.panels as panels_module
+from ecli.core.Ecli import Ecli
+from ecli.ui.geometry import compute_layout
+from ecli.ui.KeyBinder import KeyBinder
+from ecli.ui.panels import MODAL_PANEL_KINDS, SIDE_PANEL_KINDS, BasePanel
+
+
+def test_terminal_is_a_reserved_side_panel_kind() -> None:
+    assert "terminal" in SIDE_PANEL_KINDS
+    assert "terminal" not in MODAL_PANEL_KINDS
+
+
+def test_terminal_panel_is_not_implemented_yet() -> None:
+    # Reserved vocabulary only: no TerminalPanel class, no PTY/subprocess wiring.
+    assert not hasattr(panels_module, "TerminalPanel")
+
+
+def test_toggle_terminal_panel_is_a_safe_noop() -> None:
+    editor = Ecli.__new__(Ecli)
+    messages: list[str] = []
+    editor._set_status_message = lambda m, *a, **k: messages.append(m)  # type: ignore[method-assign]
+    # Must not crash, must not open a panel or start anything; just reports back.
+    assert editor.toggle_terminal_panel() is True
+    assert messages and "Terminal" in messages[0]
+
+
+def test_f11_is_reserved_for_terminal_panel() -> None:
+    source = inspect.getsource(KeyBinder)
+    assert '"toggle_terminal_panel"' in source
+    assert "f11" in source
+    assert "self.editor.toggle_terminal_panel" in source
+
+
+# --- A representative future terminal side panel inherits the split layout ----
+
+
+class _FakeWin:
+    def __init__(self) -> None:
+        """Minimal curses-window stand-in."""
+        self.bkgd_calls: list[tuple] = []
+
+    def getmaxyx(self) -> tuple[int, int]:
+        return (32, 120)
+
+    def keypad(self, _value: bool) -> None:
+        return None
+
+    def bkgd(self, *args: object) -> None:
+        self.bkgd_calls.append(args)
+
+    def touchwin(self) -> None:
+        return None
+
+    def noutrefresh(self) -> None:
+        return None
+
+
+class _FakeEditor:
+    def __init__(self) -> None:
+        """Editor double exposing only what BasePanel geometry needs."""
+        self.stdscr = _FakeWin()
+        self.colors: dict[str, int] = {}
+        self.is_lightweight = False
+
+
+class _TerminalLikePanel(BasePanel):
+    """Stand-in for the FUTURE Terminal Panel; no PTY/subprocess here."""
+
+    panel_kind = "terminal"
+    is_modal_panel = False
+
+
+def test_future_terminal_side_panel_gets_split_layout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("ecli.ui.panels.curses.newwin", lambda *args: _FakeWin())
+    editor = _FakeEditor()
+    panel = _TerminalLikePanel(editor.stdscr, editor)  # type: ignore[arg-type]
+
+    panel._layout_window()
+
+    geo = compute_layout(120, 32, active_panel=True)
+    assert panel.panel_kind == "terminal"
+    assert panel._rendered_as_modal is False
+    # Same 60/40 split, work-area rows only, no global-chrome overlap.
+    assert panel.start_y == geo.panel.y == 1
+    assert panel.start_x == geo.editor.width
+    assert panel.start_x + panel.width == 120
+    assert panel.start_y + panel.height <= 32 - 2
+    # Opaque background applied like every other side panel.
+    assert panel.win.bkgd_calls


### PR DESCRIPTION
## Summary

Stabilize ECLI editor rendering, file round-trip behavior, theme handling, paste/copy correctness, mouse-selection foundations, and terminal UI panels.

This PR moves the editor toward a professional terminal application model with theme-aware chrome, opaque panels, MC-style panel behavior, and cleaner buffer/rendering separation.

## What changed

* Fix file/buffer/save round-trip stability so multiline files do not collapse after save/reopen.
* Use deterministic LF save behavior.
* Add an 8-theme built-in theme system selectable via `theme = 1..8`.
* Wire syntax highlighting to the active theme palette.
* Improve xterm-256 color fidelity for near-neutral colors.
* Add professional editor chrome:

  * header
  * status bar
  * footer/action strip
  * line-number gutter
  * current-line highlight
* Add shared terminal UI design roles.
* Add shared layout geometry for editor/panel regions.
* Add mouse/hit-test model foundations.
* Add text operations utilities for selection/copy/paste correctness.
* Improve panel rendering with:

  * opaque backgrounds
  * consistent borders
  * theme-aware styling
  * no ghosted editor text
* Move side panels toward MC-style split layout and selection behavior.
* Improve File Manager, Git Control, System Doctor, AI Provider, Help, and diagnostics panel rendering.
* Add paste transaction handling for multiline paste and Unicode preservation.
* Add logical copy/selection behavior so copied editor text excludes gutter, line numbers, borders, and UI chrome.
* Reserve the layout/focus architecture for a future side Terminal Panel.

## Behavior guarantees

* Keyboard-only operation remains supported.
* Editor copy uses logical buffer text, not visual screen cells.
* UI chrome is not copied into editor clipboard payloads.
* Multiline paste is normalized and inserted as text, not executed as shortcuts.
* Valid Unicode is preserved through paste/copy paths.
* Panels use solid backgrounds and consistent theme roles.
* Packaging, release, artifact naming, and package matrix surfaces are not intentionally changed.

## Validation

* `uv run ruff format --check .` — passed
* `uv run ruff check . --output-format=concise` — passed
* `uv run pytest -q` — passed, 601 passed
* `uv run pytest -ra -q` — passed, 601 passed
* `uv run python scripts/check_runtime_imports.py` — passed
* `python3 tools/license_guard.py --report logs/license-guard.md` — passed
* `git diff --check` — passed

## Manual validation

Live terminal testing was performed during the stabilization pass for:

* theme switching;
* panel rendering;
* File Manager visual behavior;
* paste/copy behavior;
* Unicode paste behavior;
* Ctrl+S and reopen behavior;
* editor/panel layout behavior.

## Deferred follow-up

* Dedicated side Terminal Panel.
* Full mouse UX polish:

  * drag selection refinement;
  * double-click File Manager open;
  * wheel tuning;
  * richer panel focus behavior.
* Further visual refinement toward a more complete MC/btop-quality application shell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Eight built-in color themes (light and dark variants) to choose from via `theme = 1-8` configuration
  * Optional mouse support—enable via configuration for click navigation and scrolling
  * Syntax highlighting can now be toggled on/off per editor instance
  * Professional header/footer interface with file, theme, and keyboard shortcut indicators

* **Bug Fixes**
  * File saving now uses consistent newline format across all platforms
  * Pasted text now properly normalizes line endings (CRLF/CR to LF)
  * Improved bracket-matching and cursor positioning calculations

* **Configuration**
  * Legacy `[colors]` and `[theme.ui]` tables automatically migrate to the new `theme = 1-8` setting
  * New `syntax_highlighting` and `mouse` boolean options in configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->