### PR TITLE
docs: define ECLI extensions layer architecture

### DIFF
--- a/.claude/PIPELINE.md
+++ b/.claude/PIPELINE.md
@@ -157,8 +157,12 @@ gh api repos/SSobol77/ecli/milestones --jq \
 |---|---|---|
 | `#70` publish v0.2.0 w/ TUI panels | v0.2.0 (m2) | reconcile vs released v0.2.2 → close-as-delivered OR keep as next-tag tracker |
 | `#53` reduce `Ecli.py` by service delegation | v0.2.0 (m2) | keep open; **no agent split of `Ecli.py`** (contract-forbidden) |
-| `#54` finalize VMLab contracts (`status:contract-drift`) | v0.3.0 (m3) | clear contract-drift BEFORE #55/#56 |
-| `#55/#56/#57` VMLab discovery/argv/CLI | v0.3.0 (m3) | keep `status:blocked` until m2 closes; order 54→55→56→57 |
+| `#54` finalize VMLab contracts (`status:contract-drift`) | v0.3.5 (m3) | clear contract-drift BEFORE #55/#56 |
+| `#55/#56/#57` VMLab discovery/argv/CLI | v0.3.5 (m3) | keep `status:blocked` until m2 closes; order 54→55→56→57 |
+
+Milestone note: the VMLab Skeleton is milestone #3, **v0.3.5 — VMLab Skeleton**,
+and stays `status:blocked` until the Extensions Foundation milestone completes.
+The Extensions Foundation milestone is **v0.3.0**.
 
 `[MAINTAINER]` Execute the chosen actions yourself (examples):
 

--- a/.claude/project-context.md
+++ b/.claude/project-context.md
@@ -99,6 +99,25 @@ Do not activate render-stabilizer, software-architect, test-harness-builder, or 
 
 Before Stage 2 starts, the maintainer must explicitly approve the transition from Stage 1 safety automation to Stage 2 rendering stabilization.
 
+## Extensions Layer contract (v0.3.0 Foundation)
+
+The ECLI Extensions Layer is defined normatively in
+`docs/architecture/extensions-layer.md`. It is the imported, data-only,
+VS Code / TextMate-compatible asset tree plus deterministic adapter code.
+Issue #97 is architecture/documentation only — no assets are imported and no
+runtime is implemented.
+
+- `src/ecli/extensions/` is the only approved location for imported extension
+  assets. Do not invent `vendor/`, `third_party/`, or `src/ecli/syntax/assets/`.
+- Imported/upstream files are read-only; add behavior through deterministic
+  adapter code, never by editing upstream files.
+- No VS Code extension host, no Node activation, no `activationEvents` execution,
+  no `package.json` scripts, no Copilot runtime, no network/auth side effects,
+  no hidden command execution through extension metadata.
+- Preserve F11 as the PySH Console Panel; no generic PTY terminal emulator.
+- VMLab moved to v0.3.5 and is blocked until the v0.3.0 Extensions Foundation is
+  complete.
+
 ## Operating constraints
 
 - Preserve user changes.

--- a/.codex/PIPELINE.md
+++ b/.codex/PIPELINE.md
@@ -38,6 +38,26 @@ The maintainer owns:
 * PyPI publishing,
 * release artifact upload.
 
