### PR TITLE
feat: add TextMate grammar catalog and language detection

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -66,6 +66,21 @@ syntax_highlighting = true
 mouse = false
 
 
+# --- Extensions Layer (data-only) -------------------------------------------
+# Deterministic switches for the imported VS Code/TextMate extension metadata
+# adapters under src/ecli/extensions/ecli_integration/. These enable DATA-ONLY
+# behavior only; they never start a VS Code extension host, Node/TypeScript or
+# Copilot runtime, activationEvents, or package.json scripts.
+#   syntax_engine = "legacy" keeps the current regex highlighter authoritative
+#   until issue #102 ships a tested extension-backed syntax renderer.
+[extensions]
+enabled = true
+metadata_registry = true
+grammar_catalog = true
+language_detection = true
+syntax_engine = "legacy"
+
+
 [settings]
 auto_save_interval = 5
 show_git_info = true

--- a/docs/architecture/extensions-layer.md
+++ b/docs/architecture/extensions-layer.md
@@ -221,6 +221,25 @@ new matrix entry.
   extension host, no Node/TypeScript or Copilot runtime, no `activationEvents`,
   and no `package.json` scripts. Covered by
   `tests/extensions/test_extension_manifest_registry.py`.
+- **Status (#101):** building on #100, ECLI now has a deterministic, **data-only**
+  TextMate grammar catalog (`grammar_catalog.py`) and language detection
+  (`language_detection.py`). The catalog lists grammar contributions, exposes
+  them by language id and TextMate scope name (plus embedded-language and
+  token-type metadata), verifies grammar files resolve under
+  `src/ecli/extensions/`, and emits deterministic diagnostics for missing files,
+  path traversal, malformed metadata, and conflicting scopes. Language detection
+  maps a file name/extension/exact-filename/filename-pattern to a language id
+  with deterministic precedence and explicit ambiguity metadata. `config.toml`
+  now exposes the data-path switches via an `[extensions]` table (`enabled`,
+  `metadata_registry`, `grammar_catalog`, `language_detection`,
+  `syntax_engine = "legacy"`), parsed through `config.py`
+  (`ExtensionLayerConfig`); no config value can enable an extension runtime.
+  **Syntax rendering remains legacy:** the existing regex/Pygments highlighter is
+  unchanged and stays authoritative — it is **not** removed or disabled in #101.
+  An extension-backed syntax service and editor rendering replacement arrive in
+  #102. Covered by `tests/extensions/test_textmate_grammar_catalog.py`,
+  `tests/extensions/test_extension_language_detection.py`, and
+  `tests/extensions/test_extension_layer_config.py`.
 
 ## Sequencing
 

--- a/src/ecli/extensions/ecli_integration/__init__.py
+++ b/src/ecli/extensions/ecli_integration/__init__.py
@@ -11,17 +11,36 @@
 # Licensed under the GNU General Public License version 2 only.
 # See the LICENSE file in the project root for full license text.
 
-"""ECLI-owned deterministic adapter layer over the imported extension tree (#100).
+"""ECLI-owned deterministic adapter layer over the imported extension tree.
 
-This package reads VS Code-style ``package.json`` contribution metadata from the
-read-only imported extension tree under ``src/ecli/extensions/`` and exposes it
-as typed, immutable Python data. It is data-only: it never starts a VS Code
-extension host, never activates a Node/TypeScript or Copilot runtime, never runs
-``activationEvents`` or ``package.json`` scripts, and never executes any command.
+This package reads VS Code-style extension metadata from the read-only imported
+extension tree under ``src/ecli/extensions/`` and exposes it as typed, immutable
+Python data:
+
+* #100 — ``package.json`` contribution registry (manifests, languages, grammars,
+  snippets, configuration).
+* #101 — TextMate grammar catalog, language detection, and the typed
+  ``[extensions]`` configuration surface.
+
+It is data-only: it never starts a VS Code extension host, never activates a
+Node/TypeScript or Copilot runtime, never runs ``activationEvents`` or
+``package.json`` scripts, never tokenizes or renders syntax, and never executes
+any command.
 """
 
 from __future__ import annotations
 
+from .config import ExtensionLayerConfig, SyntaxEngine
+from .grammar_catalog import (
+    GrammarCatalog,
+    TextMateGrammar,
+    build_grammar_catalog,
+)
+from .language_detection import (
+    LanguageDetectionResult,
+    LanguageDetector,
+    build_language_detector,
+)
 from .manifest import (
     ConfigurationContribution,
     ExtensionManifest,
@@ -41,12 +60,20 @@ from .registry import (
 
 __all__ = [
     "ConfigurationContribution",
+    "ExtensionLayerConfig",
     "ExtensionManifest",
     "ExtensionRegistry",
+    "GrammarCatalog",
     "GrammarContribution",
     "LanguageContribution",
+    "LanguageDetectionResult",
+    "LanguageDetector",
     "RegistryDiagnostic",
     "SnippetContribution",
+    "SyntaxEngine",
+    "TextMateGrammar",
+    "build_grammar_catalog",
+    "build_language_detector",
     "build_registry",
     "discover_manifest_directories",
     "extensions_root",

--- a/src/ecli/extensions/ecli_integration/config.py
+++ b/src/ecli/extensions/ecli_integration/config.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/extensions/ecli_integration/config.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Typed ``[extensions]`` configuration for the Extensions Layer (#101).
+
+This module reads the deterministic ``[extensions]`` table that ECLI ships in
+``config.toml`` (and in the legacy ``DEFAULT_CONFIG`` fallback) and exposes it as
+an immutable :class:`ExtensionLayerConfig`. It only turns configuration data into
+typed flags — it never activates an extension runtime.
+
+The Extensions Layer is data-only. There is **no** configuration value that can
+enable a VS Code extension host, Node/TypeScript activation, ``activationEvents``,
+``package.json`` scripts, or a Copilot runtime. Any such key found in the table
+is ignored with a diagnostic, and ``syntax_engine`` stays ``"legacy"`` until
+issue #102 ships a tested extension-backed renderer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from .manifest import RegistryDiagnostic
+
+
+_CONFIG_SOURCE = "config.extensions"
+
+# Keys that would imply executing extension runtime behaviour. They are never
+# honoured; their presence only produces a deterministic diagnostic.
+_FORBIDDEN_RUNTIME_KEYS = frozenset(
+    {
+        "runtime",
+        "execute",
+        "execution",
+        "activation",
+        "activation_events",
+        "activationevents",
+        "extension_host",
+        "host",
+        "node",
+        "npm",
+        "scripts",
+        "copilot",
+    }
+)
+
+
+class SyntaxEngine(StrEnum):
+    """Selectable syntax engine. Only ``LEGACY`` is active until issue #102."""
+
+    LEGACY = "legacy"
+    EXTENSION = "extension"
+
+
+@dataclass(frozen=True)
+class ExtensionLayerConfig:
+    """Immutable, data-only view of the ``[extensions]`` configuration table."""
+
+    enabled: bool = True
+    metadata_registry: bool = True
+    grammar_catalog: bool = True
+    language_detection: bool = True
+    syntax_engine: str = SyntaxEngine.LEGACY.value
+    diagnostics: tuple[RegistryDiagnostic, ...] = field(default_factory=tuple)
+
+    @property
+    def uses_legacy_syntax(self) -> bool:
+        """Return ``True`` while the legacy regex highlighter stays authoritative."""
+        return self.syntax_engine == SyntaxEngine.LEGACY.value
+
+    @property
+    def allows_runtime_execution(self) -> bool:
+        """Always ``False``: no setting can enable extension runtime execution."""
+        return False
+
+    @classmethod
+    def from_config(
+        cls, config: Mapping[str, object] | None, source: str = _CONFIG_SOURCE
+    ) -> ExtensionLayerConfig:
+        """Build from a full ECLI config mapping by reading its ``extensions`` table."""
+        section = config.get("extensions") if isinstance(config, Mapping) else None
+        return cls.from_section(section, source)
+
+    @classmethod
+    def from_section(
+        cls, section: object, source: str = _CONFIG_SOURCE
+    ) -> ExtensionLayerConfig:
+        """Build from the ``[extensions]`` table itself, validating every field."""
+        if section is None:
+            return cls()
+        diagnostics: list[RegistryDiagnostic] = []
+        if not isinstance(section, Mapping):
+            diagnostics.append(
+                RegistryDiagnostic("warning", source, "extensions must be a table")
+            )
+            return cls(diagnostics=tuple(diagnostics))
+
+        _diagnose_forbidden_keys(section, source, diagnostics)
+        default = cls()
+        return cls(
+            enabled=_read_bool(
+                section, "enabled", default.enabled, source, diagnostics
+            ),
+            metadata_registry=_read_bool(
+                section,
+                "metadata_registry",
+                default.metadata_registry,
+                source,
+                diagnostics,
+            ),
+            grammar_catalog=_read_bool(
+                section, "grammar_catalog", default.grammar_catalog, source, diagnostics
+            ),
+            language_detection=_read_bool(
+                section,
+                "language_detection",
+                default.language_detection,
+                source,
+                diagnostics,
+            ),
+            syntax_engine=_read_syntax_engine(section, source, diagnostics),
+            diagnostics=tuple(diagnostics),
+        )
+
+
+def _diagnose_forbidden_keys(
+    section: Mapping[str, object], source: str, diagnostics: list[RegistryDiagnostic]
+) -> None:
+    for key in section:
+        if isinstance(key, str) and key.lower() in _FORBIDDEN_RUNTIME_KEYS:
+            diagnostics.append(
+                RegistryDiagnostic(
+                    "warning",
+                    source,
+                    f"runtime execution settings are not permitted; ignored: {key!r}",
+                )
+            )
+
+
+def _read_bool(
+    section: Mapping[str, object],
+    key: str,
+    default: bool,  # noqa: FBT001
+    source: str,
+    diagnostics: list[RegistryDiagnostic],
+) -> bool:
+    if key not in section:
+        return default
+    value = section[key]
+    if isinstance(value, bool):
+        return value
+    diagnostics.append(
+        RegistryDiagnostic(
+            "warning", source, f"{key} must be a boolean; using {default!r}"
+        )
+    )
+    return default
+
+
+def _read_syntax_engine(
+    section: Mapping[str, object], source: str, diagnostics: list[RegistryDiagnostic]
+) -> str:
+    if "syntax_engine" not in section:
+        return SyntaxEngine.LEGACY.value
+    value = section["syntax_engine"]
+    if value == SyntaxEngine.LEGACY.value:
+        return SyntaxEngine.LEGACY.value
+    if value == SyntaxEngine.EXTENSION.value:
+        diagnostics.append(
+            RegistryDiagnostic(
+                "warning",
+                source,
+                "extension syntax engine is not available until #102; using 'legacy'",
+            )
+        )
+        return SyntaxEngine.LEGACY.value
+    diagnostics.append(
+        RegistryDiagnostic(
+            "warning", source, f"unknown syntax_engine {value!r}; using 'legacy'"
+        )
+    )
+    return SyntaxEngine.LEGACY.value

