### PR TITLE
test: add extension package-data contract coverage

### DIFF
--- a/docs/architecture/extensions-layer.md
+++ b/docs/architecture/extensions-layer.md
@@ -197,6 +197,14 @@ new matrix entry.
   helper evidence; and the GitHub Actions workflow contract evidence.
 - The exact-21-asset count is unchanged by this layer; extension assets ship
   *inside* the wheel/sdist artifacts, not as new top-level release assets.
+- **Status (#99):** tree and package-data contract tests live in
+  `tests/extensions/` (`test_extensions_tree_contract.py`,
+  `test_extensions_package_data_contract.py`). They prove representative
+  imported extension assets are present in the repository tree and inside the
+  built wheel and sdist. Hatchling's default file selection for
+  `packages = ["src/ecli"]` already ships the imported data files, so **no
+  additional `force-include`/`include` entries were required** in
+  `pyproject.toml`.
 
 ## Sequencing
 

--- a/tests/extensions/test_extensions_package_data_contract.py
+++ b/tests/extensions/test_extensions_package_data_contract.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/extensions/test_extensions_package_data_contract.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Package-data contract tests for imported extension assets (#99).
+
+These tests build the PyPI wheel and source distribution into a throwaway temp
+directory and prove, with the standard library only (``zipfile`` for the wheel
+and ``tarfile`` for the sdist), that representative imported extension assets
+from ``src/ecli/extensions/`` ship inside both artifacts.
+
+They build nothing into the repository tree, publish nothing, upload nothing,
+and create no release artifacts outside the pytest temp directory. The build is
+performed once per module via a module-scoped fixture.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tarfile
+import zipfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Representative imported assets, expressed as repository-relative source paths.
+REPRESENTATIVE_SOURCE_PATHS: tuple[str, ...] = (
+    "src/ecli/extensions/cgmanifest.json",
+    "src/ecli/extensions/bat/package.json",
+    "src/ecli/extensions/bat/language-configuration.json",
+    "src/ecli/extensions/bat/syntaxes/batchfile.tmLanguage.json",
+    "src/ecli/extensions/python/package.json",
+    "src/ecli/extensions/json/package.json",
+    "src/ecli/extensions/javascript/package.json",
+    "src/ecli/extensions/markdown-basics/package.json",
+)
+
+# Inside the wheel the ``src/`` prefix is dropped and ``ecli`` is the package
+# root, so ``src/ecli/extensions/X`` -> ``ecli/extensions/X``.
+WHEEL_MEMBER_PATHS: tuple[str, ...] = tuple(
+    path[len("src/") :] for path in REPRESENTATIVE_SOURCE_PATHS
+)
+
+
+def _build_command(out_dir: Path) -> list[str] | None:
+    """Return the artifact build command, preferring ``uv build``.
+
+    ``uv build`` provisions the ``hatchling`` build backend from uv's managed
+    environment, matching how this repository builds everywhere. ``python -m
+    build`` is the documented fallback (see ``scripts/publish_pypi.py``). Returns
+    ``None`` if no build frontend is available.
+    """
+    uv = shutil.which("uv")
+    if uv is not None:
+        return [uv, "build", "--out-dir", str(out_dir), str(REPO_ROOT)]
+    try:
+        import build  # noqa: F401
+    except ImportError:
+        return None
+    return [
+        sys.executable,
+        "-m",
+        "build",
+        "--outdir",
+        str(out_dir),
+        str(REPO_ROOT),
+    ]
+
+
+@pytest.fixture(scope="module")
+def built_artifacts(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[Path, Path]]:
+    """Build the wheel and sdist once into a temp dir; yield ``(wheel, sdist)``."""
+    out_dir = tmp_path_factory.mktemp("ecli_pkg_data_artifacts")
+    command = _build_command(out_dir)
+    if command is None:
+        pytest.skip("no build frontend available (need `uv` or the `build` module)")
+
+    result = subprocess.run(
+        command,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            "package build unavailable in this environment "
+            f"(exit {result.returncode}):\n{result.stdout}\n{result.stderr}"
+        )
+
+    wheels = sorted(out_dir.glob("*.whl"))
+    sdists = sorted(out_dir.glob("*.tar.gz"))
+    assert wheels, f"no wheel produced by build command: {command}"
+    assert sdists, f"no sdist produced by build command: {command}"
+    yield wheels[0], sdists[0]
+
+
+def test_wheel_contains_representative_extension_assets(
+    built_artifacts: tuple[Path, Path],
+) -> None:
+    wheel_path, _ = built_artifacts
+    with zipfile.ZipFile(wheel_path) as wheel:
+        names = set(wheel.namelist())
+
+    missing = [member for member in WHEEL_MEMBER_PATHS if member not in names]
+    assert not missing, (
+        f"wheel {wheel_path.name} is missing extension assets: {missing}"
+    )
+
+
+def test_sdist_contains_representative_extension_assets(
+    built_artifacts: tuple[Path, Path],
+) -> None:
+    _, sdist_path = built_artifacts
+    with tarfile.open(sdist_path) as sdist:
+        names = set(sdist.getnames())
+
+    # The sdist wraps everything in a single ``<name>-<version>/`` root dir.
+    roots = {name.split("/", 1)[0] for name in names if "/" in name}
+    root = next(
+        (candidate for candidate in roots if f"{candidate}/pyproject.toml" in names),
+        None,
+    )
+    assert root is not None, f"could not locate sdist root dir in {sdist_path.name}"
+
+    expected = [f"{root}/{path}" for path in REPRESENTATIVE_SOURCE_PATHS]
+    missing = [member for member in expected if member not in names]
+    assert not missing, (
+        f"sdist {sdist_path.name} is missing extension assets: {missing}"
+    )

--- a/tests/extensions/test_extensions_tree_contract.py
+++ b/tests/extensions/test_extensions_tree_contract.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/extensions/test_extensions_tree_contract.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Contract tests for the imported ECLI Extensions Layer source tree (#99).
+
+Issue #98 imported the prepared upstream VS Code / TextMate-compatible extension
+asset tree **unchanged** under ``src/ecli/extensions/``. This module asserts that
+representative imported assets are present in the repository tree, that the
+known import-cleanup artifacts are absent, and that each representative file
+*type* is represented at least once.
+
+These are read-only tree assertions only. They do not import, execute, parse, or
+adapt any extension asset, and they must never modify the imported tree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXTENSIONS_ROOT = REPO_ROOT / "src" / "ecli" / "extensions"
+
+
+# Representative imported assets that must exist verbatim in the tree. If any of
+# these ever differs from the imported upstream layout, fix the path here to the
+# real imported location -- never rename the upstream file.
+REPRESENTATIVE_ASSETS: tuple[str, ...] = (
+    "cgmanifest.json",
+    "bat/package.json",
+    "bat/language-configuration.json",
+    "bat/syntaxes/batchfile.tmLanguage.json",
+    "bat/snippets/batchfile.code-snippets",
+    "python/package.json",
+    "python/language-configuration.json",
+    "json/package.json",
+    "javascript/package.json",
+    "markdown-basics/package.json",
+    "cpp/package.json",
+)
+
+# Import-cleanup artifacts that must NOT exist under the extensions root: a
+# nested ``extensions/extensions/`` directory and the upstream structure note.
+FORBIDDEN_PATHS: tuple[str, ...] = (
+    "extensions",
+    "EXTENSIONS_FOLDER-structure.md",
+)
+
+
+def test_extensions_root_exists() -> None:
+    assert EXTENSIONS_ROOT.is_dir(), (
+        f"imported extensions root missing: {EXTENSIONS_ROOT}"
+    )
+
+
+@pytest.mark.parametrize("relative_path", REPRESENTATIVE_ASSETS)
+def test_representative_asset_exists(relative_path: str) -> None:
+    asset = EXTENSIONS_ROOT / relative_path
+    assert asset.is_file(), (
+        f"imported extension asset missing: src/ecli/extensions/{relative_path}"
+    )
+    assert asset.stat().st_size > 0, (
+        f"imported extension asset is empty: src/ecli/extensions/{relative_path}"
+    )
+
+
+@pytest.mark.parametrize("relative_path", FORBIDDEN_PATHS)
+def test_forbidden_path_absent(relative_path: str) -> None:
+    forbidden = EXTENSIONS_ROOT / relative_path
+    assert not forbidden.exists(), (
+        f"unexpected path present under extensions root: "
+        f"src/ecli/extensions/{relative_path}"
+    )
+
+
+# Representative file *types* that the imported tree must contain at least once.
+# ``glob_pattern`` is matched recursively under the extensions root.
+REPRESENTATIVE_TYPES: tuple[tuple[str, str], ...] = (
+    ("package.json", "**/package.json"),
+    ("package.nls.json", "**/package.nls.json"),
+    ("language-configuration.json", "**/language-configuration.json"),
+    ("*.tmLanguage.json", "**/*.tmLanguage.json"),
+    ("*.code-snippets", "**/*.code-snippets"),
+    ("cgmanifest.json", "**/cgmanifest.json"),
+)
+
+
+@pytest.mark.parametrize(("label", "glob_pattern"), REPRESENTATIVE_TYPES)
+def test_representative_file_type_present(label: str, glob_pattern: str) -> None:
+    matches = list(EXTENSIONS_ROOT.glob(glob_pattern))
+    assert matches, (
+        f"imported tree has no {label} file (pattern {glob_pattern!r}) under "
+        f"src/ecli/extensions/"
+    )


### PR DESCRIPTION
Adds contract coverage for the imported ECLI Extensions Layer assets under `src/ecli/extensions`.

Scope:
- adds repository tree contract tests for representative imported extension assets
- verifies forbidden import-shape artifacts are absent, including nested `src/ecli/extensions/extensions/` and `EXTENSIONS_FOLDER-structure.md`
- adds wheel and sdist package-data contract tests
- builds package artifacts in pytest temp directories and inspects them with standard-library `zipfile` and `tarfile`
- documents that #99 proves representative extension assets are included in wheel/sdist

Representative checked assets:
- `src/ecli/extensions/cgmanifest.json`
- `src/ecli/extensions/bat/package.json`
- `src/ecli/extensions/bat/language-configuration.json`
- `src/ecli/extensions/bat/syntaxes/batchfile.tmLanguage.json`
- `src/ecli/extensions/bat/snippets/batchfile.code-snippets`
- `src/ecli/extensions/python/package.json`
- `src/ecli/extensions/python/language-configuration.json`
- `src/ecli/extensions/json/package.json`
- `src/ecli/extensions/javascript/package.json`
- `src/ecli/extensions/markdown-basics/package.json`
- `src/ecli/extensions/cpp/package.json`

Confirmed:
- no imported upstream extension files modified
- no `pyproject.toml` package-data change required
- no runtime/source behavior added
- no VS Code extension host
- no Node/TypeScript activation
- no Copilot runtime activation
- no hidden command execution
- no generic PTY terminal emulator
- F11 remains the PySH Console Panel
- no VMLab, QEMU, or QMP behavior added
- no manifest registry, grammar catalog, syntax service, theme bridge, diagnostics, snippets, or language-configuration loaders

Validation:
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run python scripts/check_runtime_imports.py`
- `uv run pytest -q tests/extensions tests/packaging tests/docs tests/ui/test_terminal_panel_reservation.py tests/ui/test_pysh_console_panel.py tests/ui/test_pysh_console_panel_keybindings.py`

Closes #99.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture guidance on extensions packaging and distribution requirements.

* **Tests**
  * Added contract tests to verify extension assets are properly included in distribution packages.
  * Added contract tests to validate the extensions directory structure and required files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->