+## Extensions Layer contract (v0.3.0 Foundation)
+
+The ECLI Extensions Layer is defined normatively in
+`docs/architecture/extensions-layer.md`. It is the imported, data-only,
+VS Code / TextMate-compatible asset tree plus deterministic adapter code.
+Issue #97 is architecture/documentation only.
+
+Codex must obey:
+
+* `src/ecli/extensions/` is the only approved location for imported extension
+  assets. Do not invent `vendor/`, `third_party/`, or `src/ecli/syntax/assets/`.
+* Imported/upstream files are read-only; add behavior through deterministic
+  adapter code, never by editing upstream files.
+* No VS Code extension host, no Node activation, no `activationEvents`
+  execution, no `package.json` scripts, no Copilot runtime, no network/auth side
+  effects, no hidden command execution through extension metadata.
+* Preserve F11 as the PySH Console Panel; no generic PTY terminal emulator.
+* VMLab moved to v0.3.5 and is blocked until the v0.3.0 Extensions Foundation is
+  complete.
+
 ## Recommended Codex execution mode
 
 For Stage 1 inventory and diagnostics:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -659,3 +659,35 @@ Result:
 ```
 
 If no files were changed, say so explicitly.
+
+## 13. Extensions Layer contract (v0.3.0 Foundation)
+
+The ECLI Extensions Layer is the imported, data-only, VS Code / TextMate-compatible
+asset tree and the deterministic adapter code around it. Its normative contract is
+`docs/architecture/extensions-layer.md`. Until the asset tree is imported in a
+later issue, this is documentation/architecture only.
+
+All agents (Codex, Claude Code, Cursor, and any other automation) must obey:
+
+* `src/ecli/extensions/` is the **only** approved location for imported extension
+  assets. Do not invent or use `vendor/`, `third_party/`, or
+  `src/ecli/syntax/assets/`.
+* Imported/upstream files under `src/ecli/extensions/` are **read-only** from the
+  ECLI integration perspective. Do not edit, reformat, or relicense them.
+* Implement ECLI-specific behavior through **deterministic adapter code** that
+  reads those assets, never by modifying upstream files.
+* **No VS Code extension host, no Node/TypeScript activation, no
+  `activationEvents` execution, no `package.json` scripts, no Copilot runtime,
+  no network/auth side effects, no hidden command execution** through extension
+  metadata.
+* Preserve **F11 as the PySH Console Panel**; command execution stays routed
+  through explicit ECLI services / PySH / CommandPlan surfaces.
+* **No generic PTY terminal emulator.** Extensions must not reintroduce terminal
+  execution behavior.
+* Do not import the prepared asset tree in issue #97. Sequencing is #97 contract,
+  #98 import unchanged, #99 package-data tests, #100–#105 adapters.
+* When the asset tree is imported (#98) and tested (#99), extension data files
+  must be included in the wheel and sdist with explicit package-data coverage,
+  and all active platform packaging contracts must remain green.
+* VMLab is out of scope: it moved to v0.3.5 and is blocked until the v0.3.0
+  Extensions Foundation is complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -858,3 +858,33 @@ Result:
 ```
 
 If no files were changed, say so explicitly.
+
+## 20. Extensions Layer contract (v0.3.0 Foundation)
+
+The ECLI Extensions Layer is the imported, data-only, VS Code / TextMate-compatible
+asset tree and the deterministic adapter code around it. Its normative contract is
+`docs/architecture/extensions-layer.md`. Until the asset tree is imported in a
+later issue, this is documentation/architecture only.
+
+Agents working anywhere near extensions, syntax highlighting, themes, snippets,
+language configuration, or linter/diagnostics asset wiring must obey:
+
+* `src/ecli/extensions/` is the **only** approved location for imported extension
+  assets. Do not invent or use `vendor/`, `third_party/`, or
+  `src/ecli/syntax/assets/`.
+* Imported/upstream files under `src/ecli/extensions/` are **read-only** from the
+  ECLI integration perspective. Do not edit, reformat, or relicense them.
+* Implement ECLI-specific behavior through **deterministic adapter code** that
+  reads those assets, never by modifying upstream files.
+* **No VS Code extension host, no Node/TypeScript activation, no
+  `activationEvents` execution, no `package.json` scripts, no Copilot runtime,
+  no network/auth side effects, no hidden command execution** through extension
+  metadata.
+* Preserve **F11 as the PySH Console Panel**; command execution stays routed
+  through explicit ECLI services / PySH / CommandPlan surfaces.
+* **No generic PTY terminal emulator.** Extensions must not reintroduce terminal
+  execution behavior.
+* Do not import the prepared asset tree in issue #97. Sequencing is #97 contract,
+  #98 import unchanged, #99 package-data tests, #100–#105 adapters.
+* VMLab is out of scope: it moved to v0.3.5 and is blocked until the v0.3.0
+  Extensions Foundation is complete.

--- a/CODEX.md
+++ b/CODEX.md
@@ -194,6 +194,35 @@ During Stage 1, Codex may only:
 
 Codex must not implement the rendering rewrite during Stage 1.
 
