### PR TITLE
feat: add extension manifest registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,16 @@ jobs:
             uv run ruff check src
           fi
 
+      - name: Lint extensions adapter (ruff)
+        # The imported upstream extension tree under src/ecli/extensions/ is
+        # excluded from the broad Ruff scan above (issue #98), but the ECLI-owned
+        # adapter package src/ecli/extensions/ecli_integration/ (issue #100) is
+        # real source and must be linted explicitly. This focused check does not
+        # scan the imported upstream tree.
+        run: |
+          uv run ruff check src/ecli/extensions/ecli_integration
+          uv run ruff format --check src/ecli/extensions/ecli_integration
+
       - name: Format check (ruff)
         run: |
           if [ -d tests ]; then

--- a/docs/architecture/extensions-layer.md
+++ b/docs/architecture/extensions-layer.md
@@ -206,6 +206,22 @@ new matrix entry.
   additional `force-include`/`include` entries were required** in
   `pyproject.toml`.
 
+## Adapter status
+
+- **Status (#100):** ECLI now has a deterministic, **data-only** `package.json`
+  contribution registry under `src/ecli/extensions/ecli_integration/`
+  (`paths.py`, `manifest.py`, `registry.py`). It discovers direct-child
+  extension folders that contain a `package.json` (no recursion into nested
+  language-server/node `package.json` files), parses
+  `contributes.languages|grammars|snippets|configuration` into typed, immutable
+  metadata, resolves contribution target paths safely under
+  `src/ecli/extensions/` (rejecting traversal), and exposes read-only lookups by
+  language id, file extension, grammar, and snippet, plus deterministic
+  diagnostics for malformed manifests. It executes **no** extension code: no
+  extension host, no Node/TypeScript or Copilot runtime, no `activationEvents`,
+  and no `package.json` scripts. Covered by
+  `tests/extensions/test_extension_manifest_registry.py`.
+
 ## Sequencing
 
 The Extensions Foundation is delivered as an ordered series. Each issue depends

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,9 +137,12 @@ markers = [
 [tool.mypy]
 files = ["src/ecli", "tests"]
 # Imported, read-only VS Code / TextMate extension assets (issue #98) are not
-# ECLI Python sources and must not be type-checked. See
-# docs/architecture/extensions-layer.md.
-exclude = ['^src/ecli/extensions/']
+# ECLI Python sources and must not be type-checked. The negative lookahead keeps
+# the ECLI-owned deterministic adapter package
+# src/ecli/extensions/ecli_integration/ (issue #100) type-checked, while still
+# excluding every imported upstream extension folder beside it.
+# See docs/architecture/extensions-layer.md.
+exclude = ['^src/ecli/extensions/(?!ecli_integration/)']
 mypy_path = "src"
 python_version = "3.11"
 ignore_missing_imports = true

--- a/scripts/check_runtime_imports.py
+++ b/scripts/check_runtime_imports.py
@@ -30,7 +30,13 @@ SOURCE_ROOT = Path("src/ecli")
 # ECLI runtime source. The upstream tree must remain unchanged and contains
 # foreign-language code and intentionally-malformed Python fixtures, so this
 # guard must not parse it. See docs/architecture/extensions-layer.md.
-EXCLUDED_TOP_LEVEL = frozenset({"extensions"})
+#
+# Exception (issue #100): ``src/ecli/extensions/ecli_integration/`` is ECLI-owned
+# deterministic adapter code, not imported upstream, so it MUST be scanned. Every
+# other direct child of ``src/ecli/extensions/`` stays an imported upstream asset
+# tree and remains skipped.
+IMPORTED_EXTENSIONS_DIR = "extensions"
+ECLI_OWNED_EXTENSIONS_SUBDIR = "ecli_integration"
 
 
 def _forbidden_imports(path: Path) -> list[tuple[int, str]]:
@@ -57,13 +63,39 @@ def _is_forbidden_module(module_name: str) -> bool:
     return any(part in FORBIDDEN_IMPORT_PARTS for part in parts)
 
 
+def _is_imported_upstream(relative: Path) -> bool:
+    """Return ``True`` if ``relative`` (under ``src/ecli``) is an imported asset.
+
+    The imported VS Code extension tree lives under ``extensions/`` and is read
+    only (issue #98). The single ECLI-owned exception is the deterministic
+    adapter package ``extensions/ecli_integration/`` (issue #100), which is
+    scanned like any other ECLI source.
+    """
+    parts = relative.parts
+    if not parts or parts[0] != IMPORTED_EXTENSIONS_DIR:
+        return False
+    return len(parts) < 2 or parts[1] != ECLI_OWNED_EXTENSIONS_SUBDIR
+
+
+def scanned_source_files(root: Path | None = None) -> list[Path]:
+    """Return ECLI-owned ``*.py`` files under ``root``, skipping imported assets.
+
+    ``root`` defaults to the module-level ``SOURCE_ROOT`` resolved at call time,
+    so tests that monkeypatch ``SOURCE_ROOT`` are honoured.
+    """
+    base = SOURCE_ROOT if root is None else root
+    files: list[Path] = []
+    for path in sorted(base.rglob("*.py")):
+        if _is_imported_upstream(path.relative_to(base)):
+            continue
+        files.append(path)
+    return files
+
+
 def main() -> int:
     """Validate production runtime import policy."""
     violations: list[str] = []
-    for path in sorted(SOURCE_ROOT.rglob("*.py")):
-        relative = path.relative_to(SOURCE_ROOT)
-        if relative.parts and relative.parts[0] in EXCLUDED_TOP_LEVEL:
-            continue
+    for path in scanned_source_files():
         for lineno, import_text in _forbidden_imports(path):
             violations.append(
                 f"{path}:{lineno}: forbidden runtime import: {import_text}"

--- a/src/ecli/extensions/ecli_integration/__init__.py
+++ b/src/ecli/extensions/ecli_integration/__init__.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/extensions/ecli_integration/__init__.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""ECLI-owned deterministic adapter layer over the imported extension tree (#100).
+
+This package reads VS Code-style ``package.json`` contribution metadata from the
+read-only imported extension tree under ``src/ecli/extensions/`` and exposes it
+as typed, immutable Python data. It is data-only: it never starts a VS Code
+extension host, never activates a Node/TypeScript or Copilot runtime, never runs
+``activationEvents`` or ``package.json`` scripts, and never executes any command.
+"""
+
+from __future__ import annotations
+
+from .manifest import (
+    ConfigurationContribution,
+    ExtensionManifest,
+    GrammarContribution,
+    LanguageContribution,
+    RegistryDiagnostic,
+    SnippetContribution,
+    parse_manifest,
+)
+from .paths import extensions_root
+from .registry import (
+    ExtensionRegistry,
+    build_registry,
+    discover_manifest_directories,
+)
+
+
+__all__ = [
+    "ConfigurationContribution",
+    "ExtensionManifest",
+    "ExtensionRegistry",
+    "GrammarContribution",
+    "LanguageContribution",
+    "RegistryDiagnostic",
+    "SnippetContribution",
+    "build_registry",
+    "discover_manifest_directories",
+    "extensions_root",
+    "parse_manifest",
+]

--- a/src/ecli/extensions/ecli_integration/manifest.py
+++ b/src/ecli/extensions/ecli_integration/manifest.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/extensions/ecli_integration/manifest.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Data-only model + safe parser for VS Code ``package.json`` contributions (#100).
+
+This module turns an imported ``package.json`` contribution block into typed,
+immutable Python data. It is a deterministic adapter over the read-only imported
+extension tree (issue #98). It reads JSON metadata only and **never**:
+
+* executes ``activationEvents`` or ``scripts``,
+* runs npm/node/esbuild/tsc or any extension build tool,
+* activates a VS Code extension host or Copilot runtime,
+* performs network, auth, or any side effect.
+
+Fields that could describe executable behavior (``scripts``,
+``activationEvents``, ``main``, ``browser`` …) are intentionally **not** modeled,
+so they can never be exposed or invoked through this layer.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import paths
+
+
+@dataclass(frozen=True)
+class RegistryDiagnostic:
+    """A deterministic, non-fatal problem found while reading a manifest."""
+
+    level: str
+    manifest: str
+    message: str
+
+
+@dataclass(frozen=True)
+class LanguageContribution:
+    """A single ``contributes.languages[]`` entry (metadata only)."""
+
+    language_id: str
+    aliases: tuple[str, ...] = ()
+    extensions: tuple[str, ...] = ()
+    filenames: tuple[str, ...] = ()
+    filename_patterns: tuple[str, ...] = ()
+    configuration_path: str | None = None
+    configuration_repo_path: str | None = None
+
+
+@dataclass(frozen=True)
+class GrammarContribution:
+    """A single ``contributes.grammars[]`` entry (metadata only)."""
+
+    language_id: str | None
+    scope_name: str | None
+    path: str | None
+    path_repo_relative: str | None = None
+    embedded_languages: tuple[tuple[str, str], ...] = ()
+    token_types: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class SnippetContribution:
+    """A single ``contributes.snippets[]`` entry (metadata only)."""
+
+    language_id: str | None
+    path: str | None
+    path_repo_relative: str | None = None
+
+
+@dataclass(frozen=True)
+class ConfigurationContribution:
+    """A ``contributes.configuration`` block, reduced to declarative metadata.
+
+    Only the title, ordering hint, and the *names* of contributed settings are
+    preserved. Setting values, defaults, and schemas are never interpreted or
+    applied; this is pure metadata exposure.
+    """
+
+    title: str | None
+    order: int | None
+    property_keys: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ExtensionManifest:
+    """Parsed, data-only view of one extension's ``package.json``."""
+
+    name: str
+    directory_name: str
+    manifest_repo_path: str
+    display_name: str | None = None
+    version: str | None = None
+    publisher: str | None = None
+    languages: tuple[LanguageContribution, ...] = field(default_factory=tuple)
+    grammars: tuple[GrammarContribution, ...] = field(default_factory=tuple)
+    snippets: tuple[SnippetContribution, ...] = field(default_factory=tuple)
+    configuration: tuple[ConfigurationContribution, ...] = field(default_factory=tuple)
+
+
+@dataclass
+class _ParseContext:
+    """Mutable per-manifest parsing context shared by the section parsers."""
+
+    base_dir: Path
+    root: Path
+    label: str
+    diagnostics: list[RegistryDiagnostic]
+
+    def warn(self, message: str) -> None:
+        """Record a non-fatal warning diagnostic for this manifest."""
+        self.diagnostics.append(RegistryDiagnostic("warning", self.label, message))
+
+    def error(self, message: str) -> None:
+        """Record a fatal error diagnostic for this manifest."""
+        self.diagnostics.append(RegistryDiagnostic("error", self.label, message))
+
+    def resolve_target(self, relative: str | None, kind: str) -> str | None:
+        """Resolve a contribution target path; diagnose problems, never raise."""
+        if relative is None:
+            return None
+        resolved = paths.resolve_contribution_path(self.base_dir, relative, self.root)
+        if resolved is None:
+            self.warn(f"{kind} path escapes extension tree: {relative!r}")
+            return None
+        repo_relative = paths.to_repo_relative(resolved, self.root)
+        if not resolved.exists():
+            self.warn(f"{kind} target file missing: {repo_relative}")
+        return repo_relative
+
+
+def _as_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _str_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str))
+
+
+def _str_pairs(value: object) -> tuple[tuple[str, str], ...]:
+    if not isinstance(value, dict):
+        return ()
+    pairs = [
+        (key, val)
+        for key, val in value.items()
+        if isinstance(key, str) and isinstance(val, str)
+    ]
+    return tuple(sorted(pairs))
+
+
+def _parse_languages(
+    raw: object, context: _ParseContext
+) -> tuple[LanguageContribution, ...]:
+    if not isinstance(raw, list):
+        return ()
+    result: list[LanguageContribution] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        language_id = _as_str(entry.get("id"))
+        if language_id is None:
+            continue
+        configuration_path = _as_str(entry.get("configuration"))
+        result.append(
+            LanguageContribution(
+                language_id=language_id,
+                aliases=_str_tuple(entry.get("aliases")),
+                extensions=_str_tuple(entry.get("extensions")),
+                filenames=_str_tuple(entry.get("filenames")),
+                filename_patterns=_str_tuple(entry.get("filenamePatterns")),
+                configuration_path=configuration_path,
+                configuration_repo_path=context.resolve_target(
+                    configuration_path, "language-configuration"
+                ),
+            )
+        )
+    return tuple(result)
+
+
+def _parse_grammars(
+    raw: object, context: _ParseContext
+) -> tuple[GrammarContribution, ...]:
+    if not isinstance(raw, list):
+        return ()
+    result: list[GrammarContribution] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        grammar_path = _as_str(entry.get("path"))
+        result.append(
+            GrammarContribution(
+                language_id=_as_str(entry.get("language")),
+                scope_name=_as_str(entry.get("scopeName")),
+                path=grammar_path,
+                path_repo_relative=context.resolve_target(grammar_path, "grammar"),
+                embedded_languages=_str_pairs(entry.get("embeddedLanguages")),
+                token_types=_str_pairs(entry.get("tokenTypes")),
+            )
+        )
+    return tuple(result)
+
+
+def _parse_snippets(
+    raw: object, context: _ParseContext
+) -> tuple[SnippetContribution, ...]:
+    if not isinstance(raw, list):
+        return ()
+    result: list[SnippetContribution] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        snippet_path = _as_str(entry.get("path"))
+        result.append(
+            SnippetContribution(
+                language_id=_as_str(entry.get("language")),
+                path=snippet_path,
+                path_repo_relative=context.resolve_target(snippet_path, "snippet"),
+            )
+        )
+    return tuple(result)
+
+
+def _parse_configuration(raw: object) -> tuple[ConfigurationContribution, ...]:
+    blocks = raw if isinstance(raw, list) else [raw]
+    result: list[ConfigurationContribution] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        properties = block.get("properties")
+        property_keys = (
+            tuple(sorted(k for k in properties if isinstance(k, str)))
+            if isinstance(properties, dict)
+            else ()
+        )
+        order = block.get("order")
+        result.append(
+            ConfigurationContribution(
+                title=_as_str(block.get("title")),
+                order=order if isinstance(order, int) else None,
+                property_keys=property_keys,
+            )
+        )
+    return tuple(result)
+
+
+def parse_manifest(
+    directory: Path, root: Path
+) -> tuple[ExtensionManifest | None, list[RegistryDiagnostic]]:
+    """Parse ``directory/package.json`` into an :class:`ExtensionManifest`.
+
+    Returns ``(manifest, diagnostics)``. On unrecoverable problems (unreadable or
+    invalid JSON, or a non-object document) ``manifest`` is ``None`` and a
+    diagnostic explains why. Malformed ``contributes`` sub-sections degrade to
+    empty contributions with warnings rather than raising.
+    """
+    manifest_path = directory / "package.json"
+    label = paths.to_repo_relative(manifest_path, root)
+    context = _ParseContext(directory, root, label, [])
+
+    try:
+        text = manifest_path.read_text(encoding="utf-8")
+    except OSError as error:
+        context.error(f"cannot read package.json: {error}")
+        return None, context.diagnostics
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as error:
+        context.error(f"invalid JSON: {error}")
+        return None, context.diagnostics
+
+    if not isinstance(data, dict):
+        context.error("package.json is not a JSON object")
+        return None, context.diagnostics
+
+    contributes = data.get("contributes")
+    if contributes is not None and not isinstance(contributes, dict):
+        context.warn("contributes is not an object")
+        contributes = {}
+    contributes = contributes or {}
+
+    manifest = ExtensionManifest(
+        name=_as_str(data.get("name")) or directory.name,
+        directory_name=directory.name,
+        manifest_repo_path=label,
+        display_name=_as_str(data.get("displayName")),
+        version=_as_str(data.get("version")),
+        publisher=_as_str(data.get("publisher")),
+        languages=_parse_languages(contributes.get("languages"), context),
+        grammars=_parse_grammars(contributes.get("grammars"), context),
+        snippets=_parse_snippets(contributes.get("snippets"), context),
+        configuration=_parse_configuration(contributes.get("configuration")),
+    )
+    return manifest, context.diagnostics

--- a/src/ecli/extensions/ecli_integration/paths.py
+++ b/src/ecli/extensions/ecli_integration/paths.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/extensions/ecli_integration/paths.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Path helpers for the deterministic extension manifest registry (#100).
+
+These helpers locate the imported extension asset tree and resolve
+contribution-relative paths **safely**, guaranteeing that every resolved path
+stays under ``src/ecli/extensions/``. They never read, execute, or import any
+extension asset; they only compute and validate filesystem locations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+# Logical repository-relative prefix for the imported extension tree. This is a
+# stable identifier used in diagnostics and contribution records; it does not
+# depend on where the package is installed at runtime.
+REPO_RELATIVE_PREFIX = "src/ecli/extensions"
+
+
+def extensions_root() -> Path:
+    """Return the absolute path to the imported ``ecli/extensions`` asset tree.
+
+    ``paths.py`` lives at ``ecli/extensions/ecli_integration/paths.py``, so the
+    asset tree root is this file's grandparent directory. This works both in a
+    source checkout and inside an installed wheel.
+    """
+    return Path(__file__).resolve().parent.parent
+
+
+def to_repo_relative(path: Path, root: Path | None = None) -> str:
+    """Return ``path`` as a logical ``src/ecli/extensions/...`` POSIX string.
+
+    The returned value is a stable, install-location-independent identifier
+    suitable for diagnostics and contribution records.
+    """
+    base = (root or extensions_root()).resolve()
+    relative = path.resolve().relative_to(base).as_posix()
+    return (
+        f"{REPO_RELATIVE_PREFIX}/{relative}"
+        if relative != "."
+        else REPO_RELATIVE_PREFIX
+    )
+
+
+def is_within_root(path: Path, root: Path | None = None) -> bool:
+    """Return ``True`` if ``path`` resolves to a location under ``root``."""
+    base = (root or extensions_root()).resolve()
+    resolved = path.resolve()
+    return resolved == base or resolved.is_relative_to(base)
+
+
+def resolve_contribution_path(
+    base_dir: Path, relative: str, root: Path | None = None
+) -> Path | None:
+    """Resolve a manifest-relative contribution path, rejecting traversal.
+
+    ``relative`` is a path declared inside a ``package.json`` contribution (for
+    example ``./syntaxes/batchfile.tmLanguage.json``). The result is resolved
+    against ``base_dir`` (the manifest's own directory) and returned only if it
+    stays under the imported extension tree root. Any path that escapes the tree
+    (via ``..`` or an absolute path) yields ``None`` so the caller can record a
+    diagnostic instead of touching a file outside the tree.
+    """
+    if not isinstance(relative, str) or not relative:
+        return None
+    candidate = (base_dir / relative).resolve()
+    return candidate if is_within_root(candidate, root) else None

--- a/src/ecli/extensions/ecli_integration/registry.py
+++ b/src/ecli/extensions/ecli_integration/registry.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/extensions/ecli_integration/registry.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Deterministic, data-only registry of imported extension contributions (#100).
+
+The registry discovers **direct child** extension folders under
+``src/ecli/extensions/`` that contain a ``package.json``, parses their
+contribution metadata, and exposes read-only lookup APIs. It deliberately does
+not recurse into nested ``package.json`` files (language servers, node packages,
+fixtures, tests), and it never executes extension code, scripts, activation
+events, npm/node, or any runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import paths
+from .manifest import (
+    ExtensionManifest,
+    GrammarContribution,
+    LanguageContribution,
+    RegistryDiagnostic,
+    SnippetContribution,
+    parse_manifest,
+)
+
+
+def _normalize_extension(extension: str) -> str:
+    """Return a lowercase file extension with a single leading dot."""
+    extension = extension.lower()
+    return extension if extension.startswith(".") else f".{extension}"
+
+
+@dataclass(frozen=True)
+class ExtensionRegistry:
+    """Immutable collection of parsed manifests with deterministic lookups."""
+
+    manifests: tuple[ExtensionManifest, ...] = field(default_factory=tuple)
+    diagnostics: tuple[RegistryDiagnostic, ...] = field(default_factory=tuple)
+
+    def list_manifests(self) -> tuple[ExtensionManifest, ...]:
+        """Return every discovered manifest, ordered by directory name."""
+        return self.manifests
+
+    def list_diagnostics(self) -> tuple[RegistryDiagnostic, ...]:
+        """Return diagnostics for malformed or skipped manifests/targets."""
+        return self.diagnostics
+
+    def language_ids(self) -> tuple[str, ...]:
+        """Return every contributed language id, sorted and de-duplicated."""
+        ids = {
+            language.language_id
+            for manifest in self.manifests
+            for language in manifest.languages
+        }
+        return tuple(sorted(ids))
+
+    def find_languages_by_id(
+        self, language_id: str
+    ) -> tuple[LanguageContribution, ...]:
+        """Return all language contributions declaring ``language_id``."""
+        return tuple(
+            language
+            for manifest in self.manifests
+            for language in manifest.languages
+            if language.language_id == language_id
+        )
+
+    def find_language_by_id(self, language_id: str) -> LanguageContribution | None:
+        """Return the first language contribution for ``language_id`` or ``None``."""
+        matches = self.find_languages_by_id(language_id)
+        return matches[0] if matches else None
+
+    def find_languages_by_extension(
+        self, extension: str
+    ) -> tuple[LanguageContribution, ...]:
+        """Return all language contributions claiming the given file extension."""
+        wanted = _normalize_extension(extension)
+        return tuple(
+            language
+            for manifest in self.manifests
+            for language in manifest.languages
+            if wanted in {_normalize_extension(item) for item in language.extensions}
+        )
+
+    def find_language_by_extension(self, extension: str) -> LanguageContribution | None:
+        """Return the first language contribution for ``extension`` or ``None``."""
+        matches = self.find_languages_by_extension(extension)
+        return matches[0] if matches else None
+
+    def find_grammars_by_language(
+        self, language_id: str
+    ) -> tuple[GrammarContribution, ...]:
+        """Return grammar contributions whose ``language`` is ``language_id``."""
+        return tuple(
+            grammar
+            for manifest in self.manifests
+            for grammar in manifest.grammars
+            if grammar.language_id == language_id
+        )
+
+    def find_snippets_by_language(
+        self, language_id: str
+    ) -> tuple[SnippetContribution, ...]:
+        """Return snippet contributions whose ``language`` is ``language_id``."""
+        return tuple(
+            snippet
+            for manifest in self.manifests
+            for snippet in manifest.snippets
+            if snippet.language_id == language_id
+        )
+
+
+def discover_manifest_directories(root: Path) -> tuple[Path, ...]:
+    """Return direct-child directories of ``root`` that contain a ``package.json``.
+
+    Discovery is intentionally shallow: only immediate children of the extension
+    tree root are considered, so nested ``package.json`` files (for example
+    ``html-language-features/server/package.json``) are never picked up.
+    """
+    if not root.is_dir():
+        return ()
+    children = (entry for entry in root.iterdir() if entry.is_dir())
+    return tuple(
+        sorted(
+            (child for child in children if (child / "package.json").is_file()),
+            key=lambda path: path.name,
+        )
+    )
+
+
+def build_registry(root: Path | None = None) -> ExtensionRegistry:
+    """Build an :class:`ExtensionRegistry` from the imported extension tree.
+
+    ``root`` defaults to the imported ``ecli/extensions`` asset tree but may be
+    overridden (for example with a temporary directory) to exercise malformed or
+    edge-case manifests in tests. Parsing never raises on bad input; problems are
+    collected as deterministic diagnostics.
+    """
+    base = (root or paths.extensions_root()).resolve()
+    manifests: list[ExtensionManifest] = []
+    diagnostics: list[RegistryDiagnostic] = []
+
+    for directory in discover_manifest_directories(base):
+        manifest, manifest_diagnostics = parse_manifest(directory, base)
+        diagnostics.extend(manifest_diagnostics)
+        if manifest is not None:
+            manifests.append(manifest)
+
+    return ExtensionRegistry(
+        manifests=tuple(manifests),
+        diagnostics=tuple(diagnostics),
+    )

--- a/tests/extensions/test_extension_manifest_registry.py
+++ b/tests/extensions/test_extension_manifest_registry.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/extensions/test_extension_manifest_registry.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Contract tests for the data-only extension manifest registry (#100).
+
+These tests exercise the deterministic adapter over the imported, read-only
+extension tree under ``src/ecli/extensions/``. They assert discovery, lookups,
+deterministic diagnostics for malformed input, shallow (non-recursive)
+discovery, path containment, and that the registry exposes no executable
+surface. They never modify imported upstream files.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from ecli.extensions.ecli_integration import (
+    ExtensionManifest,
+    ExtensionRegistry,
+    build_registry,
+    manifest as manifest_module,
+    paths as paths_module,
+    registry as registry_module,
+)
+
+
+REPRESENTATIVE_MANIFEST_DIRS = (
+    "bat",
+    "python",
+    "json",
+    "javascript",
+    "typescript-basics",
+    "markdown-basics",
+    "cpp",
+)
+
+# (file extension, expected language id) using actual imported metadata.
+REPRESENTATIVE_EXTENSIONS = (
+    (".py", "python"),
+    (".json", "json"),
+    (".js", "javascript"),
+    (".ts", "typescript"),
+    (".md", "markdown"),
+    (".c", "c"),
+    (".cpp", "cpp"),
+    (".h", "cpp"),
+    (".bat", "bat"),
+)
+
+
+@pytest.fixture(scope="module")
+def registry() -> ExtensionRegistry:
+    return build_registry()
+
+
+def _make_extension(root: Path, name: str, manifest: object) -> Path:
+    """Create a throwaway extension folder with a ``package.json`` payload."""
+    directory = root / name
+    directory.mkdir(parents=True)
+    payload = manifest if isinstance(manifest, str) else json.dumps(manifest)
+    (directory / "package.json").write_text(payload, encoding="utf-8")
+    return directory
+
+
+# --------------------------------------------------------------------------- #
+# Discovery + lookups against the real imported tree.
+# --------------------------------------------------------------------------- #
+
+
+def test_real_tree_discovery_is_clean(registry: ExtensionRegistry) -> None:
+    assert registry.list_manifests(), "no manifests discovered in imported tree"
+    # The pristine imported tree must parse without diagnostics.
+    assert registry.list_diagnostics() == ()
+
+
+@pytest.mark.parametrize("directory_name", REPRESENTATIVE_MANIFEST_DIRS)
+def test_discovers_representative_manifests(
+    registry: ExtensionRegistry, directory_name: str
+) -> None:
+    names = {manifest.directory_name for manifest in registry.list_manifests()}
+    assert directory_name in names
+
+
+def test_lists_representative_language_ids(registry: ExtensionRegistry) -> None:
+    language_ids = set(registry.language_ids())
+    expected = {
+        "python",
+        "json",
+        "javascript",
+        "typescript",
+        "markdown",
+        "bat",
+        "c",
+        "cpp",
+    }
+    assert expected <= language_ids
+
+
+@pytest.mark.parametrize(("extension", "expected_id"), REPRESENTATIVE_EXTENSIONS)
+def test_extension_lookup(
+    registry: ExtensionRegistry, extension: str, expected_id: str
+) -> None:
+    language = registry.find_language_by_extension(extension)
+    assert language is not None, f"no language resolved for {extension}"
+    assert language.language_id == expected_id
+
+
+def test_extension_lookup_is_case_insensitive(registry: ExtensionRegistry) -> None:
+    assert registry.find_language_by_extension(".PY") is not None
+    assert registry.find_language_by_extension("py") is not None
+
+
+@pytest.mark.parametrize(
+    ("language_id", "scope_name"),
+    [
+        ("python", "source.python"),
+        ("json", "source.json"),
+        ("bat", "source.batchfile"),
+        ("cpp", "source.cpp"),
+    ],
+)
+def test_grammar_lookup(
+    registry: ExtensionRegistry, language_id: str, scope_name: str
+) -> None:
+    scopes = {g.scope_name for g in registry.find_grammars_by_language(language_id)}
+    assert scope_name in scopes
+
+
+def test_snippet_lookup_where_present(registry: ExtensionRegistry) -> None:
+    bat_snippets = registry.find_snippets_by_language("bat")
+    assert bat_snippets, "expected at least one bat snippet contribution"
+    assert any(
+        s.path_repo_relative
+        and s.path_repo_relative.endswith("batchfile.code-snippets")
+        for s in bat_snippets
+    )
+    assert registry.find_snippets_by_language("cpp"), "expected cpp snippets"
+
+
+def test_configuration_contributions_are_metadata_only(
+    registry: ExtensionRegistry,
+) -> None:
+    # At least one manifest in the imported tree contributes configuration.
+    with_config = [m for m in registry.list_manifests() if m.configuration]
+    assert with_config, "expected configuration contributions in the imported tree"
+    for block in with_config[0].configuration:
+        # Only declarative metadata is exposed; no values/schemas are applied.
+        assert isinstance(block.property_keys, tuple)
+
+
+# --------------------------------------------------------------------------- #
+# Shallow discovery (no recursion into nested package.json).
+# --------------------------------------------------------------------------- #
+
+
+def test_discovery_is_shallow(registry: ExtensionRegistry) -> None:
+    extensions_root = paths_module.extensions_root()
+    direct_children = {
+        child.name
+        for child in extensions_root.iterdir()
+        if child.is_dir() and (child / "package.json").is_file()
+    }
+    discovered = {m.directory_name for m in registry.list_manifests()}
+    assert discovered == direct_children
+    # A known nested server manifest must never appear as its own entry.
+    assert "server" not in discovered
+    assert "html-language-features" in discovered
+
+
+def test_discovery_ignores_nested_package_json(tmp_path: Path) -> None:
+    parent = _make_extension(
+        tmp_path,
+        "outer",
+        {"name": "outer", "contributes": {"languages": [{"id": "outer-lang"}]}},
+    )
+    nested = parent / "server"
+    nested.mkdir()
+    (nested / "package.json").write_text(
+        json.dumps(
+            {"name": "nested", "contributes": {"languages": [{"id": "nested"}]}}
+        ),
+        encoding="utf-8",
+    )
+
+    built = build_registry(root=tmp_path)
+    discovered = {m.directory_name for m in built.list_manifests()}
+    assert discovered == {"outer"}
+    assert built.find_language_by_id("nested") is None
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic diagnostics for malformed / edge-case manifests.
+# --------------------------------------------------------------------------- #
+
+
+def test_malformed_json_is_diagnosed_not_fatal(tmp_path: Path) -> None:
+    _make_extension(tmp_path, "broken", "{ this is not valid json ")
+    _make_extension(
+        tmp_path,
+        "good",
+        {
+            "name": "good",
+            "contributes": {"languages": [{"id": "good", "extensions": [".good"]}]},
+        },
+    )
+
+    first = build_registry(root=tmp_path)
+    second = build_registry(root=tmp_path)
+
+    # Discovery did not crash and the valid manifest is still available.
+    assert {m.directory_name for m in first.list_manifests()} == {"good"}
+    assert first.find_language_by_extension(".good") is not None
+
+    # Exactly one error diagnostic, pointing at the broken manifest.
+    errors = [d for d in first.list_diagnostics() if d.level == "error"]
+    assert len(errors) == 1
+    assert "broken" in errors[0].manifest
+
+    # Diagnostics are deterministic across repeated builds.
+    assert first.list_diagnostics() == second.list_diagnostics()
+
+
+def test_malformed_contributes_does_not_crash(tmp_path: Path) -> None:
+    _make_extension(
+        tmp_path, "weird", {"name": "weird", "contributes": "not-an-object"}
+    )
+    built = build_registry(root=tmp_path)
+    manifest = built.list_manifests()[0]
+    assert manifest.languages == ()
+    assert any(d.level == "warning" for d in built.list_diagnostics())
+
+
+def test_missing_target_file_is_diagnosed_not_fatal(tmp_path: Path) -> None:
+    _make_extension(
+        tmp_path,
+        "ghost",
+        {
+            "name": "ghost",
+            "contributes": {
+                "grammars": [
+                    {
+                        "language": "ghost",
+                        "scopeName": "source.ghost",
+                        "path": "./missing.json",
+                    }
+                ]
+            },
+        },
+    )
+    built = build_registry(root=tmp_path)
+    assert built.list_manifests(), "manifest with a missing target must still load"
+    grammars = built.find_grammars_by_language("ghost")
+    assert grammars and grammars[0].path == "./missing.json"
+    assert any("missing" in d.message for d in built.list_diagnostics())
+
+
+# --------------------------------------------------------------------------- #
+# Path containment / traversal safety.
+# --------------------------------------------------------------------------- #
+
+
+def test_path_traversal_is_rejected(tmp_path: Path) -> None:
+    _make_extension(
+        tmp_path,
+        "escape",
+        {
+            "name": "escape",
+            "contributes": {
+                "grammars": [
+                    {
+                        "language": "escape",
+                        "scopeName": "source.escape",
+                        "path": "../../../../../../etc/passwd",
+                    }
+                ]
+            },
+        },
+    )
+    built = build_registry(root=tmp_path)
+    grammar = built.find_grammars_by_language("escape")[0]
+    # The escaping path is preserved as raw metadata but never resolved.
+    assert grammar.path_repo_relative is None
+    assert any("escapes extension tree" in d.message for d in built.list_diagnostics())
+
+
+def test_resolved_paths_stay_under_extensions_root(
+    registry: ExtensionRegistry,
+) -> None:
+    extensions_root = paths_module.extensions_root()
+    prefix = f"{paths_module.REPO_RELATIVE_PREFIX}/"
+    for manifest in registry.list_manifests():
+        records = (
+            [g.path_repo_relative for g in manifest.grammars]
+            + [s.path_repo_relative for s in manifest.snippets]
+            + [language.configuration_repo_path for language in manifest.languages]
+        )
+        for repo_path in records:
+            if repo_path is None:
+                continue
+            assert repo_path.startswith(prefix)
+            relative = repo_path[len(paths_module.REPO_RELATIVE_PREFIX) + 1 :]
+            resolved = (extensions_root / relative).resolve()
+            assert resolved.is_relative_to(extensions_root.resolve())
+
+
+# --------------------------------------------------------------------------- #
+# No executable / runtime surface.
+# --------------------------------------------------------------------------- #
+
+
+def test_manifest_model_exposes_no_executable_fields() -> None:
+    field_names = {f.name for f in dataclasses.fields(ExtensionManifest)}
+    forbidden = {
+        "scripts",
+        "activation_events",
+        "activationEvents",
+        "main",
+        "browser",
+        "commands",
+    }
+    assert field_names.isdisjoint(forbidden)
+
+
+def test_copilot_manifest_is_data_only(registry: ExtensionRegistry) -> None:
+    copilot = next(
+        (m for m in registry.list_manifests() if m.directory_name == "copilot"), None
+    )
+    if copilot is None:
+        pytest.skip("copilot extension not present in imported tree")
+    # It is exposed as inert metadata, never as an activatable runtime.
+    assert copilot.name
+    assert not hasattr(copilot, "activation_events")
+    assert not hasattr(copilot, "scripts")
+
+
+def test_adapter_modules_have_no_execution_primitives() -> None:
+    execution_tokens = (
+        "subprocess",
+        "os.system",
+        "os.popen",
+        "pty.",
+        "eval(",
+        "exec(",
+        "__import__(",
+    )
+    for module in (paths_module, manifest_module, registry_module):
+        source = inspect.getsource(module)
+        for token in execution_tokens:
+            assert token not in source, f"{module.__name__} must not use {token!r}"

--- a/tests/packaging/test_runtime_import_guard_scope.py
+++ b/tests/packaging/test_runtime_import_guard_scope.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/packaging/test_runtime_import_guard_scope.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Scope tests for the runtime-import guard after the #100 adapter (issue #100).
+
+The guard (`scripts/check_runtime_imports.py`) must skip the imported upstream
+extension tree under ``src/ecli/extensions/`` (issue #98) but still scan the
+ECLI-owned adapter package ``src/ecli/extensions/ecli_integration/`` (issue
+#100). These tests prove the predicate and the file walk honour that boundary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from conftest import load_script_module
+
+
+@pytest.fixture
+def guard(repo_root: Path) -> ModuleType:
+    return load_script_module(
+        repo_root, "scripts/check_runtime_imports.py", "check_runtime_imports_guard"
+    )
+
+
+def test_predicate_skips_imported_upstream(guard: ModuleType) -> None:
+    assert guard._is_imported_upstream(Path("extensions/python/extension.py")) is True
+    assert guard._is_imported_upstream(Path("extensions/json/server/x.py")) is True
+
+
+def test_predicate_scans_adapter_and_normal_source(guard: ModuleType) -> None:
+    assert (
+        guard._is_imported_upstream(Path("extensions/ecli_integration/registry.py"))
+        is False
+    )
+    assert guard._is_imported_upstream(Path("core/Ecli.py")) is False
+
+
+def test_walk_includes_adapter_and_excludes_upstream(
+    guard: ModuleType, repo_root: Path
+) -> None:
+    source_root = repo_root / "src" / "ecli"
+    scanned = guard.scanned_source_files(source_root)
+    relative = {path.relative_to(source_root).as_posix() for path in scanned}
+
+    # The ECLI-owned adapter package is scanned.
+    for expected in (
+        "extensions/ecli_integration/__init__.py",
+        "extensions/ecli_integration/paths.py",
+        "extensions/ecli_integration/manifest.py",
+        "extensions/ecli_integration/registry.py",
+    ):
+        assert expected in relative, f"guard must scan {expected}"
+
+    # Every scanned path under extensions/ belongs to the adapter package; no
+    # imported upstream extension file is scanned.
+    extension_paths = {rel for rel in relative if rel.startswith("extensions/")}
+    assert extension_paths
+    assert all(
+        rel.startswith("extensions/ecli_integration/") for rel in extension_paths
+    )
+
+    # Normal ECLI runtime source is still scanned.
+    assert any(rel.startswith("core/") for rel in relative)


### PR DESCRIPTION
Implements the data-only VS Code `package.json` contribution registry for the ECLI Extensions Layer.

Scope:

* adds ECLI-owned adapter package under `src/ecli/extensions/ecli_integration/`
* discovers direct child extension folders under `src/ecli/extensions/` that contain `package.json`
* parses VS Code-style contribution metadata without executing extension code
* adds deterministic lookup APIs for manifests, languages, file extensions, grammars, snippets, and diagnostics
* adds contract tests for representative imported extension metadata
* fixes tooling boundaries so `ecli_integration` is treated as ECLI-owned source while imported upstream extension assets remain excluded
* updates architecture documentation with #100 registry status

Public registry behavior:

* lists discovered manifests
* lists language ids
* finds languages by id
* finds languages by extension
* finds grammars by language id
* finds snippets by language id
* exposes deterministic diagnostics for malformed/skipped manifests
* prevents contribution paths from escaping `src/ecli/extensions/`

Representative mappings verified:

* `.py` → `python`
* `.json` → `json`
* `.js` → `javascript`
* `.ts` → `typescript`
* `.md` → `markdown`
* `.c` → `c`
* `.cpp` → `cpp`
* `.h` → `cpp`
* `.bat` → `bat`

Tooling boundary:

* `src/ecli/extensions/ecli_integration/` is scanned as ECLI-owned Python code
* imported upstream extension folders remain excluded from broad Ruff/mypy/runtime-import scans
* CI now explicitly runs Ruff against `src/ecli/extensions/ecli_integration`
* runtime import guard verifies the adapter is scanned while upstream extension folders are skipped

Confirmed:

* no imported upstream extension files modified
* no VS Code extension host added
* no Node/TypeScript extension runtime activated
* no Copilot runtime activated
* no `activationEvents` or `package.json` scripts executed
* no hidden command execution added
* no generic PTY terminal emulator added
* F11 remains the PySH Console Panel
* no TextMate tokenization or syntax rendering implemented in this issue
* no theme bridge, diagnostics execution, snippets loader, or language-configuration behavior implemented in this issue
* no VMLab, QEMU, or QMP behavior added
* no packaging behavior changed

Validation:

* `uv run ruff check src/ecli/extensions/ecli_integration`
* `uv run ruff check src tests`
* `uv run ruff format --check src tests`
* `uv run python scripts/check_runtime_imports.py`
* `uv run mypy src/ecli/extensions/ecli_integration`
* `uv run pytest -q tests/extensions tests/packaging tests/docs tests/ui/test_terminal_panel_reservation.py tests/ui/test_pysh_console_panel.py tests/ui/test_pysh_console_panel_keybindings.py`

Closes #100.