--- a/src/ecli/extensions/ecli_integration/grammar_catalog.py
+++ b/src/ecli/extensions/ecli_integration/grammar_catalog.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/extensions/ecli_integration/grammar_catalog.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""TextMate grammar catalog built from the #100 manifest registry (#101).
+
+This is a deterministic, data-only catalog of ``contributes.grammars`` metadata.
+It records each grammar's TextMate scope, language binding, file location,
+embedded-language metadata, and token-type metadata, and verifies that grammar
+files resolve to existing locations under ``src/ecli/extensions/``.
+
+It does **not** parse TextMate grammar internals, tokenize text, or render
+syntax. Those belong to the syntax service (#102), which does not exist yet.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import paths
+from .manifest import RegistryDiagnostic
+from .registry import ExtensionRegistry, build_registry
+
+
+@dataclass(frozen=True)
+class TextMateGrammar:
+    """Data-only record for one ``contributes.grammars[]`` entry."""
+
+    scope_name: str | None
+    language_id: str | None
+    path: str | None
+    path_repo_relative: str | None
+    exists: bool
+    source_manifest: str
+    embedded_languages: tuple[tuple[str, str], ...] = ()
+    token_types: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class GrammarCatalog:
+    """Immutable catalog of grammars with deterministic lookups + diagnostics."""
+
+    grammars: tuple[TextMateGrammar, ...] = field(default_factory=tuple)
+    diagnostics: tuple[RegistryDiagnostic, ...] = field(default_factory=tuple)
+
+    def list_grammars(self) -> tuple[TextMateGrammar, ...]:
+        """Return every grammar in deterministic registry order."""
+        return self.grammars
+
+    def list_diagnostics(self) -> tuple[RegistryDiagnostic, ...]:
+        """Return diagnostics for missing/traversal/malformed/conflicting grammars."""
+        return self.diagnostics
+
+    def scope_names(self) -> tuple[str, ...]:
+        """Return every contributed TextMate scope name, sorted and de-duplicated."""
+        return tuple(sorted({g.scope_name for g in self.grammars if g.scope_name}))
+
+    def language_ids(self) -> tuple[str, ...]:
+        """Return every language id that has a grammar, sorted and de-duplicated."""
+        return tuple(sorted({g.language_id for g in self.grammars if g.language_id}))
+
+    def grammars_for_language(self, language_id: str) -> tuple[TextMateGrammar, ...]:
+        """Return grammars bound to ``language_id`` in deterministic order."""
+        return tuple(g for g in self.grammars if g.language_id == language_id)
+
+    def grammar_for_language(self, language_id: str) -> TextMateGrammar | None:
+        """Return the first grammar bound to ``language_id`` or ``None``."""
+        matches = self.grammars_for_language(language_id)
+        return matches[0] if matches else None
+
+    def grammars_for_scope(self, scope_name: str) -> tuple[TextMateGrammar, ...]:
+        """Return grammars declaring ``scope_name`` in deterministic order."""
+        return tuple(g for g in self.grammars if g.scope_name == scope_name)
+
+    def grammar_for_scope(self, scope_name: str) -> TextMateGrammar | None:
+        """Return the first grammar declaring ``scope_name`` or ``None``."""
+        matches = self.grammars_for_scope(scope_name)
+        return matches[0] if matches else None
+
+    def embedded_languages_for_language(
+        self, language_id: str
+    ) -> tuple[tuple[str, str], ...]:
+        """Return the union of embedded-language pairs for ``language_id``."""
+        pairs: set[tuple[str, str]] = set()
+        for grammar in self.grammars_for_language(language_id):
+            pairs.update(grammar.embedded_languages)
+        return tuple(sorted(pairs))
+
+
+def _grammar_relative(path_repo_relative: str) -> str:
+    prefix = f"{paths.REPO_RELATIVE_PREFIX}/"
+    if path_repo_relative.startswith(prefix):
+        return path_repo_relative[len(prefix) :]
+    return path_repo_relative
+
+
+def _build_grammar(
+    manifest_name: str,
+    grammar: object,
+    root: Path,
+    diagnostics: list[RegistryDiagnostic],
+) -> TextMateGrammar:
+    # ``grammar`` is a manifest.GrammarContribution; typed loosely to avoid a
+    # cyclic import while keeping this helper focused.
+    scope_name = grammar.scope_name  # type: ignore[attr-defined]
+    path = grammar.path  # type: ignore[attr-defined]
+    path_repo_relative = grammar.path_repo_relative  # type: ignore[attr-defined]
+
+    exists = False
+    if path is not None and path_repo_relative is None:
+        diagnostics.append(
+            RegistryDiagnostic(
+                "warning",
+                manifest_name,
+                f"grammar path escapes extension tree: {path!r}",
+            )
+        )
+    elif path_repo_relative is not None:
+        exists = (root / _grammar_relative(path_repo_relative)).is_file()
+        if not exists:
+            diagnostics.append(
+                RegistryDiagnostic(
+                    "warning",
+                    manifest_name,
+                    f"grammar file missing: {path_repo_relative}",
+                )
+            )
+
+    if scope_name is None:
+        diagnostics.append(
+            RegistryDiagnostic(
+                "warning",
+                manifest_name,
+                f"grammar missing scopeName: {path_repo_relative or path}",
+            )
+        )
+
+    return TextMateGrammar(
+        scope_name=scope_name,
+        language_id=grammar.language_id,  # type: ignore[attr-defined]
+        path=path,
+        path_repo_relative=path_repo_relative,
+        exists=exists,
+        source_manifest=manifest_name,
+        embedded_languages=grammar.embedded_languages,  # type: ignore[attr-defined]
+        token_types=grammar.token_types,  # type: ignore[attr-defined]
+    )
+
+
+def _diagnose_scope_conflicts(
+    grammars: list[TextMateGrammar], diagnostics: list[RegistryDiagnostic]
+) -> None:
+    scope_paths: dict[str, set[str]] = {}
+    exact_seen: set[tuple[str | None, str | None, str | None]] = set()
+    for grammar in grammars:
+        key = (grammar.scope_name, grammar.path_repo_relative, grammar.language_id)
+        if key in exact_seen:
+            diagnostics.append(
+                RegistryDiagnostic(
+                    "warning",
+                    grammar.source_manifest,
+                    f"duplicate grammar entry: scope={grammar.scope_name} "
+                    f"language={grammar.language_id}",
+                )
+            )
+        exact_seen.add(key)
+        if grammar.scope_name is not None and grammar.path_repo_relative is not None:
+            scope_paths.setdefault(grammar.scope_name, set()).add(
+                grammar.path_repo_relative
+            )
+    for scope_name, paths_for_scope in sorted(scope_paths.items()):
+        if len(paths_for_scope) > 1:
+            diagnostics.append(
+                RegistryDiagnostic(
+                    "warning",
+                    scope_name,
+                    f"conflicting grammar paths for scope {scope_name}: "
+                    f"{sorted(paths_for_scope)}",
+                )
+            )
+
+
+def build_grammar_catalog(
+    registry: ExtensionRegistry | None = None, root: Path | None = None
+) -> GrammarCatalog:
+    """Build a :class:`GrammarCatalog` from the manifest registry.
+
+    ``root`` defaults to the imported ``ecli/extensions`` asset tree. To exercise
+    fixtures, pass ``root=<temp dir>`` (a registry is built from it automatically)
+    so grammar file-existence checks resolve against that fixture tree.
+    """
+    base = (root or paths.extensions_root()).resolve()
+    if registry is None:
+        registry = build_registry(base)
+
+    grammars: list[TextMateGrammar] = []
+    diagnostics: list[RegistryDiagnostic] = []
+    for manifest in registry.list_manifests():
+        for grammar in manifest.grammars:
+            grammars.append(
+                _build_grammar(manifest.directory_name, grammar, base, diagnostics)
+            )
+    _diagnose_scope_conflicts(grammars, diagnostics)
+
+    return GrammarCatalog(grammars=tuple(grammars), diagnostics=tuple(diagnostics))

--- a/src/ecli/extensions/ecli_integration/language_detection.py
+++ b/src/ecli/extensions/ecli_integration/language_detection.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: src/ecli/extensions/ecli_integration/language_detection.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Deterministic language detection from imported extension metadata (#101).
+
+Detection maps a file name (or path) to a language id using only the
+``contributes.languages`` metadata exposed by the #100 registry: exact
+filenames, filename glob patterns, and file extensions. It is pure metadata
+lookup — it never reads file contents, tokenizes text, or renders syntax, and it
+is not wired into editor rendering in this issue.
+
+Precedence is deterministic: an exact filename match wins over a filename-pattern
+match, which wins over a file-extension match. Within the winning tier, all
+candidate language ids are returned in deterministic order; more than one marks
+the result ambiguous.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+from .registry import ExtensionRegistry, build_registry
+
+
+MATCH_FILENAME = "filename"
+MATCH_FILENAME_PATTERN = "filename_pattern"
+MATCH_EXTENSION = "extension"
+
+
+@dataclass(frozen=True)
+class LanguageDetectionResult:
+    """Immutable result of a single detection lookup."""
+
+    language_id: str | None
+    matched_by: str | None
+    matched_value: str | None
+    candidates: tuple[str, ...] = ()
+    is_ambiguous: bool = False
+
+    @property
+    def matched(self) -> bool:
+        """Return ``True`` if a language id was detected."""
+        return self.language_id is not None
+
+    @classmethod
+    def no_match(cls) -> LanguageDetectionResult:
+        """Return the canonical 'no language detected' result."""
+        return cls(language_id=None, matched_by=None, matched_value=None)
+
+
+@dataclass(frozen=True)
+class LanguageDetector:
+    """Immutable detector built from deterministic registry metadata indexes."""
+
+    extensions: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    filenames: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    filename_patterns: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+
+    def detect(self, name: str) -> LanguageDetectionResult:
+        """Detect the language id for a file name or path, deterministically."""
+        base = name.replace("\\", "/").rsplit("/", 1)[-1]
+
+        by_filename = _match_tier(
+            self.filenames, lambda token: token == base, MATCH_FILENAME
+        )
+        if by_filename is not None:
+            return by_filename
+
+        by_pattern = _match_tier(
+            self.filename_patterns,
+            lambda token: _pattern_matches(token, base, name),
+            MATCH_FILENAME_PATTERN,
+        )
+        if by_pattern is not None:
+            return by_pattern
+
+        suffix = _suffix(base)
+        if suffix is None:
+            return LanguageDetectionResult.no_match()
+        by_extension = _match_tier(
+            self.extensions, lambda token: token == suffix, MATCH_EXTENSION
+        )
+        return (
+            by_extension
+            if by_extension is not None
+            else LanguageDetectionResult.no_match()
+        )
+
+    def detect_by_extension(self, extension: str) -> LanguageDetectionResult:
+        """Detect using a bare file extension such as ``.py`` or ``py``."""
+        suffix = _normalize_extension(extension)
+        result = _match_tier(
+            self.extensions, lambda token: token == suffix, MATCH_EXTENSION
+        )
+        return result if result is not None else LanguageDetectionResult.no_match()
+
+
+def _suffix(base: str) -> str | None:
+    dot = base.rfind(".")
+    if dot <= 0:
+        return None
+    return base[dot:].lower()
+
+
+def _normalize_extension(extension: str) -> str:
+    extension = extension.lower()
+    return extension if extension.startswith(".") else f".{extension}"
+
+
+def _pattern_matches(pattern: str, base: str, full_name: str) -> bool:
+    normalized = full_name.replace("\\", "/")
+    return fnmatchcase(base, pattern) or fnmatchcase(normalized, pattern)
+
+
+def _match_tier(
+    index: Iterable[tuple[str, str]],
+    predicate: Callable[[str], bool],
+    matched_by: str,
+) -> LanguageDetectionResult | None:
+    language_ids: list[str] = []
+    matched_value: str | None = None
+    for token, language_id in index:
+        if predicate(token):
+            if matched_value is None:
+                matched_value = token
+            if language_id not in language_ids:
+                language_ids.append(language_id)
+    if not language_ids:
+        return None
+    return LanguageDetectionResult(
+        language_id=language_ids[0],
+        matched_by=matched_by,
+        matched_value=matched_value,
+        candidates=tuple(language_ids),
+        is_ambiguous=len(language_ids) > 1,
+    )
+
+
+def build_language_detector(
+    registry: ExtensionRegistry | None = None, root: Path | None = None
+) -> LanguageDetector:
+    """Build a :class:`LanguageDetector` from the manifest registry.
+
+    ``registry`` defaults to the registry for the imported extension tree; pass a
+    fixture registry (or ``root=<temp dir>``) to exercise edge cases. Index order
+    follows the registry's deterministic manifest/language ordering.
+    """
+    if registry is None:
+        registry = build_registry(root) if root is not None else build_registry()
+
+    extensions: list[tuple[str, str]] = []
+    filenames: list[tuple[str, str]] = []
+    filename_patterns: list[tuple[str, str]] = []
+    for manifest in registry.list_manifests():
+        for language in manifest.languages:
+            for extension in language.extensions:
+                extensions.append(
+                    (_normalize_extension(extension), language.language_id)
+                )
+            for filename in language.filenames:
+                filenames.append((filename, language.language_id))
+            for pattern in language.filename_patterns:
+                filename_patterns.append((pattern, language.language_id))
+
+    return LanguageDetector(
+        extensions=tuple(extensions),
+        filenames=tuple(filenames),
+        filename_patterns=tuple(filename_patterns),
+    )

--- a/src/ecli/utils/utils.py
+++ b/src/ecli/utils/utils.py
@@ -75,6 +75,16 @@ DEFAULT_CONFIG: dict[str, Any] = {
         # Opt-in mouse support (off by default to preserve native text selection).
         "mouse": False,
     },
+    # Extensions Layer (data-only) switches. These mirror the [extensions] table
+    # in config.toml and gate ONLY the deterministic metadata adapters under
+    # src/ecli/extensions/ecli_integration/. They never enable an extension
+    # runtime; syntax_engine = "legacy" preserves the regex highlighter until the
+    # #102 extension-backed syntax service replaces it. See
+    # docs/architecture/extensions-layer.md.
+    "extensions": {
+        "enabled": True, "metadata_registry": True, "grammar_catalog": True,
+        "language_detection": True, "syntax_engine": "legacy",
+    },
     "fonts": {"font_family": "monospace", "font_size": 12},
     "keybindings": {
         "delete": "del", "paste": "ctrl+v", "copy": "ctrl+c", "cut": "ctrl+x",

--- a/tests/core/test_config_loading.py
+++ b/tests/core/test_config_loading.py
@@ -102,3 +102,14 @@ def test_loaded_config_path_recorded_when_present(isolated_home: Path) -> None:
     config = load_config()
     assert "_loaded_config_path" in config
     assert config["_loaded_config_path"].endswith("config.toml")
+
+
+def test_extensions_layer_switches_default_through_loader(isolated_home: Path) -> None:
+    # The data-only Extensions Layer switches (#101) are exposed by the existing
+    # config loader via DEFAULT_CONFIG, with syntax rendering kept on "legacy".
+    extensions = load_config()["extensions"]
+    assert extensions["enabled"] is True
+    assert extensions["metadata_registry"] is True
+    assert extensions["grammar_catalog"] is True
+    assert extensions["language_detection"] is True
+    assert extensions["syntax_engine"] == "legacy"

--- a/tests/extensions/test_extension_language_detection.py
+++ b/tests/extensions/test_extension_language_detection.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/extensions/test_extension_language_detection.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Contract tests for deterministic language detection (#101).
+
+Detection is metadata-only: it maps file names/extensions/exact-filenames/
+filename-patterns to language ids using #100 registry data, with deterministic
+precedence and explicit ambiguity. These tests cover representative extensions,
+precedence, case handling, unknown input, and deterministic ambiguity (via temp
+fixtures). They never read file contents or render syntax.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from ecli.extensions.ecli_integration import (
+    LanguageDetector,
+    build_language_detector,
+)
+
+
+REPRESENTATIVE_EXTENSIONS = (
+    ("main.py", "python"),
+    ("data.json", "json"),
+    ("app.js", "javascript"),
+    ("app.ts", "typescript"),
+    ("README.md", "markdown"),
+    ("core.c", "c"),
+    ("core.cpp", "cpp"),
+    ("core.h", "cpp"),
+    ("run.bat", "bat"),
+)
+
+
+@pytest.fixture(scope="module")
+def detector() -> LanguageDetector:
+    return build_language_detector()
+
+
+def _make_extension(root: Path, name: str, manifest: Mapping[str, object]) -> Path:
+    directory = root / name
+    directory.mkdir(parents=True)
+    (directory / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return directory
+
+
+# --------------------------------------------------------------------------- #
+# Real imported tree.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(("file_name", "expected"), REPRESENTATIVE_EXTENSIONS)
+def test_representative_extension_detection(
+    detector: LanguageDetector, file_name: str, expected: str
+) -> None:
+    result = detector.detect(file_name)
+    assert result.matched
+    assert result.language_id == expected
+    assert result.matched_by == "extension"
+
+
+def test_exact_filename_detection(detector: LanguageDetector) -> None:
+    # 'SConstruct' is a real exact-filename rule for python in the imported tree.
+    result = detector.detect("SConstruct")
+    assert result.language_id == "python"
+    assert result.matched_by == "filename"
+
+
+def test_filename_pattern_detection(detector: LanguageDetector) -> None:
+    # 'tsconfig.*.json' is a real filename pattern in the imported tree.
+    result = detector.detect("tsconfig.build.json")
+    assert result.language_id == "jsonc"
+    assert result.matched_by == "filename_pattern"
+
+
+def test_exact_filename_beats_extension(detector: LanguageDetector) -> None:
+    # 'tsconfig.json' is both an exact filename (jsonc) and a '.json' extension.
+    result = detector.detect("tsconfig.json")
+    assert result.language_id == "jsonc"
+    assert result.matched_by == "filename"
+
+
+def test_extension_detection_is_case_insensitive(detector: LanguageDetector) -> None:
+    assert detector.detect("Main.PY").language_id == "python"
+    assert detector.detect("Main.py").language_id == "python"
+    assert detector.detect_by_extension(".PY").language_id == "python"
+    assert detector.detect_by_extension("py").language_id == "python"
+
+
+def test_detection_handles_full_paths(detector: LanguageDetector) -> None:
+    assert detector.detect("/home/user/project/main.py").language_id == "python"
+    assert detector.detect("C:\\src\\app.ts").language_id == "typescript"
+
+
+def test_unknown_extension_returns_no_match(detector: LanguageDetector) -> None:
+    result = detector.detect("archive.zzz")
+    assert not result.matched
+    assert result.language_id is None
+    assert result.candidates == ()
+
+
+def test_no_extension_does_not_crash(detector: LanguageDetector) -> None:
+    result = detector.detect("PLAINFILE_NO_RULE")
+    assert not result.matched
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic ambiguity via fixtures.
+# --------------------------------------------------------------------------- #
+
+
+def test_conflicting_extension_is_deterministically_ambiguous(tmp_path: Path) -> None:
+    # Two extensions claim '.shared'; directory-name ordering is deterministic.
+    _make_extension(
+        tmp_path,
+        "a_alpha",
+        {
+            "name": "a_alpha",
+            "contributes": {"languages": [{"id": "alpha", "extensions": [".shared"]}]},
+        },
+    )
+    _make_extension(
+        tmp_path,
+        "b_beta",
+        {
+            "name": "b_beta",
+            "contributes": {"languages": [{"id": "beta", "extensions": [".shared"]}]},
+        },
+    )
+    from ecli.extensions.ecli_integration import build_registry
+
+    detector = build_language_detector(build_registry(root=tmp_path))
+    first = detector.detect("thing.shared")
+    second = detector.detect("thing.shared")
+
+    assert first.is_ambiguous
+    assert first.candidates == ("alpha", "beta")
+    assert first.language_id == "alpha"
+    assert first == second

--- a/tests/extensions/test_extension_layer_config.py
+++ b/tests/extensions/test_extension_layer_config.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/extensions/test_extension_layer_config.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Contract tests for the [extensions] configuration surface (#101).
+
+These verify that the shipped ``config.toml`` and the ``DEFAULT_CONFIG`` fallback
+expose the required data-only Extensions Layer switches, that
+``ExtensionLayerConfig`` parses and validates them deterministically, that no
+configuration value can enable an extension runtime, and that the legacy regex
+syntax highlighter is preserved (not removed or disabled) in #101.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import tomllib
+from pathlib import Path
+
+from ecli.extensions.ecli_integration import ExtensionLayerConfig
+from ecli.utils.utils import DEFAULT_CONFIG
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_EXTENSIONS_DEFAULTS = {
+    "enabled": True,
+    "metadata_registry": True,
+    "grammar_catalog": True,
+    "language_detection": True,
+    "syntax_engine": "legacy",
+}
+
+
+def _config_toml() -> dict[str, object]:
+    return tomllib.loads((REPO_ROOT / "config.toml").read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------- #
+# Shipped defaults.
+# --------------------------------------------------------------------------- #
+
+
+def test_config_toml_ships_extensions_defaults() -> None:
+    extensions = _config_toml()["extensions"]
+    assert extensions == REQUIRED_EXTENSIONS_DEFAULTS
+
+
+def test_default_config_fallback_exposes_extensions() -> None:
+    assert DEFAULT_CONFIG["extensions"] == REQUIRED_EXTENSIONS_DEFAULTS
+
+
+def test_from_config_parses_default_config() -> None:
+    config = ExtensionLayerConfig.from_config(DEFAULT_CONFIG)
+    assert config.enabled
+    assert config.metadata_registry
+    assert config.grammar_catalog
+    assert config.language_detection
+    assert config.syntax_engine == "legacy"
+    assert config.diagnostics == ()
+
+
+# --------------------------------------------------------------------------- #
+# Defaults + validation.
+# --------------------------------------------------------------------------- #
+
+
+def test_dataclass_defaults() -> None:
+    config = ExtensionLayerConfig()
+    assert (config.enabled, config.metadata_registry) == (True, True)
+    assert (config.grammar_catalog, config.language_detection) == (True, True)
+    assert config.syntax_engine == "legacy"
+    assert config.uses_legacy_syntax is True
+
+
+def test_missing_section_uses_defaults() -> None:
+    config = ExtensionLayerConfig.from_config({})
+    assert config.enabled and config.uses_legacy_syntax
+    assert config.diagnostics == ()
+
+
+def test_non_mapping_section_is_diagnosed() -> None:
+    config = ExtensionLayerConfig.from_section("not-a-table")
+    assert any(d.level == "warning" for d in config.diagnostics)
+
+
+def test_syntax_engine_legacy_is_preserved() -> None:
+    config = ExtensionLayerConfig.from_section({"syntax_engine": "legacy"})
+    assert config.syntax_engine == "legacy"
+    assert config.diagnostics == ()
+
+
+def test_syntax_engine_extension_falls_back_to_legacy() -> None:
+    config = ExtensionLayerConfig.from_section({"syntax_engine": "extension"})
+    assert config.syntax_engine == "legacy"
+    assert any("not available until #102" in d.message for d in config.diagnostics)
+
+
+def test_unknown_syntax_engine_falls_back_to_legacy() -> None:
+    config = ExtensionLayerConfig.from_section({"syntax_engine": "tree-sitter"})
+    assert config.syntax_engine == "legacy"
+    assert any("unknown syntax_engine" in d.message for d in config.diagnostics)
+
+
+def test_invalid_boolean_falls_back_with_diagnostic() -> None:
+    config = ExtensionLayerConfig.from_section({"enabled": "yes"})
+    assert config.enabled is True  # default preserved
+    assert any("enabled must be a boolean" in d.message for d in config.diagnostics)
+
+
+# --------------------------------------------------------------------------- #
+# No runtime execution surface.
+# --------------------------------------------------------------------------- #
+
+
+def test_no_runtime_execution_field_exists() -> None:
+    field_names = {f.name for f in dataclasses.fields(ExtensionLayerConfig)}
+    forbidden = {"runtime", "execute", "execution", "host", "node", "npm", "scripts"}
+    assert field_names.isdisjoint(forbidden)
+    assert ExtensionLayerConfig().allows_runtime_execution is False
+
+
+def test_runtime_execution_keys_are_ignored_with_diagnostic() -> None:
+    config = ExtensionLayerConfig.from_section(
+        {"enabled": True, "runtime": True, "node": True, "scripts": ["build"]}
+    )
+    assert config.allows_runtime_execution is False
+    assert not hasattr(config, "runtime")
+    messages = " ".join(d.message for d in config.diagnostics)
+    assert "runtime execution settings are not permitted" in messages
+
+
+# --------------------------------------------------------------------------- #
+# Legacy regex highlighter is not removed in #101.
+# --------------------------------------------------------------------------- #
+
+
+def test_legacy_regex_highlighter_is_preserved() -> None:
+    config = _config_toml()
+    # The legacy regex highlighter config and toggle remain in place.
+    assert "syntax_highlighting" in config
+    assert "python" in config["syntax_highlighting"]
+    assert config["editor"]["syntax_highlighting"] is True
+    assert DEFAULT_CONFIG["editor"]["syntax_highlighting"] is True

--- a/tests/extensions/test_textmate_grammar_catalog.py
+++ b/tests/extensions/test_textmate_grammar_catalog.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Project: Ecli
+# File: tests/extensions/test_textmate_grammar_catalog.py
+# Website: https://www.ecli.io
+# Repository: https://github.com/SSobol77/ecli
+# PyPI: https://pypi.org/project/ecli-editor/0.0.1/
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# Licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for full license text.
+
+"""Contract tests for the data-only TextMate grammar catalog (#101).
+
+The catalog is built from the #100 manifest registry. These tests verify
+representative grammar lookups against the real imported tree, path containment,
+and deterministic, non-fatal diagnostics for missing/traversal/malformed/
+conflicting grammar metadata (using temp fixtures). They never tokenize text,
+render syntax, or modify imported upstream files.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from ecli.extensions.ecli_integration import (
+    GrammarCatalog,
+    build_grammar_catalog,
+    paths as paths_module,
+)
+
+
+# (language id, expected TextMate scope) using actual imported metadata.
+REPRESENTATIVE_GRAMMARS = (
+    ("python", "source.python"),
+    ("json", "source.json"),
+    ("javascript", "source.js"),
+    ("typescript", "source.ts"),
+    ("markdown", "text.html.markdown"),
+    ("bat", "source.batchfile"),
+    ("c", "source.c"),
+    ("cpp", "source.cpp"),
+)
+
+
+@pytest.fixture(scope="module")
+def catalog() -> GrammarCatalog:
+    return build_grammar_catalog()
+
+
+def _make_extension(
+    root: Path,
+    name: str,
+    manifest: Mapping[str, object],
+    files: Mapping[str, str] | None = None,
+) -> Path:
+    directory = root / name
+    directory.mkdir(parents=True)
+    (directory / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
+    for relative, content in (files or {}).items():
+        target = directory / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    return directory
+
+
+def _grammar_manifest(name: str, scope: str, path: str) -> dict[str, object]:
+    return {
+        "name": name,
+        "contributes": {
+            "grammars": [{"language": name, "scopeName": scope, "path": path}]
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Real imported tree.
+# --------------------------------------------------------------------------- #
+
+
+def test_catalog_builds_from_real_registry(catalog: GrammarCatalog) -> None:
+    assert catalog.list_grammars(), "catalog must discover grammars from the registry"
+    # The pristine imported tree resolves every grammar file without diagnostics.
+    assert catalog.list_diagnostics() == ()
+
+
+def test_real_catalog_is_deterministic() -> None:
+    first = build_grammar_catalog()
+    second = build_grammar_catalog()
+    assert first.list_grammars() == second.list_grammars()
+    assert first.list_diagnostics() == second.list_diagnostics()
+
+
+@pytest.mark.parametrize(("language_id", "scope_name"), REPRESENTATIVE_GRAMMARS)
+def test_representative_grammar_lookup(
+    catalog: GrammarCatalog, language_id: str, scope_name: str
+) -> None:
+    grammars = catalog.grammars_for_language(language_id)
+    assert grammars, f"no grammar for language {language_id}"
+    scopes = {g.scope_name for g in grammars}
+    assert scope_name in scopes
+    assert all(g.exists for g in grammars if g.scope_name == scope_name)
+
+
+def test_grammar_lookup_by_scope(catalog: GrammarCatalog) -> None:
+    grammar = catalog.grammar_for_scope("source.batchfile")
+    assert grammar is not None
+    assert grammar.language_id == "bat"
+
+
+def test_grammar_paths_stay_under_extensions_root(catalog: GrammarCatalog) -> None:
+    extensions_root = paths_module.extensions_root()
+    prefix = f"{paths_module.REPO_RELATIVE_PREFIX}/"
+    for grammar in catalog.list_grammars():
+        if grammar.path_repo_relative is None:
+            continue
+        assert grammar.path_repo_relative.startswith(prefix)
+        relative = grammar.path_repo_relative[len(prefix) :]
+        resolved = (extensions_root / relative).resolve()
+        assert resolved.is_relative_to(extensions_root.resolve())
+
+
+def test_embedded_language_metadata_is_exposed(catalog: GrammarCatalog) -> None:
+    # Markdown embeds many fenced languages; metadata must be exposed as data.
+    embedded = catalog.embedded_languages_for_language("markdown")
+    assert embedded, "expected embedded-language metadata for markdown"
+    assert all(isinstance(pair, tuple) and len(pair) == 2 for pair in embedded)
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic diagnostics via fixtures.
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_grammar_file_is_diagnosed(tmp_path: Path) -> None:
+    _make_extension(
+        tmp_path, "ghost", _grammar_manifest("ghost", "source.ghost", "./missing.json")
+    )
+    catalog = build_grammar_catalog(root=tmp_path)
+    grammar = catalog.grammar_for_language("ghost")
+    assert grammar is not None and grammar.exists is False
+    assert any("missing" in d.message for d in catalog.list_diagnostics())
+
+
+def test_grammar_path_traversal_is_diagnosed(tmp_path: Path) -> None:
+    _make_extension(
+        tmp_path,
+        "escape",
+        _grammar_manifest("escape", "source.escape", "../../../../etc/passwd"),
+    )
+    catalog = build_grammar_catalog(root=tmp_path)
+    grammar = catalog.grammar_for_language("escape")
+    assert grammar is not None and grammar.path_repo_relative is None
+    assert any(
+        "escapes extension tree" in d.message for d in catalog.list_diagnostics()
+    )
+
+
+def test_missing_scope_name_is_diagnosed(tmp_path: Path) -> None:
+    _make_extension(
+        tmp_path,
+        "noscope",
+        {
+            "name": "noscope",
+            "contributes": {"grammars": [{"language": "noscope", "path": "./g.json"}]},
+        },
+        files={"g.json": "{}"},
+    )
+    catalog = build_grammar_catalog(root=tmp_path)
+    assert any("missing scopeName" in d.message for d in catalog.list_diagnostics())
+
+
+def test_conflicting_scope_is_diagnosed_deterministically(tmp_path: Path) -> None:
+    _make_extension(
+        tmp_path,
+        "a_one",
+        _grammar_manifest("a_one", "source.shared", "./a.json"),
+        files={"a.json": "{}"},
+    )
+    _make_extension(
+        tmp_path,
+        "b_two",
+        {
+            "name": "b_two",
+            "contributes": {
+                "grammars": [
+                    {
+                        "language": "b_two",
+                        "scopeName": "source.shared",
+                        "path": "./b.json",
+                    }
+                ]
+            },
+        },
+        files={"b.json": "{}"},
+    )
+    first = build_grammar_catalog(root=tmp_path)
+    second = build_grammar_catalog(root=tmp_path)
+    assert any(
+        "conflicting grammar paths for scope source.shared" in d.message
+        for d in first.list_diagnostics()
+    )
+    assert first.list_diagnostics() == second.list_diagnostics()


### PR DESCRIPTION
- add ECLI-owned extension integration layer under src/ecli/extensions/ecli_integration
- build deterministic TextMate grammar catalog from imported extension metadata
- add metadata-based language detection with exact filename, pattern, and extension precedence
- add safe [extensions] configuration surface with legacy syntax engine default
- keep imported upstream extension files unchanged
- keep legacy syntax highlighter, PySH Console Panel, and VMLab scope untouched
- add regression coverage for grammar catalog, language detection, config loading, and packaging safety

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Extensions Layer configuration enabling metadata adapters for grammar catalog and language detection
* New `[extensions]` configuration table with feature toggles for metadata registry, grammar catalog, and language detection
* Legacy syntax rendering remains unchanged regardless of configuration settings

## Documentation
* Updated architecture documentation describing Extensions Layer capabilities and deterministic metadata handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->