+## Extensions Layer contract (v0.3.0 Foundation)
+
+The ECLI Extensions Layer is the imported, data-only, VS Code / TextMate-compatible
+asset tree and the deterministic adapter code around it. Its normative contract is
+`docs/architecture/extensions-layer.md`. Until the asset tree is imported in a
+later issue, this is documentation/architecture only.
+
+Codex must obey:
+
+* `src/ecli/extensions/` is the **only** approved location for imported extension
+  assets. Do not invent or use `vendor/`, `third_party/`, or
+  `src/ecli/syntax/assets/`.
+* Imported/upstream files under `src/ecli/extensions/` are **read-only** from the
+  ECLI integration perspective. Do not edit, reformat, or relicense them.
+* Implement ECLI-specific behavior through **deterministic adapter code** that
+  reads those assets, never by modifying upstream files.
+* **No VS Code extension host, no Node/TypeScript activation, no
+  `activationEvents` execution, no `package.json` scripts, no Copilot runtime,
+  no network/auth side effects, no hidden command execution** through extension
+  metadata.
+* Preserve **F11 as the PySH Console Panel**; command execution stays routed
+  through explicit ECLI services / PySH / CommandPlan surfaces.
+* **No generic PTY terminal emulator.** Extensions must not reintroduce terminal
+  execution behavior.
+* Do not import the prepared asset tree in issue #97. Sequencing is #97 contract,
+  #98 import unchanged, #99 package-data tests, #100–#105 adapters.
+* VMLab is out of scope: it moved to v0.3.5 and is blocked until the v0.3.0
+  Extensions Foundation is complete.
+
 ## Expected Codex final response
 
 For non-trivial work, finish with:

--- a/docs/architecture/README-architecture.md
+++ b/docs/architecture/README-architecture.md
@@ -27,6 +27,7 @@ Defines architecture authority, ownership contracts, lifecycle semantics, and mi
 | `event-and-concurrency-model.md` | Operational + contract | queue ownership, payload expectations, redraw triggers |
 | `integration-boundaries.md` | Normative + operational | integration isolation, degradation semantics, failure consequence |
 | `panel-console-stabilization.md` | Normative boundary | 0.2.x F11/PySH console direction and full PTY terminal emulator rejection |
+| `extensions-layer.md` | Normative contract | v0.3.0 imported data-only extension asset tree under `src/ecli/extensions/` and the deterministic adapter boundary |
 
 ## Explicit Authority Pointers
 

--- a/docs/architecture/extensions-layer.md
+++ b/docs/architecture/extensions-layer.md
@@ -1,0 +1,242 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+
+Project: Ecli
+File: docs/architecture/extensions-layer.md
+Website: https://www.ecli.io
+Repository: https://github.com/SSobol77/ecli
+PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+
+Copyright (c) 2026 Siergej Sobolewski
+
+Licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for full license text.
+-->
+# ECLI Extensions Layer
+
+## Status
+
+- Class: Normative architecture contract.
+- Milestone: v0.3.0 — Extensions Foundation.
+- Scope of this document (issue #97): architecture contract only. No code, no
+  imported asset tree, no runtime, no packaging implementation changes.
+
+This document defines the **ECLI Extensions Layer** boundary before any asset is
+imported. It is the authority for what `src/ecli/extensions/` is, what may live
+there, and how ECLI is allowed to consume it. It exists so that issue #98 (asset
+import) and later issues land against a contract that is already agreed.
+
+> Current state: `src/ecli/extensions/` does not exist yet. This contract is
+> written ahead of the import so the import is deterministic and reviewable.
+
+## Definition
+
+The ECLI Extensions Layer is the bounded location and contract for **imported,
+VS Code / TextMate-compatible, data-only assets** that ECLI uses to drive editor
+quality features: syntax highlighting, readable themes, a diagnostics/linter
+path, snippets, and language-configuration metadata.
+
+- Imported VS Code / TextMate-compatible assets live under
+  `src/ecli/extensions/`.
+- `src/ecli/extensions/` is the **only** approved location for imported
+  extension assets. Do not invent `vendor/`, `third_party/`,
+  `src/ecli/syntax/assets/`, or any other parallel asset tree.
+- Imported / upstream assets are **read-only from the ECLI integration
+  perspective**. They must remain byte-for-byte unchanged versus their upstream
+  source.
+- ECLI-specific behavior must be implemented through **deterministic adapter
+  code** that reads those assets. ECLI must not patch, rewrite, or fork upstream
+  files to change behavior.
+
+The Extensions Layer is a **data layer plus adapter code**, not an extension
+*host*. ECLI consumes static metadata and grammars; it does not execute
+extension programs.
+
+## Relationship to existing extension docs
+
+This document is distinct from the existing `docs/extensions/*` set:
+
+- `docs/extensions/plugin-api.md`, `extension-guardrails.md`,
+  `ai-provider-runtime.md`, `diagnostics-model.md` describe ECLI's own runtime
+  plugin/integration boundaries and the AI/diagnostics runtime.
+- This document (`docs/architecture/extensions-layer.md`) describes the
+  **imported, data-only asset tree** under `src/ecli/extensions/` and the
+  adapter contract around it.
+
+Where the two overlap (for example the diagnostics path), the imported asset
+layer feeds ECLI's own normalization model defined in
+`docs/extensions/diagnostics-model.md`; it does not replace it.
+
+## Imported assets must remain unchanged
+
+- Files imported under `src/ecli/extensions/` are upstream artifacts.
+- ECLI must not edit them to add behavior, fix style, reformat, or relicense.
+- Any required ECLI-specific transformation happens at read time in adapter
+  code, never by mutating the imported file.
+- Re-imports replace the asset wholesale from upstream; ECLI carries no private
+  patches inside the tree.
+
+This keeps provenance auditable and keeps re-import a mechanical, deterministic
+operation.
+
+## Adapter code contract
+
+ECLI integration code around the imported assets must be **deterministic adapter
+code**:
+
+- pure, side-effect-free reads of declared data inputs,
+- no execution of imported code paths,
+- no network, auth, filesystem-mutation, or process-spawn side effects triggered
+  by imported metadata,
+- stable, testable mapping from asset data to ECLI internal models.
+
+### Expected future adapter responsibilities (target state)
+
+These are the planned adapters. They are **not implemented in issue #97**; they
+are listed here so the boundary is fixed before implementation begins.
+
+- **package.json contribution registry** — parse `contributes.*` declarations
+  (languages, grammars, themes, snippets, configuration) into an ECLI-internal
+  registry. Ignore `activationEvents`, `main`, `scripts`, and any executable
+  hooks.
+- **TextMate grammar catalog** — index `syntaxes/*.tmLanguage.json` and
+  `syntaxes/*.tmLanguage` by scope name and language id.
+- **language detection** — map file name / extension / first-line patterns
+  (from `package.json` language contributions) to a language id.
+- **syntax service** — apply the resolved grammar to editor text to produce
+  scope spans for rendering.
+- **scope-to-style / theme bridge** — map TextMate scopes to ECLI theme styles,
+  producing readable, deterministic colors.
+- **diagnostics / linter integration path** — feed external linter/diagnostic
+  output into ECLI's existing diagnostics normalization model
+  (`docs/extensions/diagnostics-model.md`). The Extensions Layer supplies
+  language/linter metadata only; it does not itself run arbitrary tools.
+- **snippets registry** — load `snippets/*.code-snippets` into an ECLI snippet
+  store.
+- **language-configuration registry** — load `language-configuration.json`
+  (comments, brackets, auto-closing pairs, word patterns) for editor behavior.
+- **schema registry** — index `schemas/*.json` where applicable for
+  configuration/data validation.
+
+## Explicitly supported data-only inputs
+
+The Extensions Layer reads these file kinds and **only** these as data:
+
+- `package.json` — contribution manifest (data only; no activation/scripts).
+- `package.nls.json` — localization string table.
+- `language-configuration.json` — language editor behavior metadata.
+- `syntaxes/*.tmLanguage.json` — TextMate grammars (JSON form).
+- `syntaxes/*.tmLanguage` — TextMate grammars (plist/XML form).
+- `snippets/*.code-snippets` — snippet definitions.
+- `schemas/*.json` — JSON schemas where applicable.
+- `themes/*.json` — color themes, if present.
+- `cgmanifest.json` — component governance / provenance manifest.
+
+Any other file kind is out of scope for the Extensions Layer until this contract
+is amended.
+
+## Explicitly forbidden runtime behavior
+
+The Extensions Layer is data + adapters only. The following are forbidden:
+
+- **No VS Code extension host.** ECLI does not implement or embed the VS Code
+  extension API or activation lifecycle.
+- **No Node activation.** No Node.js/TypeScript extension runtime is started.
+- **No `activationEvents` execution.** Activation declarations are ignored, not
+  executed.
+- **No arbitrary scripts from `package.json`.** `scripts`, `main`, and similar
+  entrypoints are ignored.
+- **No Copilot runtime activation.** Imported Copilot-related assets, if any, are
+  treated as inert data and must not start any Copilot runtime.
+- **No network or auth side effects** from imported extension code or metadata.
+- **No hidden command execution through extensions.** Extension metadata must
+  never become a path to running commands. There is no implicit
+  metadata-to-command bridge.
+
+## PySH boundary
+
+The Extensions Layer must not weaken or bypass the panel-console boundary in
+`docs/architecture/panel-console-stabilization.md`:
+
+- **F11 remains the PySH Console Panel.** The Extensions Layer does not own,
+  replace, or re-route F11.
+- Command execution remains routed through **explicit ECLI services / PySH /
+  CommandPlan surfaces** (see `docs/architecture/command-plan-service.md`).
+- Extensions must not reintroduce terminal execution behavior, a generic PTY
+  terminal emulator, or any interactive shell embedded in curses.
+
+PySH is a command execution backend only. Imported extension assets are not a
+side channel into it.
+
+## Release / package-data impact
+
+Issue #97 does **not** change packaging. This section records the contract that
+later issues (#98/#99) must satisfy. The active release contract is the
+`Canonical 21-Item Platform & Packaging Artifact Matrix` (summarized by the
+`Platform & Packaging Release Contract Matrix`) in
+`docs/release/artifact-contract.md`; this section is additive guidance, not a
+new matrix entry.
+
+- When the asset tree is imported (#98) and tested (#99), extension assets under
+  `src/ecli/extensions/` **must be included in the wheel and sdist**. The wheel
+  uses `[tool.hatch.build.targets.wheel] packages = ["src/ecli"]`, so Python
+  packages are included automatically, but **non-`.py` data files**
+  (`*.json`, `*.tmLanguage`, `*.code-snippets`, etc.) require explicit
+  `force-include` (wheel) and `include` (sdist) coverage in `pyproject.toml`,
+  mirroring how `src/ecli/assets/ecli.png` is handled today.
+- **Package-data coverage must be tested.** A `tests/packaging/` test must assert
+  that imported extension data files are present in the built wheel and sdist
+  (added in #99), the same way other packaging contracts are enforced.
+- **All active platform packaging contracts must remain green.** Adding the asset
+  tree must not break any of the 21 canonical assets or their
+  `tests/packaging/` contract tests across: PyPI wheel and sdist; Linux
+  PyInstaller binary and tarball; Debian `.deb`; generic RPM; openSUSE RPM; Arch
+  package; Slackware `.txz`; AppImage; FreeBSD `.pkg`, ports/chroot evidence, and
+  the FreeBSD CI VM path; macOS `.app` evidence and `.dmg`; Windows portable EXE
+  and NSIS installer; Nix flake and NixOS package evidence; Docker DEB/RPM build
+  helper evidence; and the GitHub Actions workflow contract evidence.
+- The exact-21-asset count is unchanged by this layer; extension assets ship
+  *inside* the wheel/sdist artifacts, not as new top-level release assets.
+
+## Sequencing
+
+The Extensions Foundation is delivered as an ordered series. Each issue depends
+on the previous one and must not be skipped or merged.
+
+| Issue | Scope |
+|---|---|
+| #97 | Extensions Layer **architecture contract** (this document). No assets, no code. |
+| #98 | Import the prepared assets **unchanged** under `src/ecli/extensions/`. |
+| #99 | Asset **tree / package-data tests** (wheel/sdist inclusion, contract checks). |
+| #100 | **Manifest registry** (`package.json` contribution parsing). |
+| #101 | **TextMate grammar catalog** and **language detection**. |
+| #102 | **Syntax service** wired to editor rendering. |
+| #103 | **Theme bridge** (scope-to-style). |
+| #104 | **Linter diagnostics path**. |
+| #105 | **Snippets** and **language-configuration** metadata. |
+
+Issue #97 is complete when this contract exists; it explicitly does **not**
+import assets or implement adapters.
+
+## VMLab note
+
+VMLab is **not** part of the Extensions Foundation and is not touched by this
+work. VMLab has moved to the **v0.3.5** milestone and is **blocked until the
+v0.3.0 Extensions Foundation is complete**. This document does not change any
+VMLab implementation; the VMLab implementation docs under `docs/extensions/`
+remain as-is and out of scope for issue #97.
+
+## Acceptance checklist (issue #97)
+
+- [x] Defines the ECLI Extensions Layer.
+- [x] States imported assets live under `src/ecli/extensions/` and remain
+      unchanged.
+- [x] States ECLI integration is deterministic adapter code around the assets.
+- [x] Lists future adapter responsibilities.
+- [x] Lists explicitly supported data-only inputs.
+- [x] Lists explicitly forbidden runtime behavior (no host/Node/activation/
+      scripts/Copilot/network/hidden command execution).
+- [x] States the PySH boundary (F11 stays PySH Console Panel; no PTY emulator).
+- [x] States the release/package-data impact for #98/#99.
+- [x] States the #97–#105 sequencing.
+- [x] No assets imported; no runtime; no packaging implementation changes.

--- a/docs/architecture/panel-console-stabilization.md
+++ b/docs/architecture/panel-console-stabilization.md
@@ -95,8 +95,17 @@ architecture decision.
 
 ## Release Boundary
 
-v0.2.3 must not change the VMLab roadmap and must not modify the v0.3.0 VMLab
-Skeleton scope. VMLab remains in its own milestone line after v0.2.3.
+v0.2.3 must not change the VMLab roadmap and must not modify the VMLab Skeleton
+milestone scope. VMLab remains in its own milestone line after v0.2.3.
+
+> Roadmap clarification (recorded for issue #97; the v0.2.x ADR decision above is
+> unchanged). The milestone numbering has since been revised, so this note is
+> added to prevent misreading. The v0.3.0 milestone is now **Extensions
+> Foundation**. The VMLab Skeleton was moved to a later milestone,
+> **v0.3.5 — VMLab Skeleton**, and is blocked until the Extensions Foundation
+> milestone (v0.3.0) is complete. This clarification changes no technical
+> behavior: F11 remains the PySH Console Panel, and a generic PTY terminal
+> emulator remains rejected.
 
 ## Acceptance Checklist
 

--- a/docs/product/terminology-and-naming.md
+++ b/docs/product/terminology-and-naming.md
@@ -25,6 +25,21 @@ See the LICENSE file in the project root for full license text.
 - Use `artifact contract` only for release naming and verification policy.
 - Avoid mixing roadmap terms into normative architecture contracts.
 
+## Extensions Layer Terminology
+
+- `ECLI Extensions Layer` is the canonical name for the imported, data-only,
+  VS Code / TextMate-compatible asset tree and the deterministic adapter code
+  around it. It is defined in `docs/architecture/extensions-layer.md`.
+- `src/ecli/extensions/` is the only approved location for imported extension
+  assets. Do not introduce or refer to `vendor/`, `third_party/`, or
+  `src/ecli/syntax/assets/` for this purpose.
+- `imported assets` (or `upstream assets`) are read-only from the ECLI
+  integration perspective; ECLI behavior is added through `adapter code`, not by
+  editing imported files.
+- The Extensions Layer is a data + adapter layer, not an extension `host`. Do not
+  describe it as a VS Code extension host or a runtime that activates Node,
+  `activationEvents`, or Copilot.
+
 ## File Naming Policy for Docs
 
 - Lowercase kebab-case filenames.

--- a/docs/release/build-matrix.md
+++ b/docs/release/build-matrix.md
@@ -78,6 +78,23 @@ readiness depends on these CI/release surfaces remaining mapped:
   installer path.
 - `.github/workflows/windows-validate.yml`: Windows package validation.
 
+## Future Extensions Layer Package-Data Impact (planned, #98/#99)
+
+The ECLI Extensions Layer (`docs/architecture/extensions-layer.md`) does not yet
+exist on disk and does not change this matrix in issue #97. When the imported
+asset tree lands under `src/ecli/extensions/` (issue #98) and is covered by
+package-data tests (issue #99):
+
+- The 21-asset count is unchanged. Extension assets ship **inside** the existing
+  PyPI wheel/sdist and downstream artifacts, not as new top-level GitHub Release
+  assets.
+- Non-`.py` extension data files (`*.json`, `*.tmLanguage`,
+  `*.code-snippets`, `schemas/*.json`, etc.) require explicit wheel
+  `force-include` and sdist `include` coverage in `pyproject.toml`.
+- Every active platform/package contract above must remain green after the asset
+  tree is added; a `tests/packaging/` test must assert extension data inclusion
+  in the wheel and sdist.
+
 ## Validation State
 
 - Actual flow support is bounded by current CI behavior and script/workflow drift.

--- a/docs/release/packaging-flows.md
+++ b/docs/release/packaging-flows.md
@@ -56,6 +56,29 @@ ecli_<version>_docker_rpm_helper_evidence.tar.gz
 ecli_<version>_workflow_contract_evidence.tar.gz
 ```
 
+## Future Extensions Layer Package-Data (planned, #98/#99)
+
+The ECLI Extensions Layer (`docs/architecture/extensions-layer.md`) is an
+architecture contract only in issue #97 and changes no packaging flow here. When
+the imported, data-only asset tree lands under `src/ecli/extensions/` (issue #98)
+and is covered by tests (issue #99), the following packaging rules apply:
+
+- Extension assets must be included in the **PyPI wheel and sdist**. The wheel
+  target already includes the `src/ecli` package, but non-`.py` data files
+  (`package.json`, `*.tmLanguage`/`*.tmLanguage.json`, `*.code-snippets`,
+  `language-configuration.json`, `schemas/*.json`, `themes/*.json`,
+  `package.nls.json`, `cgmanifest.json`) require explicit
+  `[tool.hatch.build.targets.wheel.force-include]` and
+  `[tool.hatch.build.targets.sdist] include` entries, mirroring how
+  `src/ecli/assets/ecli.png` is shipped.
+- **Package-data coverage must be tested** under `tests/packaging/`, asserting the
+  imported extension data files are present in the built wheel and sdist.
+- Imported assets are read-only; packaging must ship them unchanged. Packaging
+  scripts must not mutate, reformat, or regenerate imported extension files.
+- The exact 21-asset GitHub Release contract is unchanged: extension assets ride
+  inside the wheel/sdist and downstream platform artifacts, not as new
+  top-level release assets.
+
 ## Shell-to-Python Script Migration
 
 Active packaging/build/verification scripts under `scripts/` have been migrated

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -60,6 +60,12 @@ See the LICENSE file in the project root for full license text.
       present in the exact 21-asset set.
 - [ ] Confirm vmactions/freebsd-vm is still pinned to a known-good commit SHA
       in both `release.yml` and `freebsd-pkg.yml`.
+- [ ] Extensions Layer (planned, gated by issue #98/#99): once imported under
+      `src/ecli/extensions/`, confirm non-`.py` extension data files are present
+      in the built wheel and sdist via `tests/packaging/`, that imported assets
+      are shipped unchanged, and that all 21 canonical assets remain green.
+      Not applicable until the asset tree is imported; see
+      `docs/architecture/extensions-layer.md`.
 
 ## Mandatory GitHub Release Assets
 


### PR DESCRIPTION
Defines the ECLI Extensions Layer architecture contract for v0.3.0.

Scope:
- documents src/ecli/extensions as the only approved imported extension asset path
- defines imported upstream assets as read-only from the ECLI integration perspective
- documents deterministic adapter-only integration
- forbids VS Code extension host, Node activation, Copilot runtime activation, hidden command execution, and generic PTY terminal reintroduction
- preserves F11 as the PySH Console Panel
- documents package-data and release-contract impact for future extension asset import
- updates agent/tooling contracts for AGENTS, CLAUDE, CODEX, .claude, and .codex
- records that VMLab moved to v0.3.5 and is blocked until v0.3.0 Extensions Foundation is complete

Validation:
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run pytest -q tests/docs tests/packaging tests/ui/test_terminal_panel_reservation.py tests/ui/test_pysh_console_panel.py tests/ui/test_pysh_console_panel_keybindings.py

No source/runtime changes.
No src/ecli/extensions asset import.
No VMLab implementation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Established Extensions Layer architecture contract defining rules for imported extension assets and deterministic adapter code.
  * Clarified project milestone structure: Extensions Foundation foundation (v0.3.0) precedes VMLab Skeleton (v0.3.5).
  * Added packaging expectations for future extension asset inclusion in wheel/sdist distributions.

* **Chores**
  * Updated release planning documentation; no functional changes.
  * F11 remains dedicated to PySH Console Panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->